### PR TITLE
fix: reap orphaned nested pi child processes

### DIFF
--- a/docs/engineering-discipline/plans/2026-04-09-autonomous-dev-process-cleanup-review-fixes.md
+++ b/docs/engineering-discipline/plans/2026-04-09-autonomous-dev-process-cleanup-review-fixes.md
@@ -1,0 +1,467 @@
+# Autonomous Dev Process Cleanup Review Fixes Implementation Plan
+
+> **Worker note:** Execute this plan task-by-task using the agentic-run-plan skill or subagents. Each step uses checkbox (`- [ ]`) syntax for progress tracking.
+
+**Goal:** Fix the merge-blocking review issues in the nested worker reaping branch without changing the intended POSIX process-group cleanup behavior.
+
+**Architecture:** Keep the current `runAgent()` ownership model and autonomous-dev integration, but make shutdown accounting truthful and preserve Node’s default signal termination behavior. The fix is limited to lifecycle semantics, result normalization, and regression tests; it does not redesign the logging subsystem or add Windows process-tree reaping.
+
+**Tech Stack:** TypeScript, Node.js child process/signal APIs, pi extension API, Vitest
+
+**Work Scope:**
+- **In scope:** restore default `SIGINT`/`SIGTERM` termination behavior in `autonomous-dev`, capture close signals in `runAgent()`, stop masking real post-`agent_end` failures as success, preserve semantic success if cancellation arrives after semantic completion, and add regression tests/fixtures for those cases.
+- **Out of scope:** Windows descendant-process reaping, log sink unification between `logger.ts` and direct lifecycle appends, changing the 250ms grace window, or broader autonomous-dev feature work.
+
+**Verification Strategy:**
+- **Level:** test-suite
+- **Command:** `npx vitest run`
+- **What it validates:** the full extension regression suite passes, including the new autonomous-dev shutdown tests and subagent lifecycle/process-ownership tests.
+
+---
+
+## File Structure Mapping
+
+- **Modify:** `extensions/autonomous-dev/index.ts`
+  - Responsibility: autonomous-dev lifecycle hook registration and process cleanup behavior
+- **Modify:** `extensions/autonomous-dev/tests/index.test.ts`
+  - Responsibility: regression coverage for command registration and signal-cleanup behavior
+- **Modify:** `extensions/agentic-harness/subagent.ts`
+  - Responsibility: subagent lifecycle tracking, close-signal capture, and final result normalization
+- **Modify:** `extensions/agentic-harness/tests/subagent-process.test.ts`
+  - Responsibility: end-to-end process ownership and shutdown semantics regression coverage
+- **Modify:** `extensions/agentic-harness/tests/fixtures/subagent-parent.mjs`
+  - Responsibility: process fixture modes that simulate semantic success, abort, and late failure after `agent_end`
+
+## Project Capability Discovery
+
+- **Bundled agents available:** `explorer`, `worker`, `planner`, `plan-worker`, `plan-validator`, `plan-compliance`, review agents
+- **Project-specific agents:** none found under `.agents/` or `.pi/agents/`
+- **Project-specific skills:** none found under `.agents/skills/` or `.pi/skills/`
+
+Use `plan-worker` for execution and `plan-validator` for independent verification if this plan is run via subagents.
+
+---
+
+### Task 1: Restore default SIGINT/SIGTERM termination behavior in autonomous-dev
+
+**Dependencies:** None (can run in parallel)
+**Files:**
+- Modify: `extensions/autonomous-dev/index.ts:168-182`
+- Test: `extensions/autonomous-dev/tests/index.test.ts:121-140`
+- Test: `extensions/autonomous-dev/tests/index.test.ts` (add new regression test near the command-registration block)
+
+- [ ] **Step 1: Add a helper that cleans up and then re-raises the original signal**
+
+In `extensions/autonomous-dev/index.ts`, replace the current `ensureProcessCleanupHooks()` implementation with the block below so the extension still runs cleanup, but does not swallow Node’s default process termination behavior:
+
+```ts
+function cleanupAndReraise(signalName: NodeJS.Signals): void {
+  cleanupAutonomousDev();
+  process.kill(process.pid, signalName);
+}
+
+function ensureProcessCleanupHooks(): void {
+  if (processCleanupRegistered) return;
+  processCleanupRegistered = true;
+
+  process.once("exit", () => {
+    cleanupAutonomousDev();
+  });
+
+  process.once("SIGINT", () => {
+    cleanupAndReraise("SIGINT");
+  });
+
+  process.once("SIGTERM", () => {
+    cleanupAndReraise("SIGTERM");
+  });
+}
+```
+
+- [ ] **Step 2: Keep the existing registration test green**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension
+npx vitest run extensions/autonomous-dev/tests/index.test.ts -t "registers autonomous-dev with a string name and handler when enabled"
+```
+
+Expected: PASS, and the existing assertions about registering `exit`, `SIGINT`, and `SIGTERM` listeners still succeed.
+
+- [ ] **Step 3: Add a regression test that proves the signal handler re-raises the signal**
+
+In `extensions/autonomous-dev/tests/index.test.ts`, add the following test inside the `describe("autonomous-dev extension command registration", ...)` block, after the existing registration test:
+
+```ts
+it("re-raises SIGINT after cleanup so process termination semantics are preserved", async () => {
+  process.env.PI_AUTONOMOUS_DEV = "1";
+  const onceSpy = vi.spyOn(process, "once");
+  const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true as any);
+  const { default: registerExtension } = await import("../index.js");
+  const pi = createPiMock();
+
+  registerExtension(pi);
+
+  const sigintHandler = onceSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1] as (() => void) | undefined;
+  expect(sigintHandler).toBeTypeOf("function");
+
+  sigintHandler?.();
+
+  expect(killSpy).toHaveBeenCalledWith(process.pid, "SIGINT");
+});
+```
+
+- [ ] **Step 4: Run the autonomous-dev test file**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension
+npx vitest run extensions/autonomous-dev/tests/index.test.ts
+```
+
+Expected: PASS, including the new signal re-raise regression test.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add extensions/autonomous-dev/index.ts extensions/autonomous-dev/tests/index.test.ts
+git commit -m "fix(autonomous-dev): preserve default signal termination behavior"
+```
+
+---
+
+### Task 2: Make subagent shutdown accounting truthful and stop masking real failures
+
+**Dependencies:** None (can run in parallel)
+**Files:**
+- Modify: `extensions/agentic-harness/subagent.ts:177-188`
+- Modify: `extensions/agentic-harness/subagent.ts:298-499`
+- Modify: `extensions/agentic-harness/tests/fixtures/subagent-parent.mjs:8-52`
+- Test: `extensions/agentic-harness/tests/subagent-process.test.ts:54-142`
+
+- [ ] **Step 1: Extend close-event bookkeeping so `runAgent()` knows why the child stopped**
+
+In `extensions/agentic-harness/subagent.ts`, update `RunLifecycleEvent` and the `runAgent()` local state so the close handler preserves both exit code and terminating signal:
+
+```ts
+export interface RunLifecycleEvent {
+  phase: "spawned" | "terminating" | "closed";
+  runId: string;
+  parentRunId?: string;
+  rootRunId: string;
+  owner?: string;
+  pid: number;
+  pgid?: number;
+  reason?: string;
+  signal?: NodeJS.Signals;
+  exitCode?: number | null;
+}
+```
+
+Inside `runAgent()`, add these locals next to `let wasAborted = false;`:
+
+```ts
+let wasAborted = false;
+let semanticTerminationRequested = false;
+let closeSignal: NodeJS.Signals | undefined;
+const lifecycleWrites: Promise<void>[] = [];
+```
+
+- [ ] **Step 2: Mark semantic-success reaping separately from abort-driven termination**
+
+In the `flushLine()` branch that starts the grace timer, set a dedicated flag before terminating the process group:
+
+```ts
+graceTimer = setTimeout(() => {
+  if (!didClose && !settled && result.sawAgentEnd) {
+    semanticTerminationRequested = true;
+    requestTermination("agent_end_grace_elapsed");
+  }
+}, AGENT_END_GRACE_MS);
+```
+
+Keep `abortHandler` setting `wasAborted = true`, but do not set `semanticTerminationRequested` there.
+
+- [ ] **Step 3: Update the close handler so logs record the real signal and raw exit code**
+
+Replace the current `proc.on("close", ...)` block in `extensions/agentic-harness/subagent.ts` with:
+
+```ts
+proc.on("close", (code, signalName) => {
+  didClose = true;
+  closeSignal = signalName ?? undefined;
+
+  if (buffer.trim()) {
+    for (const line of buffer.split("\n")) {
+      if (line.trim()) flushLine(line);
+    }
+  }
+
+  if (pid > 0) {
+    emitLifecycle({
+      phase: "closed",
+      runId: resolvedOwnership.runId,
+      parentRunId: resolvedOwnership.parentRunId,
+      rootRunId: resolvedOwnership.rootRunId,
+      owner: resolvedOwnership.owner,
+      pid,
+      pgid,
+      signal: closeSignal,
+      exitCode: code ?? null,
+    });
+  }
+
+  if (code !== null) {
+    finish(code);
+    return;
+  }
+
+  if (closeSignal === "SIGTERM") {
+    finish(143);
+    return;
+  }
+
+  if (closeSignal === "SIGKILL") {
+    finish(137);
+    return;
+  }
+
+  finish(1);
+});
+```
+
+- [ ] **Step 4: Tighten final result normalization so only expected semantic reaping becomes success**
+
+Replace the normalization block near the end of `runAgent()` with:
+
+```ts
+result.exitCode = exitCode;
+
+const hasSemanticOutput = result.sawAgentEnd && !!getFinalOutput(result.messages).trim();
+const endedViaSemanticReap = semanticTerminationRequested && hasSemanticOutput && (closeSignal === "SIGTERM" || closeSignal === "SIGKILL");
+
+if (endedViaSemanticReap) {
+  result.exitCode = 0;
+  if (result.stopReason === "error") result.stopReason = undefined;
+  result.errorMessage = undefined;
+} else if (wasAborted) {
+  result.exitCode = 130;
+  result.stopReason = "aborted";
+  result.errorMessage = "Subagent was aborted.";
+} else if (result.exitCode > 0) {
+  if (!result.stopReason) result.stopReason = "error";
+  if (!result.errorMessage && result.stderr.trim()) result.errorMessage = result.stderr.trim();
+}
+```
+
+This preserves success for the expected post-`agent_end` reap path, but stops converting unrelated post-`agent_end` failures into success. It also ensures a late abort does not override already-completed semantic success.
+
+- [ ] **Step 5: Add a fixture mode that emits `agent_end` and then exits with code 1**
+
+In `extensions/agentic-harness/tests/fixtures/subagent-parent.mjs`, replace the bottom section starting at `const assistantMessage = { ... }` with this block:
+
+```js
+const assistantMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: mode === "success-hang" ? "fixture complete" : mode === "agent-end-fail" ? "fixture failed after completion" : "fixture waiting" }],
+};
+
+console.log(JSON.stringify({ type: "message_end", message: assistantMessage }));
+if (mode === "success-hang" || mode === "agent-end-fail") {
+  console.log(JSON.stringify({ type: "agent_end", messages: [assistantMessage] }));
+}
+
+if (mode === "agent-end-fail") {
+  setTimeout(() => {
+    process.exit(1);
+  }, 25);
+} else {
+  const keepAlive = setInterval(() => {
+    // keep process and descendant alive until parent kills the process group
+  }, 1000);
+
+  const shutdown = () => {
+    clearInterval(keepAlive);
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}
+```
+
+- [ ] **Step 6: Extend the process-ownership test file with two regressions**
+
+In `extensions/agentic-harness/tests/subagent-process.test.ts`, add the following tests inside the existing POSIX-only `describe.runIf(...)` block.
+
+First, add a log-truthfulness assertion to the existing success test by parsing the closed event rather than only searching for substrings:
+
+```ts
+const events = readFileSync(logFile, "utf8")
+  .trim()
+  .split("\n")
+  .map((line) => JSON.parse(line));
+const closedEvent = events.find((event) => event.phase === "closed");
+expect(closedEvent).toMatchObject({
+  phase: "closed",
+  runId: "root-success-run",
+  signal: "SIGTERM",
+  exitCode: null,
+});
+```
+
+Then add this failure-regression test:
+
+```ts
+it("does not convert a post-agent_end failure into success", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-agent-end-fail-"));
+  tempDirs.push(tempDir);
+  const stateFile = join(tempDir, "state.json");
+
+  process.argv = [process.execPath, fixtureScript];
+
+  const result = await runAgent({
+    agent: {
+      name: "fixture",
+      description: "fixture agent",
+      filePath: fixtureScript,
+      source: "project",
+      systemPrompt: "",
+      tools: [],
+    },
+    agentName: "fixture",
+    task: "agent-end-fail",
+    cwd: tempDir,
+    depthConfig: resolveDepthConfig(),
+    ownership: { runId: "root-agent-end-fail", owner: "test-suite" },
+    extraEnv: {
+      FIXTURE_STATE_FILE: stateFile,
+    },
+    makeDetails: (results) => ({ mode: "single", results }),
+  });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stopReason).toBe("error");
+});
+```
+
+Finally add this late-abort regression test:
+
+```ts
+it("keeps semantic success when abort arrives after agent_end", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-late-abort-"));
+  tempDirs.push(tempDir);
+  const stateFile = join(tempDir, "state.json");
+
+  process.argv = [process.execPath, fixtureScript];
+  const controller = new AbortController();
+
+  const runPromise = runAgent({
+    agent: {
+      name: "fixture",
+      description: "fixture agent",
+      filePath: fixtureScript,
+      source: "project",
+      systemPrompt: "",
+      tools: [],
+    },
+    agentName: "fixture",
+    task: "success-hang",
+    cwd: tempDir,
+    depthConfig: resolveDepthConfig(),
+    ownership: { runId: "root-late-abort", owner: "test-suite" },
+    extraEnv: {
+      FIXTURE_STATE_FILE: stateFile,
+    },
+    signal: controller.signal,
+    makeDetails: (results) => ({ mode: "single", results }),
+  });
+
+  await waitFor(() => !!loadState(stateFile).grandchildPid, 2000);
+  controller.abort();
+  const result = await runPromise;
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stopReason).not.toBe("aborted");
+});
+```
+
+- [ ] **Step 7: Run the focused harness lifecycle tests**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension
+npx vitest run extensions/agentic-harness/tests/subagent-process.test.ts extensions/agentic-harness/tests/subagent.test.ts
+```
+
+Expected: PASS, including the new close-signal, post-`agent_end` failure, and late-abort regressions.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add extensions/agentic-harness/subagent.ts extensions/agentic-harness/tests/fixtures/subagent-parent.mjs extensions/agentic-harness/tests/subagent-process.test.ts
+git commit -m "fix(agentic-harness): make subagent shutdown accounting truthful"
+```
+
+---
+
+### Task 3 (Final): Full verification and review closure
+
+**Dependencies:** Runs after Task 1 and Task 2 complete
+**Files:** None (read-only verification)
+
+- [ ] **Step 1: Run the highest-level verification command**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension
+npx vitest run
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 2: Run build checks for the touched packages**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension/extensions/agentic-harness && npm run build
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension/extensions/autonomous-dev && npm run build
+```
+
+Expected: both commands exit 0 with no TypeScript errors.
+
+- [ ] **Step 3: Verify the review success criteria manually**
+
+Confirm each item below before declaring the work done:
+- [ ] `autonomous-dev` cleanup hooks still run on session shutdown and process exit.
+- [ ] Receiving `SIGINT` or `SIGTERM` no longer leaves the host process alive because of extension-installed listeners.
+- [ ] `runAgent()` lifecycle logs record whether the child closed by exit code or by signal.
+- [ ] A child that emits `agent_end` and then fails with a real non-zero exit is reported as failed.
+- [ ] A child that semantically completed and is then reaped by the grace-timer path is still reported as success.
+- [ ] A late abort after semantic completion does not incorrectly downgrade a completed run to `aborted`.
+
+- [ ] **Step 4: Inspect the final diff before merge**
+
+Run:
+
+```bash
+cd /home/roach/.pi/agent/extensions/pi-engineering-discipline-extension
+git diff --stat origin/main...HEAD
+```
+
+Expected: only the planned files are changed for this fix set.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** The plan covers the three merge-critical findings from review: swallowed process termination in `autonomous-dev`, inaccurate close-event/lifecycle accounting, and false success normalization after `agent_end`. It also covers the late-abort edge case called out in review. Windows process-tree cleanup and log-sink unification are intentionally excluded and documented as out of scope.
+- **Placeholder scan:** No `TODO`, `TBD`, or “figure it out” steps remain. Every code-changing step contains concrete code or exact commands.
+- **Type consistency:** `RunLifecycleEvent.signal` is reused for closed-event signals; no new inconsistent property names are introduced. `cleanupAndReraise()` is referenced consistently.
+- **Dependency verification:** Task 1 and Task 2 modify disjoint file sets and can run in parallel. Task 3 depends on both.
+- **Verification coverage:** The plan includes a declared verification strategy and a final verification task using `npx vitest run`, plus package build checks.

--- a/extensions/agentic-harness/subagent.ts
+++ b/extensions/agentic-harness/subagent.ts
@@ -1,8 +1,8 @@
 // subagent.ts
 import { spawn } from "child_process";
-import { writeFile, unlink } from "fs/promises";
+import { appendFile, mkdir, writeFile, unlink } from "fs/promises";
 import { tmpdir } from "os";
-import { join, basename } from "path";
+import { join, basename, dirname } from "path";
 import { randomBytes } from "crypto";
 import { existsSync } from "fs";
 import type { AgentConfig } from "./agents.js";
@@ -20,6 +20,11 @@ const SUBAGENT_DEPTH_ENV = "PI_SUBAGENT_DEPTH";
 const SUBAGENT_MAX_DEPTH_ENV = "PI_SUBAGENT_MAX_DEPTH";
 const SUBAGENT_STACK_ENV = "PI_SUBAGENT_STACK";
 const SUBAGENT_PREVENT_CYCLES_ENV = "PI_SUBAGENT_PREVENT_CYCLES";
+const SUBAGENT_RUN_ID_ENV = "PI_SUBAGENT_RUN_ID";
+const SUBAGENT_PARENT_RUN_ID_ENV = "PI_SUBAGENT_PARENT_RUN_ID";
+const SUBAGENT_ROOT_RUN_ID_ENV = "PI_SUBAGENT_ROOT_RUN_ID";
+const SUBAGENT_OWNER_ENV = "PI_SUBAGENT_OWNER";
+const SUBAGENT_PROCESS_LOG_ENV = "PI_SUBAGENT_PROCESS_LOG";
 
 export const DEFAULT_MAX_DEPTH = 3;
 
@@ -162,6 +167,26 @@ function buildPiArgs(agent: AgentConfig | undefined, systemPromptPath: string | 
 
 type OnUpdateCallback = (partial: { content: Array<{ type: "text"; text: string }>; details: SubagentDetails | undefined }) => void;
 
+export interface RunOwnership {
+  runId?: string;
+  parentRunId?: string;
+  rootRunId?: string;
+  owner?: string;
+}
+
+export interface RunLifecycleEvent {
+  phase: "spawned" | "terminating" | "closed";
+  runId: string;
+  parentRunId?: string;
+  rootRunId: string;
+  owner?: string;
+  pid: number;
+  pgid?: number;
+  reason?: string;
+  signal?: NodeJS.Signals;
+  exitCode?: number | null;
+}
+
 export interface RunAgentOptions {
   agent: AgentConfig | undefined;
   agentName: string;
@@ -169,12 +194,55 @@ export interface RunAgentOptions {
   cwd: string;
   depthConfig: DepthConfig;
   signal?: AbortSignal;
+  ownership?: RunOwnership;
+  extraEnv?: Record<string, string | undefined>;
   onUpdate?: OnUpdateCallback;
+  onLifecycleEvent?: (event: RunLifecycleEvent) => void;
   makeDetails: (results: SingleResult[]) => SubagentDetails;
 }
 
+function generateRunId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+function resolveRunOwnership(ownership: RunOwnership | undefined, fallbackOwner: string): Required<Pick<RunOwnership, "runId" | "rootRunId">> & RunOwnership {
+  const inheritedRunId = process.env[SUBAGENT_RUN_ID_ENV];
+  const inheritedRootRunId = process.env[SUBAGENT_ROOT_RUN_ID_ENV];
+
+  const runId = ownership?.runId || generateRunId();
+  const parentRunId = ownership?.parentRunId ?? inheritedRunId;
+  const rootRunId = ownership?.rootRunId || inheritedRootRunId || parentRunId || runId;
+  const owner = ownership?.owner || process.env[SUBAGENT_OWNER_ENV] || fallbackOwner;
+
+  return { runId, parentRunId, rootRunId, owner };
+}
+
+async function appendLifecycleLog(path: string | undefined, event: RunLifecycleEvent): Promise<void> {
+  if (!path) return;
+  const line = `${JSON.stringify({
+    ts: new Date().toISOString(),
+    event: "subagent.process",
+    ...event,
+  })}\n`;
+
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, line, "utf-8");
+}
+
 export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
-  const { agent, agentName, task, cwd, depthConfig, signal, onUpdate, makeDetails } = opts;
+  const {
+    agent,
+    agentName,
+    task,
+    cwd,
+    depthConfig,
+    signal,
+    ownership,
+    extraEnv,
+    onUpdate,
+    onLifecycleEvent,
+    makeDetails,
+  } = opts;
 
   if (!agent) {
     return {
@@ -221,22 +289,50 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
 
     const nextDepth = depthConfig.currentDepth + 1;
     const propagatedStack = [...depthConfig.ancestorStack, agentName];
+    const resolvedOwnership = resolveRunOwnership(ownership, agentName);
+    const processLogPath = extraEnv?.[SUBAGENT_PROCESS_LOG_ENV] || process.env[SUBAGENT_PROCESS_LOG_ENV];
 
     let wasAborted = false;
+    const lifecycleWrites: Promise<void>[] = [];
 
     const exitCode = await new Promise<number>((resolve) => {
       const proc = spawn(invocation.command, allArgs, {
         cwd,
         shell: false,
+        detached: process.platform !== "win32",
         stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
+          ...extraEnv,
           [SUBAGENT_DEPTH_ENV]: String(nextDepth),
           [SUBAGENT_MAX_DEPTH_ENV]: String(depthConfig.maxDepth),
           [SUBAGENT_STACK_ENV]: JSON.stringify(propagatedStack),
           [SUBAGENT_PREVENT_CYCLES_ENV]: depthConfig.preventCycles ? "1" : "0",
+          [SUBAGENT_RUN_ID_ENV]: resolvedOwnership.runId,
+          [SUBAGENT_PARENT_RUN_ID_ENV]: resolvedOwnership.parentRunId,
+          [SUBAGENT_ROOT_RUN_ID_ENV]: resolvedOwnership.rootRunId,
+          [SUBAGENT_OWNER_ENV]: resolvedOwnership.owner,
         },
       });
+
+      const pid = proc.pid ?? 0;
+      const pgid = process.platform !== "win32" && pid > 0 ? pid : undefined;
+      const emitLifecycle = (event: RunLifecycleEvent) => {
+        onLifecycleEvent?.(event);
+        lifecycleWrites.push(appendLifecycleLog(processLogPath, event).catch(() => undefined));
+      };
+
+      if (pid > 0) {
+        emitLifecycle({
+          phase: "spawned",
+          runId: resolvedOwnership.runId,
+          parentRunId: resolvedOwnership.parentRunId,
+          rootRunId: resolvedOwnership.rootRunId,
+          owner: resolvedOwnership.owner,
+          pid,
+          pgid,
+        });
+      }
 
       proc.stdin.on("error", () => { /* ignore broken pipe */ });
       proc.stdin.end();
@@ -246,29 +342,90 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
       let settled = false;
       let abortHandler: (() => void) | undefined;
       let graceTimer: ReturnType<typeof setTimeout> | undefined;
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      let terminationStarted = false;
 
       const finish = (code: number) => {
         if (settled) return;
         settled = true;
         if (graceTimer) clearTimeout(graceTimer);
+        if (killTimer) clearTimeout(killTimer);
         if (signal && abortHandler) signal.removeEventListener("abort", abortHandler);
         resolve(code);
       };
 
-      const terminateChild = () => {
-        proc.kill("SIGTERM");
-        setTimeout(() => { if (!proc.killed) proc.kill("SIGKILL"); }, KILL_TIMEOUT_MS);
+      const sendSignal = (signalName: NodeJS.Signals) => {
+        if (!pid) return;
+        try {
+          if (process.platform !== "win32") {
+            process.kill(-pid, signalName);
+          } else {
+            proc.kill(signalName);
+          }
+        } catch (error: any) {
+          if (error?.code !== "ESRCH") {
+            throw error;
+          }
+        }
+      };
+
+      const requestTermination = (reason: string, signalName: NodeJS.Signals = "SIGTERM") => {
+        if (didClose || !pid) return;
+        if (!terminationStarted) {
+          terminationStarted = true;
+          emitLifecycle({
+            phase: "terminating",
+            runId: resolvedOwnership.runId,
+            parentRunId: resolvedOwnership.parentRunId,
+            rootRunId: resolvedOwnership.rootRunId,
+            owner: resolvedOwnership.owner,
+            pid,
+            pgid,
+            reason,
+            signal: signalName,
+          });
+          sendSignal(signalName);
+          killTimer = setTimeout(() => {
+            if (didClose) return;
+            emitLifecycle({
+              phase: "terminating",
+              runId: resolvedOwnership.runId,
+              parentRunId: resolvedOwnership.parentRunId,
+              rootRunId: resolvedOwnership.rootRunId,
+              owner: resolvedOwnership.owner,
+              pid,
+              pgid,
+              reason: `${reason}:escalated`,
+              signal: "SIGKILL",
+            });
+            sendSignal("SIGKILL");
+          }, KILL_TIMEOUT_MS);
+          return;
+        }
+
+        if (signalName === "SIGKILL") {
+          emitLifecycle({
+            phase: "terminating",
+            runId: resolvedOwnership.runId,
+            parentRunId: resolvedOwnership.parentRunId,
+            rootRunId: resolvedOwnership.rootRunId,
+            owner: resolvedOwnership.owner,
+            pid,
+            pgid,
+            reason,
+            signal: signalName,
+          });
+          sendSignal(signalName);
+        }
       };
 
       const flushLine = (line: string) => {
         if (processPiJsonLine(line, result)) emitUpdate();
-        // If agent_end seen, give a grace period then finish
         if (result.sawAgentEnd && !didClose && !settled) {
           if (graceTimer) clearTimeout(graceTimer);
           graceTimer = setTimeout(() => {
             if (!didClose && !settled && result.sawAgentEnd) {
-              finish(0);
-              terminateChild();
+              requestTermination("agent_end_grace_elapsed");
             }
           }, AGENT_END_GRACE_MS);
         }
@@ -294,6 +451,18 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
             if (line.trim()) flushLine(line);
           }
         }
+        if (pid > 0) {
+          emitLifecycle({
+            phase: "closed",
+            runId: resolvedOwnership.runId,
+            parentRunId: resolvedOwnership.parentRunId,
+            rootRunId: resolvedOwnership.rootRunId,
+            owner: resolvedOwnership.owner,
+            pid,
+            pgid,
+            exitCode: code ?? 0,
+          });
+        }
         finish(code ?? 0);
       });
 
@@ -306,24 +475,21 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
         abortHandler = () => {
           if (didClose || settled) return;
           wasAborted = true;
-          terminateChild();
+          requestTermination("abort_signal_received");
         };
         if (signal.aborted) abortHandler();
         else signal.addEventListener("abort", abortHandler, { once: true });
       }
     });
 
+    await Promise.allSettled(lifecycleWrites);
     result.exitCode = exitCode;
 
     // Normalize: if agent completed semantically but process exited non-zero
     if (wasAborted) {
-      if (result.sawAgentEnd && getFinalOutput(result.messages).trim()) {
-        result.exitCode = 0;
-      } else {
-        result.exitCode = 130;
-        result.stopReason = "aborted";
-        result.errorMessage = "Subagent was aborted.";
-      }
+      result.exitCode = 130;
+      result.stopReason = "aborted";
+      result.errorMessage = "Subagent was aborted.";
     } else if (result.exitCode > 0 && result.sawAgentEnd && getFinalOutput(result.messages).trim()) {
       result.exitCode = 0;
       if (result.stopReason === "error") result.stopReason = undefined;

--- a/extensions/agentic-harness/subagent.ts
+++ b/extensions/agentic-harness/subagent.ts
@@ -293,6 +293,8 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
     const processLogPath = extraEnv?.[SUBAGENT_PROCESS_LOG_ENV] || process.env[SUBAGENT_PROCESS_LOG_ENV];
 
     let wasAborted = false;
+    let semanticTerminationRequested = false;
+    let closeSignal: NodeJS.Signals | undefined;
     const lifecycleWrites: Promise<void>[] = [];
 
     const exitCode = await new Promise<number>((resolve) => {
@@ -425,6 +427,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
           if (graceTimer) clearTimeout(graceTimer);
           graceTimer = setTimeout(() => {
             if (!didClose && !settled && result.sawAgentEnd) {
+              semanticTerminationRequested = true;
               requestTermination("agent_end_grace_elapsed");
             }
           }, AGENT_END_GRACE_MS);
@@ -444,13 +447,16 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
         result.stderr += chunk.toString();
       });
 
-      proc.on("close", (code) => {
+      proc.on("close", (code, signalName) => {
         didClose = true;
+        closeSignal = signalName ?? undefined;
+
         if (buffer.trim()) {
           for (const line of buffer.split("\n")) {
             if (line.trim()) flushLine(line);
           }
         }
+
         if (pid > 0) {
           emitLifecycle({
             phase: "closed",
@@ -460,10 +466,27 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
             owner: resolvedOwnership.owner,
             pid,
             pgid,
-            exitCode: code ?? 0,
+            signal: closeSignal,
+            exitCode: code ?? null,
           });
         }
-        finish(code ?? 0);
+
+        if (code !== null) {
+          finish(code);
+          return;
+        }
+
+        if (closeSignal === "SIGTERM") {
+          finish(143);
+          return;
+        }
+
+        if (closeSignal === "SIGKILL") {
+          finish(137);
+          return;
+        }
+
+        finish(1);
       });
 
       proc.on("error", (err) => {
@@ -474,7 +497,14 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
       if (signal) {
         abortHandler = () => {
           if (didClose || settled) return;
-          wasAborted = true;
+
+          const hasSemanticCompletion = result.sawAgentEnd && !!getFinalOutput(result.messages).trim();
+          if (hasSemanticCompletion) {
+            semanticTerminationRequested = true;
+          } else {
+            wasAborted = true;
+          }
+
           requestTermination("abort_signal_received");
         };
         if (signal.aborted) abortHandler();
@@ -485,14 +515,17 @@ export async function runAgent(opts: RunAgentOptions): Promise<SingleResult> {
     await Promise.allSettled(lifecycleWrites);
     result.exitCode = exitCode;
 
-    // Normalize: if agent completed semantically but process exited non-zero
-    if (wasAborted) {
+    const hasSemanticOutput = result.sawAgentEnd && !!getFinalOutput(result.messages).trim();
+    const endedViaSemanticReap = semanticTerminationRequested && hasSemanticOutput && (closeSignal === "SIGTERM" || closeSignal === "SIGKILL");
+
+    if (endedViaSemanticReap) {
+      result.exitCode = 0;
+      if (result.stopReason === "error") result.stopReason = undefined;
+      result.errorMessage = undefined;
+    } else if (wasAborted) {
       result.exitCode = 130;
       result.stopReason = "aborted";
       result.errorMessage = "Subagent was aborted.";
-    } else if (result.exitCode > 0 && result.sawAgentEnd && getFinalOutput(result.messages).trim()) {
-      result.exitCode = 0;
-      if (result.stopReason === "error") result.stopReason = undefined;
     } else if (result.exitCode > 0) {
       if (!result.stopReason) result.stopReason = "error";
       if (!result.errorMessage && result.stderr.trim()) result.errorMessage = result.stderr.trim();

--- a/extensions/agentic-harness/tests/fixtures/subagent-grandchild.mjs
+++ b/extensions/agentic-harness/tests/fixtures/subagent-grandchild.mjs
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+
+const stateFile = process.env.FIXTURE_STATE_FILE;
+
+function updateState(patch) {
+  const current = stateFile && existsSync(stateFile)
+    ? JSON.parse(readFileSync(stateFile, "utf8"))
+    : {};
+  writeFileSync(stateFile, JSON.stringify({ ...current, ...patch }), "utf8");
+}
+
+if (stateFile) {
+  updateState({ grandchildPid: process.pid, grandchildStartedAt: new Date().toISOString() });
+}
+
+const heartbeat = setInterval(() => {
+  // keep process alive for process-tree cleanup tests
+}, 1000);
+
+const shutdown = () => {
+  clearInterval(heartbeat);
+  process.exit(0);
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/extensions/agentic-harness/tests/fixtures/subagent-parent.mjs
+++ b/extensions/agentic-harness/tests/fixtures/subagent-parent.mjs
@@ -37,22 +37,20 @@ updateState({
 
 const assistantMessage = {
   role: "assistant",
-  content: [{ type: "text", text: mode === "success-hang" ? "fixture complete" : "fixture waiting" }],
+  content: [{ type: "text", text: mode === "success-hang" ? "fixture complete" : mode === "agent-end-fail" ? "fixture failed after completion" : "fixture waiting" }],
 };
 
 console.log(JSON.stringify({ type: "message_end", message: assistantMessage }));
-if (mode === "success-hang") {
+if (mode === "success-hang" || mode === "agent-end-fail") {
   console.log(JSON.stringify({ type: "agent_end", messages: [assistantMessage] }));
 }
 
-const keepAlive = setInterval(() => {
-  // keep process and descendant alive until parent kills the process group
-}, 1000);
-
-const shutdown = () => {
-  clearInterval(keepAlive);
-  process.exit(0);
-};
-
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+if (mode === "agent-end-fail") {
+  setTimeout(() => {
+    process.exit(1);
+  }, 25);
+} else {
+  setInterval(() => {
+    // keep process and descendant alive until parent kills the process group
+  }, 1000);
+}

--- a/extensions/agentic-harness/tests/fixtures/subagent-parent.mjs
+++ b/extensions/agentic-harness/tests/fixtures/subagent-parent.mjs
@@ -1,0 +1,58 @@
+import { spawn } from "child_process";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const grandchildScript = join(__dirname, "subagent-grandchild.mjs");
+const stateFile = process.env.FIXTURE_STATE_FILE;
+const taskArg = process.argv.find((arg) => arg.startsWith("Task: ")) || "Task: success-hang";
+const mode = taskArg.replace(/^Task:\s*/, "").trim();
+
+function updateState(patch) {
+  if (!stateFile) return;
+  const current = existsSync(stateFile)
+    ? JSON.parse(readFileSync(stateFile, "utf8") || "{}")
+    : {};
+  writeFileSync(stateFile, JSON.stringify({ ...current, ...patch }), "utf8");
+}
+
+const grandchild = spawn(process.execPath, [grandchildScript], {
+  cwd: process.cwd(),
+  stdio: ["ignore", "ignore", "ignore"],
+  env: process.env,
+});
+
+grandchild.unref();
+
+updateState({
+  parentPid: process.pid,
+  mode,
+  runId: process.env.PI_SUBAGENT_RUN_ID,
+  parentRunId: process.env.PI_SUBAGENT_PARENT_RUN_ID,
+  rootRunId: process.env.PI_SUBAGENT_ROOT_RUN_ID,
+  owner: process.env.PI_SUBAGENT_OWNER,
+  grandchildPid: grandchild.pid,
+});
+
+const assistantMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: mode === "success-hang" ? "fixture complete" : "fixture waiting" }],
+};
+
+console.log(JSON.stringify({ type: "message_end", message: assistantMessage }));
+if (mode === "success-hang") {
+  console.log(JSON.stringify({ type: "agent_end", messages: [assistantMessage] }));
+}
+
+const keepAlive = setInterval(() => {
+  // keep process and descendant alive until parent kills the process group
+}, 1000);
+
+const shutdown = () => {
+  clearInterval(keepAlive);
+  process.exit(0);
+};
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/extensions/agentic-harness/tests/subagent-process.test.ts
+++ b/extensions/agentic-harness/tests/subagent-process.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { runAgent, resolveDepthConfig } from "../subagent.js";
+
+const fixtureScript = resolve("extensions/agentic-harness/tests/fixtures/subagent-parent.mjs");
+const originalArgv = [...process.argv];
+const trackedPids = new Set<number>();
+const tempDirs: string[] = [];
+
+function isPidAlive(pid: number | undefined): boolean {
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, intervalMs: number = 25): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+function loadState(path: string): any {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+afterEach(() => {
+  process.argv = [...originalArgv];
+  for (const pid of trackedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  trackedPids.clear();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe.runIf(process.platform !== "win32")("runAgent process ownership", () => {
+  it("reaps the owned process group after semantic success", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-success-"));
+    tempDirs.push(tempDir);
+    const stateFile = join(tempDir, "state.json");
+    const logFile = join(tempDir, "process.log");
+
+    process.argv = [process.execPath, fixtureScript];
+
+    const result = await runAgent({
+      agent: {
+        name: "fixture",
+        description: "fixture agent",
+        filePath: fixtureScript,
+        source: "project",
+        systemPrompt: "",
+        tools: [],
+      },
+      agentName: "fixture",
+      task: "success-hang",
+      cwd: tempDir,
+      depthConfig: resolveDepthConfig(),
+      ownership: { runId: "root-success-run", owner: "test-suite" },
+      extraEnv: {
+        FIXTURE_STATE_FILE: stateFile,
+        PI_SUBAGENT_PROCESS_LOG: logFile,
+      },
+      makeDetails: (results) => ({ mode: "single", results }),
+    });
+
+    await waitFor(() => !!loadState(stateFile).grandchildPid, 2000);
+    const state = loadState(stateFile);
+    trackedPids.add(state.parentPid);
+    trackedPids.add(state.grandchildPid);
+
+    expect(result.exitCode).toBe(0);
+    expect(state.runId).toBe("root-success-run");
+    expect(state.rootRunId).toBe("root-success-run");
+
+    await waitFor(() => !isPidAlive(state.parentPid) && !isPidAlive(state.grandchildPid), 4000);
+
+    const processLog = readFileSync(logFile, "utf8");
+    expect(processLog).toContain('"phase":"spawned"');
+    expect(processLog).toContain('"phase":"terminating"');
+    expect(processLog).toContain('"phase":"closed"');
+    expect(processLog).toContain('"runId":"root-success-run"');
+  });
+
+  it("kills owned descendants when aborted", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-abort-"));
+    tempDirs.push(tempDir);
+    const stateFile = join(tempDir, "state.json");
+
+    process.argv = [process.execPath, fixtureScript];
+    const controller = new AbortController();
+
+    const runPromise = runAgent({
+      agent: {
+        name: "fixture",
+        description: "fixture agent",
+        filePath: fixtureScript,
+        source: "project",
+        systemPrompt: "",
+        tools: [],
+      },
+      agentName: "fixture",
+      task: "abort-hang",
+      cwd: tempDir,
+      depthConfig: resolveDepthConfig(),
+      ownership: { runId: "root-abort-run", owner: "test-suite" },
+      extraEnv: {
+        FIXTURE_STATE_FILE: stateFile,
+      },
+      signal: controller.signal,
+      makeDetails: (results) => ({ mode: "single", results }),
+    });
+
+    await waitFor(() => !!loadState(stateFile).grandchildPid, 2000);
+    const state = loadState(stateFile);
+    trackedPids.add(state.parentPid);
+    trackedPids.add(state.grandchildPid);
+
+    controller.abort();
+    const result = await runPromise;
+
+    expect(result.exitCode).toBe(130);
+    expect(result.stopReason).toBe("aborted");
+    await waitFor(() => !isPidAlive(state.parentPid) && !isPidAlive(state.grandchildPid), 4000);
+  });
+});

--- a/extensions/agentic-harness/tests/subagent-process.test.ts
+++ b/extensions/agentic-harness/tests/subagent-process.test.ts
@@ -88,7 +88,7 @@ describe.runIf(process.platform !== "win32")("runAgent process ownership", () =>
 
     expect(result.exitCode).toBe(0);
     expect(state.runId).toBe("root-success-run");
-    expect(state.rootRunId).toBe("root-success-run");
+    expect(state.rootRunId).toBe(process.env.PI_SUBAGENT_ROOT_RUN_ID || "root-success-run");
 
     await waitFor(() => !isPidAlive(state.parentPid) && !isPidAlive(state.grandchildPid), 4000);
 
@@ -97,6 +97,86 @@ describe.runIf(process.platform !== "win32")("runAgent process ownership", () =>
     expect(processLog).toContain('"phase":"terminating"');
     expect(processLog).toContain('"phase":"closed"');
     expect(processLog).toContain('"runId":"root-success-run"');
+
+    const events = readFileSync(logFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const closedEvent = events.find((event) => event.phase === "closed");
+    expect(closedEvent).toMatchObject({
+      phase: "closed",
+      runId: "root-success-run",
+      signal: "SIGTERM",
+      exitCode: null,
+    });
+  });
+
+  it("does not convert a post-agent_end failure into success", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-agent-end-fail-"));
+    tempDirs.push(tempDir);
+    const stateFile = join(tempDir, "state.json");
+
+    process.argv = [process.execPath, fixtureScript];
+
+    const result = await runAgent({
+      agent: {
+        name: "fixture",
+        description: "fixture agent",
+        filePath: fixtureScript,
+        source: "project",
+        systemPrompt: "",
+        tools: [],
+      },
+      agentName: "fixture",
+      task: "agent-end-fail",
+      cwd: tempDir,
+      depthConfig: resolveDepthConfig(),
+      ownership: { runId: "root-agent-end-fail", owner: "test-suite" },
+      extraEnv: {
+        FIXTURE_STATE_FILE: stateFile,
+      },
+      makeDetails: (results) => ({ mode: "single", results }),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stopReason).toBe("error");
+  });
+
+  it("keeps semantic success when abort arrives after agent_end", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "subagent-process-late-abort-"));
+    tempDirs.push(tempDir);
+    const stateFile = join(tempDir, "state.json");
+
+    process.argv = [process.execPath, fixtureScript];
+    const controller = new AbortController();
+
+    const runPromise = runAgent({
+      agent: {
+        name: "fixture",
+        description: "fixture agent",
+        filePath: fixtureScript,
+        source: "project",
+        systemPrompt: "",
+        tools: [],
+      },
+      agentName: "fixture",
+      task: "success-hang",
+      cwd: tempDir,
+      depthConfig: resolveDepthConfig(),
+      ownership: { runId: "root-late-abort", owner: "test-suite" },
+      extraEnv: {
+        FIXTURE_STATE_FILE: stateFile,
+      },
+      signal: controller.signal,
+      makeDetails: (results) => ({ mode: "single", results }),
+    });
+
+    await waitFor(() => !!loadState(stateFile).grandchildPid, 2000);
+    controller.abort();
+    const result = await runPromise;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stopReason).not.toBe("aborted");
   });
 
   it("kills owned descendants when aborted", async () => {

--- a/extensions/autonomous-dev/index.ts
+++ b/extensions/autonomous-dev/index.ts
@@ -1,11 +1,12 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { randomBytes } from "crypto";
 import { AutonomousDevOrchestrator } from "./orchestrator.js";
 import type { WorkerActivityCallback, WorkerResult } from "./types.js";
 import { getIssueWithComments, detectRepo } from "./github.js";
 import { loadAgentsFromDir, type AgentConfig } from "../agentic-harness/agents.js";
-import { runAgent, resolveDepthConfig } from "../agentic-harness/subagent.js";
+import { runAgent, resolveDepthConfig, type RunLifecycleEvent } from "../agentic-harness/subagent.js";
 import { getInheritedCliArgs } from "../agentic-harness/runner-cli.js";
 import { getDisplayItems, getFinalOutput, type SingleResult } from "../agentic-harness/types.js";
 import { getAutonomousDevLogPath, logAutonomousDev } from "./logger.js";
@@ -371,7 +372,11 @@ export async function resolveWorkerAgentConfig(agent: AgentConfig): Promise<Agen
   return preferredModel === agent.model ? agent : { ...agent, model: preferredModel };
 }
 
-function createAutonomousWorkerSpawner() {
+function createWorkerRunId(issueNumber: number): string {
+  return `autonomous-${issueNumber}-${Date.now()}-${randomBytes(4).toString("hex")}`;
+}
+
+export function createAutonomousWorkerSpawner() {
   let cachedWorkerAgent: AgentConfig | null = null;
 
   return async (
@@ -421,13 +426,36 @@ function createAutonomousWorkerSpawner() {
       return { status: "failed", error: resolvedWorkerAgent.error };
     }
 
+    const workerRunId = createWorkerRunId(issueNumber);
     const task = buildWorkerTask(issueNumber, config.repo, issueContext);
+    const logWorkerLifecycle = (event: RunLifecycleEvent) => {
+      logAutonomousDev("info", `worker.process.${event.phase}`, {
+        repo: config.repo,
+        issueNumber,
+        issueTitle: issueContext.issue.title,
+        message: `Worker process ${event.phase}`,
+        details: {
+          workerRunId,
+          runId: event.runId,
+          parentRunId: event.parentRunId,
+          rootRunId: event.rootRunId,
+          owner: event.owner,
+          pid: event.pid,
+          pgid: event.pgid,
+          reason: event.reason,
+          signal: event.signal,
+          exitCode: event.exitCode,
+          parentPid: process.pid,
+        },
+      });
+    };
+
     logAutonomousDev("info", "worker.run.started", {
       repo: config.repo,
       issueNumber,
       issueTitle: issueContext.issue.title,
       message: `Running ${resolvedWorkerAgent.name} worker agent`,
-      details: { cwd: process.cwd() },
+      details: { cwd: process.cwd(), workerRunId, parentPid: process.pid },
     });
     onActivity?.(`starting worker for issue #${issueNumber}`);
 
@@ -438,6 +466,14 @@ function createAutonomousWorkerSpawner() {
       task,
       cwd: process.cwd(),
       depthConfig: resolveDepthConfig(),
+      ownership: {
+        runId: workerRunId,
+        owner: `autonomous-dev#${issueNumber}`,
+      },
+      extraEnv: {
+        PI_SUBAGENT_PROCESS_LOG: getAutonomousDevLogPath(),
+      },
+      onLifecycleEvent: logWorkerLifecycle,
       makeDetails: (results) => ({ mode: "single", results }),
       onUpdate: (partial) => {
         const single = partial.details?.results?.[0];

--- a/extensions/autonomous-dev/index.ts
+++ b/extensions/autonomous-dev/index.ts
@@ -165,20 +165,25 @@ function cleanupAutonomousDev(): void {
   }
 }
 
+function cleanupAndReraise(signalName: NodeJS.Signals): void {
+  cleanupAutonomousDev();
+  process.kill(process.pid, signalName);
+}
+
 function ensureProcessCleanupHooks(): void {
   if (processCleanupRegistered) return;
   processCleanupRegistered = true;
 
-  const cleanup = () => {
+  process.once("exit", () => {
     cleanupAutonomousDev();
-  };
-
-  process.once("exit", cleanup);
-  process.once("SIGINT", () => {
-    cleanup();
   });
+
+  process.once("SIGINT", () => {
+    cleanupAndReraise("SIGINT");
+  });
+
   process.once("SIGTERM", () => {
-    cleanup();
+    cleanupAndReraise("SIGTERM");
   });
 }
 

--- a/extensions/autonomous-dev/tests/index.test.ts
+++ b/extensions/autonomous-dev/tests/index.test.ts
@@ -140,6 +140,23 @@ describe("autonomous-dev extension command registration", () => {
     });
   });
 
+  it("re-raises SIGINT after cleanup so process termination semantics are preserved", async () => {
+    process.env.PI_AUTONOMOUS_DEV = "1";
+    const onceSpy = vi.spyOn(process, "once");
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true as any);
+    const { default: registerExtension } = await import("../index.js");
+    const pi = createPiMock();
+
+    registerExtension(pi);
+
+    const sigintHandler = onceSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1] as (() => void) | undefined;
+    expect(sigintHandler).toBeTypeOf("function");
+
+    sigintHandler?.();
+
+    expect(killSpy).toHaveBeenCalledWith(process.pid, "SIGINT");
+  });
+
   it("installs persistent footer status and below-editor widget on session start", async () => {
     process.env.PI_AUTONOMOUS_DEV = "1";
     const { default: registerExtension } = await import("../index.js");

--- a/extensions/autonomous-dev/tests/index.test.ts
+++ b/extensions/autonomous-dev/tests/index.test.ts
@@ -285,9 +285,11 @@ describe("resolveWorkerAgentConfig: provider/id regression", () => {
 
   it("agent.model with provider/id passes through unchanged", async () => {
     const { resolveWorkerAgentConfig } = await import("../index.js");
-    const agent = {
+    const agent: Parameters<typeof resolveWorkerAgentConfig>[0] = {
       name: "test-worker",
-      source: "bundled",
+      description: "test worker",
+      filePath: "test.ts",
+      source: "bundled" as const,
       model: "openai-codex/gpt-5.4",
       systemPrompt: "",
       tools: ["read", "bash"],
@@ -300,9 +302,11 @@ describe("resolveWorkerAgentConfig: provider/id regression", () => {
 
   it("no model and no session returns error", async () => {
     const { resolveWorkerAgentConfig } = await import("../index.js");
-    const agent = {
+    const agent: Parameters<typeof resolveWorkerAgentConfig>[0] = {
       name: "test-worker",
-      source: "bundled",
+      description: "test worker",
+      filePath: "test.ts",
+      source: "bundled" as const,
       model: undefined,
       systemPrompt: "",
       tools: ["read", "bash"],

--- a/extensions/autonomous-dev/tests/orchestrator.test.ts
+++ b/extensions/autonomous-dev/tests/orchestrator.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { AutonomousDevOrchestrator } from "../orchestrator.js";
-import { AUTONOMOUS_LABELS } from "../types.js";
+import { AUTONOMOUS_LABELS, type WorkerResult, type WorkerAbortSignal, type OrchestratorConfig, type WorkerActivityCallback } from "../types.js";
 
 vi.mock("../logger.js", () => ({
   logAutonomousDev: vi.fn(),
@@ -45,7 +45,12 @@ const mockLogAutonomousDev = logAutonomousDev as unknown as ReturnType<typeof vi
 
 describe("orchestrator", () => {
   let orchestrator: AutonomousDevOrchestrator;
-  let workerSpawner: ReturnType<typeof vi.fn>;
+  let workerSpawner: Mock<[
+    issueNumber: number,
+    config: OrchestratorConfig,
+    onActivity?: WorkerActivityCallback,
+    signal?: WorkerAbortSignal
+  ], Promise<WorkerResult>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -117,7 +122,7 @@ describe("orchestrator", () => {
 
       const pollPromise = orchestrator.pollCycle();
       orchestrator.stop();
-      releaseListIssues?.();
+      (releaseListIssues as any)?.();
       await pollPromise;
 
       const status = orchestrator.getStatus();
@@ -162,7 +167,7 @@ describe("orchestrator", () => {
       expect(capturedSignal?.aborted).toBe(true);
 
       capturedOnActivity?.("read src/after-stop.ts");
-      resolveWorker?.({
+      (resolveWorker as any)({
         status: "completed",
         prUrl: "https://github.com/owner/repo/pull/1",
         summary: "Done",

--- a/extensions/autonomous-dev/tsconfig.json
+++ b/extensions/autonomous-dev/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add explicit subagent run ownership IDs and process lifecycle logging
- spawn subagents in their own process groups and terminate the owned group on success/abort
- pass autonomous-dev worker correlation IDs into subagent runs and log parent/child process details
- add process-level tests that verify descendant processes are reaped on success and abort

## Verification
- npx vitest run extensions/autonomous-dev/tests/ extensions/agentic-harness/tests/subagent.test.ts extensions/agentic-harness/tests/subagent-process.test.ts
- npx tsc -p extensions/agentic-harness/tsconfig.json --noEmit --ignoreDeprecations 6.0