### PR TITLE
Add Renovate dependency update config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Asia/Seoul",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@code-yeongyu/pi-nested-agents-md",
+        "pi-lsp-client"
+      ],
+      "groupName": "external pi github dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- add Renovate config for weekly npm dependency checks\n- group external GitHub-sourced pi dependencies into a dedicated PR\n- enable weekly lockfile maintenance for pinned dependency refreshes\n\n## Verification\n- node -e "JSON.parse(require('fs').readFileSync('.github/renovate.json','utf8')); console.log('valid json')"\n\nNote: package-lock.json has pre-existing unstaged local changes and was not included in this PR.