### PR TITLE
fix: replace invalid 'cyan' theme color with 'blue'

### DIFF
--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -766,7 +766,7 @@ export default function (pi: ExtensionAPI) {
         "Use /reset-phase if you want to switch from one workflow to another.",
       ];
       const randomTip = tips[Math.floor(Math.random() * tips.length)];
-      const tipLine = theme.fg("cyan", `Tip: ${randomTip}`);
+      const tipLine = theme.fg("blue", `Tip: ${randomTip}`);
       const clarifyLine = theme.fg("dim", "However, in most cases, it's best to start with /clarify.");
 
       const hints = [


### PR DESCRIPTION
## Summary
Unknown theme color 'cyan' caused extension loading to fail.

## Fix
Replace 'cyan' with 'blue' which is a valid theme color per theme.js.

## Testing
Run `pi` - extension should load without error.