### PR TITLE
fix: use valid theme color 'muted' instead of 'blue'

### DIFF
--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -766,7 +766,7 @@ export default function (pi: ExtensionAPI) {
         "Use /reset-phase if you want to switch from one workflow to another.",
       ];
       const randomTip = tips[Math.floor(Math.random() * tips.length)];
-      const tipLine = theme.fg("blue", `Tip: ${randomTip}`);
+      const tipLine = theme.fg("muted", `Tip: ${randomTip}`);
       const clarifyLine = theme.fg("dim", "However, in most cases, it's best to start with /clarify.");
 
       const hints = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-engineering-discipline-extension",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-engineering-discipline-extension",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49"


### PR DESCRIPTION
## Summary
Theme `fg()` only accepts keys from the `colors` object, not simple color names.

## Fix
Replace `theme.fg("blue", ...)` with `theme.fg("muted", ...)`

Valid theme colors: accent, muted, dim, success, error, warning, text, etc.