### PR TITLE
docs: add ROACH PI architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ The footer displays real-time metrics during every session:
 
 Everything the agent does is inspectable. No hidden behavior.
 
+## Architecture
+
+A high-level architecture diagram is available for the current extension suite:
+
+- Summary note: [`docs/architecture/README.md`](docs/architecture/README.md)
+- Editable diagram source: [`docs/architecture/roach-pi-high-level.excalidraw`](docs/architecture/roach-pi-high-level.excalidraw)
+- Shareable online view: https://excalidraw.com/#json=oVHGws8WgbCFib2A6ANW3,j-HgCZDcQrEwE93BQ_Gs0g
+
+The diagram focuses on the main runtime layers:
+- `pi` runtime as the host surface
+- `agentic-harness` as the orchestration core
+- `session-loop` as the recurring-job layer
+- `autonomous-dev` as the GitHub issue execution engine
+- spawned child `pi` processes as the shared execution primitive
+
 ## Development
 
 1. Clone the repository:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,57 @@
+# ROACH PI Architecture
+
+This note captures the current high-level architecture of the ROACH PI extension suite.
+
+Files added here:
+- `docs/architecture/roach-pi-high-level.excalidraw` — editable Excalidraw source
+- `docs/architecture/README.md` — this summary
+
+## What the diagram shows
+
+1. `pi` runtime is the host surface.
+   - It provides the tool registry, command registry, event lifecycle, and TUI surface.
+2. ROACH PI is an extension suite layered on top of that runtime.
+   - `agentic-harness` is the orchestration core.
+   - `session-loop` adds session-scoped recurring jobs.
+   - `autonomous-dev` adds a GitHub issue processing engine.
+3. The main reusable execution primitive is the spawned child `pi` process.
+   - `agentic-harness` uses it for subagents.
+   - `autonomous-dev` uses it for issue workers.
+4. Bundled agents and skills are plain Markdown assets.
+   - Agents live under `extensions/agentic-harness/agents/`
+   - Skills live under `extensions/agentic-harness/skills/`
+5. Observability and local state are first-class concerns.
+   - workflow state file: `~/.pi/extension-state.json`
+   - autonomous-dev log: `~/.pi/autonomous-dev.log`
+   - footer / status / widget UI surfaces are part of the runtime behavior
+
+## Key file map
+
+### Extension entrypoints
+- `package.json`
+- `extensions/agentic-harness/index.ts`
+- `extensions/session-loop/index.ts`
+- `extensions/autonomous-dev/index.ts`
+
+### Agentic harness internals
+- `extensions/agentic-harness/subagent.ts`
+- `extensions/agentic-harness/agents.ts`
+- `extensions/agentic-harness/footer.ts`
+- `extensions/agentic-harness/state.ts`
+- `extensions/agentic-harness/webfetch/`
+
+### Session loop
+- `extensions/session-loop/scheduler.ts`
+- `extensions/session-loop/commands.ts`
+
+### Autonomous dev
+- `extensions/autonomous-dev/orchestrator.ts`
+- `extensions/autonomous-dev/github.ts`
+- `extensions/autonomous-dev/logger.ts`
+- `extensions/autonomous-dev/agents/autonomous-dev-worker.md`
+
+## Editing
+
+- Open the local `.excalidraw` file in https://excalidraw.com by importing the file.
+- Shareable online view: https://excalidraw.com/#json=oVHGws8WgbCFib2A6ANW3,j-HgCZDcQrEwE93BQ_Gs0g
+- Source of truth in the repo: `docs/architecture/roach-pi-high-level.excalidraw`

--- a/docs/architecture/roach-pi-high-level.excalidraw
+++ b/docs/architecture/roach-pi-high-level.excalidraw
@@ -1,0 +1,1079 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "hermes-agent",
+  "elements": [
+    {
+      "type": "text",
+      "id": "title",
+      "x": 620,
+      "y": 20,
+      "text": "ROACH PI High-Level Architecture",
+      "fontSize": 30,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "originalText": "ROACH PI High-Level Architecture",
+      "autoResize": true
+    },
+    {
+      "type": "text",
+      "id": "subtitle",
+      "x": 430,
+      "y": 58,
+      "text": "pi extension suite for agentic workflow control, recurring jobs, and autonomous GitHub issue execution",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "pi extension suite for agentic workflow control, recurring jobs, and autonomous GitHub issue execution",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "zone_runtime",
+      "x": 30,
+      "y": 115,
+      "width": 1710,
+      "height": 350,
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "solid",
+      "strokeColor": "#ced4da",
+      "strokeWidth": 1,
+      "roundness": {
+        "type": 3
+      },
+      "opacity": 35
+    },
+    {
+      "type": "text",
+      "id": "zone_runtime_label",
+      "x": 50,
+      "y": 122,
+      "text": "Runtime path",
+      "fontSize": 16,
+      "fontFamily": 1,
+      "strokeColor": "#666666",
+      "originalText": "Runtime path",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "zone_state",
+      "x": 30,
+      "y": 500,
+      "width": 1710,
+      "height": 210,
+      "backgroundColor": "#f8f9fa",
+      "fillStyle": "solid",
+      "strokeColor": "#ced4da",
+      "strokeWidth": 1,
+      "roundness": {
+        "type": 3
+      },
+      "opacity": 35
+    },
+    {
+      "type": "text",
+      "id": "zone_state_label",
+      "x": 50,
+      "y": 507,
+      "text": "State, observability, and external systems",
+      "fontSize": 16,
+      "fontFamily": 1,
+      "strokeColor": "#666666",
+      "originalText": "State, observability, and external systems",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "user",
+      "x": 60,
+      "y": 250,
+      "width": 180,
+      "height": 80,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#ffd8a8",
+      "fillStyle": "solid",
+      "strokeColor": "#f59e0b",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_user",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_user",
+      "x": 66,
+      "y": 258,
+      "width": 168,
+      "height": 64,
+      "text": "User / pi TUI",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "user",
+      "originalText": "User / pi TUI",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "pi_runtime",
+      "x": 300,
+      "y": 215,
+      "width": 250,
+      "height": 150,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#a5d8ff",
+      "fillStyle": "solid",
+      "strokeColor": "#4a9eed",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_pi_runtime",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_pi_runtime",
+      "x": 306,
+      "y": 223,
+      "width": 238,
+      "height": 134,
+      "text": "pi runtime\n\nTool registry\nCommands\nEvent hooks\nUI surface",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "pi_runtime",
+      "originalText": "pi runtime\n\nTool registry\nCommands\nEvent hooks\nUI surface",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "manifest",
+      "x": 300,
+      "y": 385,
+      "width": 250,
+      "height": 60,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#f1f3f5",
+      "fillStyle": "solid",
+      "strokeColor": "#868e96",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_manifest",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_manifest",
+      "x": 306,
+      "y": 393,
+      "width": 238,
+      "height": 44,
+      "text": "package.json\nregisters extension entrypoints",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "manifest",
+      "originalText": "package.json\nregisters extension entrypoints",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "suite",
+      "x": 620,
+      "y": 145,
+      "width": 360,
+      "height": 300,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#b2f2bb",
+      "fillStyle": "solid",
+      "strokeColor": "#2f9e44",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_suite",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_suite",
+      "x": 626,
+      "y": 153,
+      "width": 348,
+      "height": 284,
+      "text": "ROACH PI extension suite",
+      "fontSize": 24,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "suite",
+      "originalText": "ROACH PI extension suite",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "harness",
+      "x": 650,
+      "y": 195,
+      "width": 300,
+      "height": 90,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#e6fcf5",
+      "fillStyle": "solid",
+      "strokeColor": "#12b886",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_harness",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_harness",
+      "x": 656,
+      "y": 203,
+      "width": 288,
+      "height": 74,
+      "text": "agentic-harness\n\n/clarify  /plan  /ultraplan\nask_user_question  subagent  webfetch",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "harness",
+      "originalText": "agentic-harness\n\n/clarify  /plan  /ultraplan\nask_user_question  subagent  webfetch",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "loop",
+      "x": 650,
+      "y": 305,
+      "width": 140,
+      "height": 70,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#fff3bf",
+      "fillStyle": "solid",
+      "strokeColor": "#f59f00",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_loop",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_loop",
+      "x": 656,
+      "y": 313,
+      "width": 128,
+      "height": 54,
+      "text": "session-loop\n\nrecurring prompt jobs",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "loop",
+      "originalText": "session-loop\n\nrecurring prompt jobs",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "autodev",
+      "x": 810,
+      "y": 305,
+      "width": 140,
+      "height": 70,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#ffc9c9",
+      "fillStyle": "solid",
+      "strokeColor": "#e03131",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_autodev",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_autodev",
+      "x": 816,
+      "y": 313,
+      "width": 128,
+      "height": 54,
+      "text": "autonomous-dev\n\nGitHub issue engine",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "autodev",
+      "originalText": "autonomous-dev\n\nGitHub issue engine",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "assets",
+      "x": 1040,
+      "y": 165,
+      "width": 280,
+      "height": 100,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#d0bfff",
+      "fillStyle": "solid",
+      "strokeColor": "#845ef7",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_assets",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_assets",
+      "x": 1046,
+      "y": 173,
+      "width": 268,
+      "height": 84,
+      "text": "Bundled agents + skills\n\nMarkdown agent prompts\nMarkdown skill rules",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "assets",
+      "originalText": "Bundled agents + skills\n\nMarkdown agent prompts\nMarkdown skill rules",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "child_pi",
+      "x": 1040,
+      "y": 315,
+      "width": 280,
+      "height": 90,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#c3fae8",
+      "fillStyle": "solid",
+      "strokeColor": "#12b886",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_child_pi",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_child_pi",
+      "x": 1046,
+      "y": 323,
+      "width": 268,
+      "height": 74,
+      "text": "Child pi processes\n\nspawned by subagent / worker pipeline",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "child_pi",
+      "originalText": "Child pi processes\n\nspawned by subagent / worker pipeline",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "github",
+      "x": 1380,
+      "y": 195,
+      "width": 280,
+      "height": 90,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#ffd8a8",
+      "fillStyle": "solid",
+      "strokeColor": "#f08c00",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_github",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_github",
+      "x": 1386,
+      "y": 203,
+      "width": 268,
+      "height": 74,
+      "text": "GitHub\n\nissue polling\ncomments / labels\nPR creation",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "github",
+      "originalText": "GitHub\n\nissue polling\ncomments / labels\nPR creation",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "repo",
+      "x": 1380,
+      "y": 325,
+      "width": 280,
+      "height": 90,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#a5d8ff",
+      "fillStyle": "solid",
+      "strokeColor": "#4a9eed",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_repo",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_repo",
+      "x": 1386,
+      "y": 333,
+      "width": 268,
+      "height": 74,
+      "text": "Local repo / filesystem\n\nread / edit / validate / commit",
+      "fontSize": 20,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "repo",
+      "originalText": "Local repo / filesystem\n\nread / edit / validate / commit",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "state",
+      "x": 60,
+      "y": 545,
+      "width": 370,
+      "height": 120,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#fff3bf",
+      "fillStyle": "solid",
+      "strokeColor": "#f59f00",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_state",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_state",
+      "x": 66,
+      "y": 553,
+      "width": 358,
+      "height": 104,
+      "text": "Local state\n\n~/.pi/extension-state.json\nworkflow phase + active goal metadata",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "state",
+      "originalText": "Local state\n\n~/.pi/extension-state.json\nworkflow phase + active goal metadata",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "ui_obs",
+      "x": 500,
+      "y": 545,
+      "width": 430,
+      "height": 120,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#d0ebff",
+      "fillStyle": "solid",
+      "strokeColor": "#228be6",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_ui_obs",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_ui_obs",
+      "x": 506,
+      "y": 553,
+      "width": 418,
+      "height": 104,
+      "text": "Observability\n\nfooter cache/context stats\nstatus lines\nbelow-editor widget\nROACH PI banner",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "ui_obs",
+      "originalText": "Observability\n\nfooter cache/context stats\nstatus lines\nbelow-editor widget\nROACH PI banner",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "logs",
+      "x": 1000,
+      "y": 545,
+      "width": 320,
+      "height": 120,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#f1f3f5",
+      "fillStyle": "solid",
+      "strokeColor": "#868e96",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_logs",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_logs",
+      "x": 1006,
+      "y": 553,
+      "width": 308,
+      "height": 104,
+      "text": "Engine logs / runtime output\n\n~/.pi/autonomous-dev.log\nsession-loop cleanup logs",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "logs",
+      "originalText": "Engine logs / runtime output\n\n~/.pi/autonomous-dev.log\nsession-loop cleanup logs",
+      "autoResize": true
+    },
+    {
+      "type": "rectangle",
+      "id": "note",
+      "x": 1380,
+      "y": 545,
+      "width": 280,
+      "height": 120,
+      "roundness": {
+        "type": 3
+      },
+      "backgroundColor": "#e9ecef",
+      "fillStyle": "solid",
+      "strokeColor": "#495057",
+      "strokeStyle": "solid",
+      "opacity": 100,
+      "boundElements": [
+        {
+          "id": "t_note",
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "t_note",
+      "x": 1386,
+      "y": 553,
+      "width": 268,
+      "height": 104,
+      "text": "Main architectural idea\n\nagentic-harness is the orchestration core\nother extensions reuse pi events, UI, and child-process execution patterns",
+      "fontSize": 18,
+      "fontFamily": 1,
+      "strokeColor": "#1e1e1e",
+      "textAlign": "center",
+      "verticalAlign": "middle",
+      "containerId": "note",
+      "originalText": "Main architectural idea\n\nagentic-harness is the orchestration core\nother extensions reuse pi events, UI, and child-process execution patterns",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_user_pi",
+      "x": 240,
+      "y": 290,
+      "width": 60,
+      "height": 0,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          60,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "arrow",
+      "id": "a_pi_suite",
+      "x": 550,
+      "y": 290,
+      "width": 70,
+      "height": 0,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          70,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_pi_suite",
+      "x": 563,
+      "y": 255,
+      "text": "extension entrypoints",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "extension entrypoints",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_manifest_suite",
+      "x": 550,
+      "y": 415,
+      "width": 70,
+      "height": -95,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          70,
+          -95
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2,
+      "strokeStyle": "dashed"
+    },
+    {
+      "type": "text",
+      "id": "lab_manifest_suite",
+      "x": 498,
+      "y": 392,
+      "text": "registration source",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#777777",
+      "originalText": "registration source",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_harness_assets",
+      "x": 950,
+      "y": 240,
+      "width": 90,
+      "height": -20,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          90,
+          -20
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_harness_assets",
+      "x": 970,
+      "y": 200,
+      "text": "discover + load",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "discover + load",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_harness_child",
+      "x": 950,
+      "y": 255,
+      "width": 90,
+      "height": 95,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          90,
+          95
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_harness_child",
+      "x": 965,
+      "y": 310,
+      "text": "runAgent()",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "runAgent()",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_assets_child",
+      "x": 1180,
+      "y": 265,
+      "width": 0,
+      "height": 50,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          50
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2,
+      "strokeStyle": "dashed"
+    },
+    {
+      "type": "text",
+      "id": "lab_assets_child",
+      "x": 1188,
+      "y": 285,
+      "text": "selected agent config",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#777777",
+      "originalText": "selected agent config",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_child_repo",
+      "x": 1320,
+      "y": 360,
+      "width": 60,
+      "height": 0,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          60,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_child_repo",
+      "x": 1328,
+      "y": 328,
+      "text": "code work",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "code work",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_autodev_github",
+      "x": 950,
+      "y": 340,
+      "width": 430,
+      "height": -95,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          430,
+          -95
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_autodev_github",
+      "x": 1120,
+      "y": 220,
+      "text": "poll + mutate issues/PRs",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "poll + mutate issues/PRs",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_autodev_child",
+      "x": 950,
+      "y": 340,
+      "width": 90,
+      "height": 0,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          90,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_autodev_child",
+      "x": 970,
+      "y": 350,
+      "text": "worker spawn",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "worker spawn",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_loop_pi",
+      "x": 650,
+      "y": 340,
+      "width": -100,
+      "height": 0,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -100,
+          0
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "text",
+      "id": "lab_loop_pi",
+      "x": 560,
+      "y": 350,
+      "text": "follow-up prompts",
+      "fontSize": 14,
+      "fontFamily": 1,
+      "strokeColor": "#555555",
+      "originalText": "follow-up prompts",
+      "autoResize": true
+    },
+    {
+      "type": "arrow",
+      "id": "a_suite_state",
+      "x": 720,
+      "y": 445,
+      "width": -380,
+      "height": 100,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -380,
+          100
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "arrow",
+      "id": "a_suite_ui",
+      "x": 790,
+      "y": 445,
+      "width": -40,
+      "height": 100,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -40,
+          100
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "arrow",
+      "id": "a_autodev_logs",
+      "x": 880,
+      "y": 375,
+      "width": 180,
+      "height": 170,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          180,
+          170
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    },
+    {
+      "type": "arrow",
+      "id": "a_autodev_ui",
+      "x": 880,
+      "y": 375,
+      "width": -90,
+      "height": 170,
+      "points": [
+        [
+          0,
+          0
+        ],
+        [
+          -90,
+          170
+        ]
+      ],
+      "endArrowhead": "arrow",
+      "strokeColor": "#1e1e1e",
+      "strokeWidth": 2
+    }
+  ],
+  "appState": {
+    "viewBackgroundColor": "#ffffff"
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,6 +38,7 @@
       <ul>
         <li><a href="#why">● <span data-lang="en">Why ROACH PI?</span><span data-lang="ko">왜 ROACH PI?</span></a></li>
         <li><a href="#quickstart">▶ <span data-lang="en">Quick Start</span><span data-lang="ko">빠른 시작</span></a></li>
+        <li><a href="#architecture">◆ <span data-lang="en">Architecture</span><span data-lang="ko">아키텍처</span></a></li>
         <li><a href="#features">■ <span data-lang="en">Features</span><span data-lang="ko">기능</span></a></li>
         <li><a href="#faq">● <span data-lang="en">FAQ</span><span data-lang="ko">FAQ</span></a></li>
         <li><a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a></li>
@@ -248,6 +249,75 @@
         </p>
         <p data-lang="ko" style="margin-bottom: 0;">
           <strong>💡 팁:</strong> <code>ask_user_question</code> 도구는 항상 사용 가능합니다 — <code>/clarify</code> 모드 외에서도 모호성을 감지하면 자동으로 질문합니다.
+        </p>
+      </div>
+    </section>
+
+    <!-- Architecture -->
+    <section class="section" id="architecture">
+      <h2>
+        <span class="icon">◆</span>
+        <span data-lang="en">Architecture</span>
+        <span data-lang="ko">아키텍처</span>
+      </h2>
+
+      <p data-lang="en">
+        ROACH PI is organized as a layered extension suite on top of the <strong>pi</strong> runtime. The main architectural idea is simple: <strong>agentic-harness</strong> acts as the orchestration core, while <strong>session-loop</strong> and <strong>autonomous-dev</strong> add specialized execution modes around the same host runtime.
+      </p>
+      <p data-lang="ko">
+        ROACH PI는 <strong>pi</strong> 런타임 위에 올라가는 계층형 익스텐션 스위트입니다. 핵심 아이디어는 단순합니다. <strong>agentic-harness</strong>가 오케스트레이션 코어 역할을 하고, <strong>session-loop</strong>와 <strong>autonomous-dev</strong>가 같은 호스트 런타임 위에 특화된 실행 모드를 추가합니다.
+      </p>
+
+      <div class="grid-2" style="margin-top: 1.5rem;">
+        <div class="card">
+          <span class="feature-icon">◆</span>
+          <div class="feature-title">
+            <span data-lang="en">Core Layers</span>
+            <span data-lang="ko">핵심 계층</span>
+          </div>
+          <div class="feature-desc">
+            <p data-lang="en">
+              <strong>pi runtime</strong> provides the tool registry, command surface, lifecycle hooks, and TUI UI. ROACH PI then injects commands, tools, event handlers, bundled agents, and recurring or autonomous workflows on top of that base.
+            </p>
+            <p data-lang="ko">
+              <strong>pi 런타임</strong>은 도구 레지스트리, 명령 표면, 라이프사이클 훅, TUI UI를 제공합니다. 그 위에 ROACH PI가 명령, 도구, 이벤트 핸들러, 번들 에이전트, 반복/자율 워크플로를 주입합니다.
+            </p>
+          </div>
+        </div>
+
+        <div class="card">
+          <span class="feature-icon">▶</span>
+          <div class="feature-title">
+            <span data-lang="en">Shared Execution Primitive</span>
+            <span data-lang="ko">공유 실행 프리미티브</span>
+          </div>
+          <div class="feature-desc">
+            <p data-lang="en">
+              Both subagents and autonomous issue workers rely on spawned child <code>pi</code> processes. This keeps the orchestration layer small and reuses the same execution model for exploration, planning, validation, and GitHub-driven work.
+            </p>
+            <p data-lang="ko">
+              서브에이전트와 자율 이슈 워커는 모두 child <code>pi</code> 프로세스 실행 패턴을 사용합니다. 덕분에 오케스트레이션 레이어를 작게 유지하면서 탐색, 계획, 검증, GitHub 기반 작업에 같은 실행 모델을 재사용합니다.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card card-blue" style="margin-top: 2rem;">
+        <p data-lang="en">
+          <strong>Resources:</strong>
+          <a href="https://github.com/tmdgusya/roach-pi/blob/main/docs/architecture/README.md" target="_blank">architecture note</a>
+          ·
+          <a href="https://github.com/tmdgusya/roach-pi/blob/main/docs/architecture/roach-pi-high-level.excalidraw" target="_blank">editable diagram source</a>
+          ·
+          <a href="https://excalidraw.com/#json=oVHGws8WgbCFib2A6ANW3,j-HgCZDcQrEwE93BQ_Gs0g" target="_blank">shareable Excalidraw view</a>
+        </p>
+        <p data-lang="ko">
+          <strong>리소스:</strong>
+          <a href="https://github.com/tmdgusya/roach-pi/blob/main/docs/architecture/README.md" target="_blank">아키텍처 노트</a>
+          ·
+          <a href="https://github.com/tmdgusya/roach-pi/blob/main/docs/architecture/roach-pi-high-level.excalidraw" target="_blank">편집 가능한 다이어그램 소스</a>
+          ·
+          <a href="https://excalidraw.com/#json=oVHGws8WgbCFib2A6ANW3,j-HgCZDcQrEwE93BQ_Gs0g" target="_blank">공유용 Excalidraw 뷰</a>
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a high-level ROACH PI architecture note under `docs/architecture/`
- add an editable Excalidraw source file for the architecture diagram
- link the architecture resources from the main README and the docs landing page

## Included resources
- `docs/architecture/README.md`
- `docs/architecture/roach-pi-high-level.excalidraw`
- Excalidraw share link for quick viewing

## Why
This makes the current runtime layering easier to understand for contributors:
- `pi` runtime as the host surface
- `agentic-harness` as the orchestration core
- `session-loop` as the recurring-job layer
- `autonomous-dev` as the GitHub issue execution engine
- spawned child `pi` processes as the shared execution primitive

## Test Plan
- docs-only change
- verified staged diff with `git diff --cached --check`
