### PR TITLE
fix(agentic-harness): hide ask_user_question from subagents

### DIFF
--- a/docs/engineering-discipline/context/2026-04-12-subagent-ask-user-question-guard-brief.md
+++ b/docs/engineering-discipline/context/2026-04-12-subagent-ask-user-question-guard-brief.md
@@ -1,0 +1,47 @@
+# Context Brief: subagent에서 ask_user_question 도구 차단
+
+## Goal
+subagent 프로세스(currentDepth > 0)에서 `ask_user_question` 도구 자체가 등록되지 않도록 하여, subagent가 자기 자신에게 질문/답변하는 루프를 원천 차단한다.
+
+## Scope
+- **In scope**:
+  - `extensions/agentic-harness/index.ts:68` — `pi.registerTool({ name: "ask_user_question", ... })` 호출을 `depthConfig.currentDepth === 0` 조건으로 감싼다 (기존 `subagent` 도구의 `canDelegate` 가드와 동일한 패턴).
+  - `extensions/agentic-harness/tests/extension.test.ts` — 환경변수 없이 실행되는 기존 테스트는 그대로 통과해야 한다. subagent 컨텍스트(`PI_SUBAGENT_DEPTH=1`)에서 `ask_user_question`이 **등록되지 않음**을 검증하는 신규 테스트 케이스를 추가한다.
+- **Out of scope**:
+  - `subagent`, `webfetch` 도구는 현상 유지.
+  - agent 정의(`agents/*`)의 tools 화이트리스트 수정 불필요 (등록 자체가 안 되므로 불필요).
+  - `/ask` 슬래시 커맨드는 루트 세션 전용이므로 변경 없음.
+  - 런타임 시점 에러 반환 방식은 선택하지 않음.
+
+## Technical Context
+- `resolveDepthConfig()`는 `PI_SUBAGENT_DEPTH` 환경변수를 읽어 `currentDepth`를 결정한다. 루트 세션에서는 0, spawn된 subagent에서는 1+ (`subagent.ts:39-58`).
+- 동일 패턴이 이미 `index.ts:152`의 `if (depthConfig.canDelegate)` 가드에 존재 — `subagent` 도구를 깊이가 허용될 때만 등록.
+- `depthConfig`는 `index.ts:121`에서 extension 초기화 시점에 한 번 resolve된다. `ask_user_question` 등록 블록(라인 68) 보다 뒤에 있으므로 등록 이전으로 이동시키거나, 등록 블록을 `depthConfig` 뒤로 이동시켜야 한다.
+- subagent 프로세스는 `pi -p --no-session ...`으로 spawn되며 동일 extension을 로드한다. 같은 `index.ts` 코드 경로를 타므로 등록 자체를 조건부로 막으면 subagent의 도구 목록에서 자연히 빠진다.
+
+## Constraints
+- 기존 테스트(`"should register ask_user_question tool"` 등)를 깨지 않아야 한다 — depth 0 경로에서는 동작 불변.
+- `depthConfig` resolve 시점은 extension 함수 초기에 한 번만 호출.
+
+## Success Criteria
+1. 루트 세션(`PI_SUBAGENT_DEPTH` unset): `ask_user_question` 정상 등록·호출 가능.
+2. subagent 컨텍스트(`PI_SUBAGENT_DEPTH=1` 또는 그 이상): `ask_user_question`이 도구 목록에 존재하지 않음 — 모델 컨텍스트에도 노출되지 않음.
+3. 기존 `extension.test.ts` 모든 케이스 통과.
+4. 신규 테스트: subagent 컨텍스트에서 `tools.get("ask_user_question")`이 `undefined`임을 검증.
+
+## Complexity Assessment
+
+| Signal | Score | Note |
+|---|---|---|
+| Scope breadth | 1 | 단일 조건 가드 추가 |
+| File impact | 1 | 2개 파일 (`index.ts`, `extension.test.ts`) |
+| Interface boundaries | 1 | 기존 `canDelegate` 패턴 재사용, 신규 인터페이스 없음 |
+| Dependency depth | 1 | 순서 의존 없음 |
+| Risk surface | 1 | 외부 시스템/스키마/호환성 영향 없음 |
+
+**Score:** 5
+**Verdict:** Simple
+**Rationale:** 기존의 동일 패턴(`canDelegate` 가드)을 한 군데 더 적용하는 대칭 변경으로, 영향 범위가 단일 파일의 한 블록에 국한된다.
+
+## Suggested Next Step
+`plan-crafting` 건너뛰고 바로 구현으로 진행.

--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -43,6 +43,8 @@ export default function (pi: ExtensionAPI) {
 
   const DIRECT_INPUT_OPTION = "직접 입력하기";
 
+  const depthConfig = resolveDepthConfig();
+
   const AskUserQuestionParams = Type.Object({
     question: Type.String({
       description: "The question to ask the user. The agent generates this dynamically based on context.",
@@ -65,60 +67,65 @@ export default function (pi: ExtensionAPI) {
     ),
   });
 
-  pi.registerTool({
-    name: "ask_user_question",
-    label: "Ask User Question",
-    description:
-      "Ask the user a question when the agent needs clarification. The agent composes the question and optional choices dynamically. Returns the user's answer as text.",
-    promptSnippet:
-      "Ask the user a clarifying question with optional multiple-choice answers",
-    promptGuidelines: [
-      "Use ask_user_question whenever you encounter ambiguity, unclear scope, or need user preference.",
-      "Generate the question and choices yourself based on the current context — do not rely on predefined templates.",
-      "Offer concrete choices (A/B/C style) when the options are enumerable. Omit choices for open-ended questions.",
-      "Ask one focused question at a time. Do not bundle multiple questions.",
-      "After receiving an answer, decide whether further clarification is needed or proceed with the task.",
-    ],
-    parameters: AskUserQuestionParams,
-    execute: async (toolCallId, params, signal, onUpdate, ctx) => {
-      const { question, choices, placeholder, defaultValue } = params;
+  // ask_user_question is only available to the root session. Subagent
+  // processes must not be able to call it — otherwise a subagent ends up
+  // asking itself questions and answering them, since subagents run
+  // non-interactively and have no user at the other end.
+  if (depthConfig.currentDepth === 0) {
+    pi.registerTool({
+      name: "ask_user_question",
+      label: "Ask User Question",
+      description:
+        "Ask the user a question when the agent needs clarification. The agent composes the question and optional choices dynamically. Returns the user's answer as text.",
+      promptSnippet:
+        "Ask the user a clarifying question with optional multiple-choice answers",
+      promptGuidelines: [
+        "Use ask_user_question whenever you encounter ambiguity, unclear scope, or need user preference.",
+        "Generate the question and choices yourself based on the current context — do not rely on predefined templates.",
+        "Offer concrete choices (A/B/C style) when the options are enumerable. Omit choices for open-ended questions.",
+        "Ask one focused question at a time. Do not bundle multiple questions.",
+        "After receiving an answer, decide whether further clarification is needed or proceed with the task.",
+      ],
+      parameters: AskUserQuestionParams,
+      execute: async (toolCallId, params, signal, onUpdate, ctx) => {
+        const { question, choices, placeholder, defaultValue } = params;
 
-      let answer: string | undefined;
+        let answer: string | undefined;
 
-      if (choices && choices.length > 0) {
-        const withDirect = choices.includes(DIRECT_INPUT_OPTION)
-          ? choices
-          : [...choices, DIRECT_INPUT_OPTION];
+        if (choices && choices.length > 0) {
+          const withDirect = choices.includes(DIRECT_INPUT_OPTION)
+            ? choices
+            : [...choices, DIRECT_INPUT_OPTION];
 
-        answer = await ctx.ui.select(question, withDirect, { signal });
+          answer = await ctx.ui.select(question, withDirect, { signal });
 
-        if (answer === DIRECT_INPUT_OPTION) {
+          if (answer === DIRECT_INPUT_OPTION) {
+            answer = await ctx.ui.input(question, placeholder || defaultValue, {
+              signal,
+            });
+          }
+        } else {
           answer = await ctx.ui.input(question, placeholder || defaultValue, {
             signal,
           });
         }
-      } else {
-        answer = await ctx.ui.input(question, placeholder || defaultValue, {
-          signal,
-        });
-      }
 
-      if (answer === undefined) {
+        if (answer === undefined) {
+          return {
+            content: [{ type: "text", text: "User cancelled the question." }],
+            details: undefined,
+          };
+        }
+
         return {
-          content: [{ type: "text", text: "User cancelled the question." }],
+          content: [{ type: "text", text: answer }],
           details: undefined,
         };
-      }
-
-      return {
-        content: [{ type: "text", text: answer }],
-        details: undefined,
-      };
-    },
-  });
+      },
+    });
+  }
 
   const HEARTBEAT_MS = 1000;
-  const depthConfig = resolveDepthConfig();
 
   const TaskItem = Type.Object({
     agent: Type.String({ description: "Name of the agent to invoke" }),

--- a/extensions/agentic-harness/tests/extension.test.ts
+++ b/extensions/agentic-harness/tests/extension.test.ts
@@ -35,6 +35,20 @@ describe("Extension Registration", () => {
     expect(tool.promptGuidelines.length).toBeGreaterThan(0);
   });
 
+  it("should NOT register ask_user_question tool in subagent context", () => {
+    const prevDepth = process.env.PI_SUBAGENT_DEPTH;
+    process.env.PI_SUBAGENT_DEPTH = "1";
+    try {
+      const { mockPi, tools } = createMockPi();
+      extension(mockPi);
+
+      expect(tools.get("ask_user_question")).toBeUndefined();
+    } finally {
+      if (prevDepth === undefined) delete process.env.PI_SUBAGENT_DEPTH;
+      else process.env.PI_SUBAGENT_DEPTH = prevDepth;
+    }
+  });
+
   it("should register subagent tool", () => {
     const { mockPi, tools } = createMockPi();
     extension(mockPi);


### PR DESCRIPTION
## Summary
- subagent 프로세스에서 `ask_user_question` 도구가 등록되지 않도록 `currentDepth === 0` 가드 추가
- subagent는 non-interactive로 실행되므로 해당 도구가 노출되면 자기 자신에게 질문하고 답하는 루프가 발생했음
- 기존 `subagent` 도구의 `canDelegate` 가드와 동일한 대칭 패턴

## Changes
- `extensions/agentic-harness/index.ts` — `resolveDepthConfig()`를 extension 초기화 선두로 이동하고 `ask_user_question` 등록 블록을 `if (depthConfig.currentDepth === 0)`로 감쌈
- `extensions/agentic-harness/tests/extension.test.ts` — `PI_SUBAGENT_DEPTH=1` 환경에서 도구가 미등록됨을 검증하는 테스트 추가
- `docs/engineering-discipline/context/2026-04-12-subagent-ask-user-question-guard-brief.md` — clarification 단계에서 합의한 Context Brief

## Test plan
- [x] 기존 extension.test.ts 17개 통과 (루트 컨텍스트 동작 불변)
- [x] 신규 테스트 1개 통과 (subagent 컨텍스트에서 `tools.get("ask_user_question") === undefined`)
- [x] `tsc --noEmit` clean
- [ ] 실제 subagent spawn 시 도구 목록에 `ask_user_question` 미노출 확인 (수동 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)