### PR TITLE
docs: add deep-dive feature documentation pages

### DIFF
--- a/docs/features/code-review.html
+++ b/docs/features/code-review.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Review — ROACH PI</title>
+  <meta name="description" content="Deep-dive documentation for ROACH PI code review modes: /review (single-pass) and /ultrareview (multi-agent pipeline with 10 parallel reviewers).">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html" class="active"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Content -->
+  <div class="doc-container">
+
+    <!-- Sidebar -->
+    <aside class="doc-sidebar">
+      <ul>
+        <li><a href="#overview"><span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#review"><span data-lang="en">/review</span><span data-lang="ko">/review</span></a></li>
+        <li><a href="#diff-commands"><span data-lang="en">Diff Commands</span><span data-lang="ko">Diff 명령어</span></a></li>
+        <li><a href="#ultrareview"><span data-lang="en">/ultrareview</span><span data-lang="ko">/ultrareview</span></a></li>
+        <li><a href="#reviewer-roles"><span data-lang="en">Reviewer Roles</span><span data-lang="ko">리뷰어 역할</span></a></li>
+        <li><a href="#verification"><span data-lang="en">Verification</span><span data-lang="ko">검증</span></a></li>
+        <li><a href="#choosing-modes"><span data-lang="en">Choosing Modes</span><span data-lang="ko">모드 선택</span></a></li>
+      </ul>
+    </aside>
+
+    <!-- Main Content -->
+    <div class="doc-with-sidebar doc-prose">
+
+      <!-- Overview -->
+      <section class="doc-section" id="overview">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Overview</span>
+          <span data-lang="ko">개요</span>
+        </h2>
+        <p data-lang="en">
+          ROACH PI provides two code review modes with different depth and cost trade-offs:
+        </p>
+        <p data-lang="ko">
+          ROACH PI는 깊이와 비용 트레이드오프가 다른 두 가지 코드 리뷰 모드를 제공합니다:
+        </p>
+        <ul>
+          <li>
+            <code>/review</code> —
+            <span data-lang="en">single-pass review performed directly by the current agent. Fast, lightweight, no subagent overhead.</span>
+            <span data-lang="ko">현재 에이전트가 직접 수행하는 단일 패스 리뷰. 빠르고 가벼우며 서브에이전트 오버헤드 없음.</span>
+          </li>
+          <li>
+            <code>/ultrareview</code> —
+            <span data-lang="en">multi-agent pipeline that dispatches 10 parallel reviewers, a verification pass, and a synthesis step. Thorough but slower.</span>
+            <span data-lang="ko">10개의 병렬 리뷰어, 검증 패스, 종합 단계를 디스패치하는 다중 에이전트 파이프라인. 철저하지만 느림.</span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- /review -->
+      <section class="doc-section" id="review">
+        <h2>
+          <span class="icon">▶</span>
+          <code>/review</code>
+          <span data-lang="en"> — Single-Pass Review</span>
+          <span data-lang="ko"> — 단일 패스 리뷰</span>
+        </h2>
+
+        <h3>
+          <span data-lang="en">Syntax</span>
+          <span data-lang="ko">구문</span>
+        </h3>
+        <div class="doc-code">
+          /review [target]
+        </div>
+
+        <p data-lang="en">
+          <code>target</code> can be a <strong>PR number</strong>, <strong>PR URL</strong>, <strong>branch name</strong>, or <strong>omitted</strong> for auto-detection. No confirmation is required — the review starts immediately.
+        </p>
+        <p data-lang="ko">
+          <code>target</code>은 <strong>PR 번호</strong>, <strong>PR URL</strong>, <strong>브랜치 이름</strong>, 또는 자동 감지를 위해 <strong>생략</strong>할 수 있습니다. 확인 없이 리뷰가 즉시 시작됩니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Target Validation</span>
+          <span data-lang="ko">타겟 검증</span>
+        </h3>
+        <p data-lang="en">
+          The target is validated against <code>/^[a-zA-Z0-9._/:\-]+$/</code> before any prompt is sent. Shell metacharacters (<code>;</code>, <code>|</code>, <code>&amp;</code>, <code>&gt;</code>, <code>`</code>, <code>$()</code>) are rejected immediately to prevent injection into the downstream <code>gh</code> / <code>git</code> commands.
+        </p>
+        <p data-lang="ko">
+          타겟은 프롬프트 전송 전에 <code>/^[a-zA-Z0-9._/:\-]+$/</code>로 검증됩니다. 셸 메타문자(<code>;</code>, <code>|</code>, <code>&amp;</code>, <code>&gt;</code>, <code>`</code>, <code>$()</code>)는 다운스트림 <code>gh</code> / <code>git</code> 명령어로의 인젝션을 방지하기 위해 즉시 거부됩니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Review Output</span>
+          <span data-lang="ko">리뷰 출력</span>
+        </h3>
+        <p data-lang="en">
+          The review is output directly to chat, grouped by file. Each finding includes: <strong>what</strong>, <strong>where</strong> (file:line), <strong>severity</strong> (Critical/High/Medium/Low), and a <strong>one-line suggested fix</strong>. No file is saved and no subagents are dispatched.
+        </p>
+        <p data-lang="ko">
+          리뷰는 파일별로 그룹화되어 채팅에 직접 출력됩니다. 각 발견 사항은 <strong>내용</strong>, <strong>위치</strong>(file:line), <strong>심각도</strong>(Critical/High/Medium/Low), <strong>한 줄 수정 제안</strong>을 포함합니다. 파일은 저장되지 않고 서브에이전트도 디스패치되지 않습니다.
+        </p>
+      </section>
+
+      <!-- Diff Commands -->
+      <section class="doc-section" id="diff-commands">
+        <h2>
+          <span class="icon">■</span>
+          <span data-lang="en">Diff Commands</span>
+          <span data-lang="ko">Diff 명령어</span>
+        </h2>
+
+        <p data-lang="en">Both <code>/review</code> and <code>/ultrareview</code> use the same target resolution logic:</p>
+        <p data-lang="ko"><code>/review</code>와 <code>/ultrareview</code> 모두 동일한 타겟 해결 로직을 사용합니다:</p>
+
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Target</span><span data-lang="ko">타겟</span></th>
+              <th><span data-lang="en">Command</span><span data-lang="ko">명령어</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span data-lang="en">PR number</span><span data-lang="ko">PR 번호</span></td>
+              <td><code>gh pr diff &lt;number&gt;</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">PR URL</span><span data-lang="ko">PR URL</span></td>
+              <td><code>gh pr diff &lt;url&gt;</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Branch name</span><span data-lang="ko">브랜치 이름</span></td>
+              <td><code>git diff main...&lt;topic&gt;</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Auto (PR found)</span><span data-lang="ko">자동 (PR 발견)</span></td>
+              <td><code>gh pr list --head &lt;branch&gt;</code> → <code>gh pr diff &lt;number&gt;</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Auto (no PR)</span><span data-lang="ko">자동 (PR 없음)</span></td>
+              <td><code>git diff main...HEAD</code> + <code>git diff</code> + <code>git diff --cached</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="doc-callout doc-callout-info">
+          <div class="doc-callout-title">
+            <span data-lang="en">💡 Note</span><span data-lang="ko">💡 참고</span>
+          </div>
+          <p data-lang="en" style="margin-bottom:0">
+            <code>gh</code> accepts PR numbers and full GitHub PR URLs interchangeably — no special URL parsing is needed.
+          </p>
+          <p data-lang="ko" style="margin-bottom:0">
+            <code>gh</code>는 PR 번호와 전체 GitHub PR URL을 상호 교환적으로 허용합니다 — 별도의 URL 파싱이 필요 없습니다.
+          </p>
+        </div>
+      </section>
+
+      <!-- /ultrareview -->
+      <section class="doc-section" id="ultrareview">
+        <h2>
+          <span class="icon">★</span>
+          <code>/ultrareview</code>
+          <span data-lang="en"> — Multi-Agent Pipeline</span><span data-lang="ko"> — 다중 에이전트 파이프라인</span>
+        </h2>
+
+        <p data-lang="en">
+          The ultrareview command dispatches a <strong>3-stage pipeline</strong> with up to <strong>12 subagent invocations</strong>. A confirmation dialog is required before the pipeline starts.
+        </p>
+        <p data-lang="ko">
+          ultrareview 명령어는 최대 <strong>12개의 서브에이전트 호출</strong>로 <strong>3단계 파이프라인</strong>을 디스패치합니다. 파이프라인 시작 전 확인 대화상자가 필요합니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Stage 1: Finding (10 parallel reviewers)</span><span data-lang="ko">1단계: 발견 (10개 병렬 리뷰어)</span>
+        </h3>
+        <p data-lang="en">
+          The diff is resolved once and written to a <strong>shared artifact</strong> (e.g. <code>docs/engineering-discipline/reviews/.tmp/&lt;date&gt;-&lt;topic&gt;.diff</code>). Then <strong>10 subagents</strong> are dispatched in parallel — <strong>5 reviewer roles × 2 seeds</strong> each. Seed 2 is instructed to focus on findings seed 1 might miss.
+        </p>
+        <p data-lang="ko">
+          diff는 한 번 해결되어 <strong>공유 아티팩트</strong>(예: <code>docs/engineering-discipline/reviews/.tmp/&lt;date&gt;-&lt;topic&gt;.diff</code>)에 작성됩니다. 그 후 <strong>10개의 서브에이전트</strong>가 병렬로 디스패치됩니다 — <strong>5개 리뷰어 역할 × 시드 2개</strong>. 시드 2는 시드 1이 놓칠 수 있는 발견에 집중하도록 지시받습니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Stage 2: Verification</span><span data-lang="ko">2단계: 검증</span>
+        </h3>
+        <p data-lang="en">
+          <code>reviewer-verifier</code> is dispatched in single mode with the aggregated findings from all 10 reviewers. It deduplicates findings, filters false positives, and assigns final <strong>severity</strong> and <strong>confidence</strong> ratings.
+        </p>
+        <p data-lang="ko">
+          10개 리뷰어의 모든 집계된 발견과 함께 <code>reviewer-verifier</code>가 단일 모드로 디스패치됩니다. 발견을 중복 제거하고, 위양성을 필터링하며, 최종 <strong>심각도</strong> 및 <strong>신뢰도</strong> 등급을 부여합니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Stage 3: Synthesis</span><span data-lang="ko">3단계: 종합</span>
+        </h3>
+        <p data-lang="en">
+          <code>review-synthesis</code> is dispatched in single mode with the verified findings. It produces a structured report and saves it to <code>docs/engineering-discipline/reviews/&lt;YYYY-MM-DD&gt;-&lt;topic&gt;-review.md</code>. A 5-item top-priority summary is also streamed to chat.
+        </p>
+        <p data-lang="ko">
+          검증된 발견과 함께 <code>review-synthesis</code>가 단일 모드로 디스패치됩니다. 구조화된 리포트를 생성하고 <code>docs/engineering-discipline/reviews/&lt;YYYY-MM-DD&gt;-&lt;topic&gt;-review.md</code>에 저장합니다. 최우선 5개 항목 요약도 채팅에 스트리밍됩니다.
+        </p>
+
+        <div class="doc-callout doc-callout-warn">
+          <div class="doc-callout-title">
+            <span data-lang="en">⚠ Guard</span><span data-lang="ko">⚠ 가드</span>
+          </div>
+          <p data-lang="en" style="margin-bottom:0">
+            No agent whose name contains <code>"worker"</code> is ever dispatched in this pipeline — only <code>reviewer-*</code> and <code>review-synthesis</code> are allowed.
+          </p>
+          <p data-lang="ko" style="margin-bottom:0">
+            이 파이프라인에서는 이름에 <code>"worker"</code>가 포함된 에이전트는 디스패치되지 않습니다 — <code>reviewer-*</code>와 <code>review-synthesis</code>만 허용됩니다.
+          </p>
+        </div>
+      </section>
+
+      <!-- Reviewer Roles -->
+      <section class="doc-section" id="reviewer-roles">
+        <h2>
+          <span class="icon">■</span>
+          <span data-lang="en">Reviewer Roles</span><span data-lang="ko">리뷰어 역할</span>
+        </h2>
+
+        <p data-lang="en">Each of the 5 reviewer roles is dispatched twice (seed 1 and seed 2) for complementary coverage:</p>
+        <p data-lang="ko">5개 리뷰어 역할 각각이 상호 보완적 커버리지를 위해 두 번(시드 1과 시드 2) 디스패치됩니다:</p>
+
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Role</span><span data-lang="ko">역할</span></th>
+              <th><span data-lang="en">Focus</span><span data-lang="ko">집중 영역</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>reviewer-bug</code></td>
+              <td>
+                <span data-lang="en">Logic errors, boundary conditions, null/undefined, race conditions, missing error handling</span>
+                <span data-lang="ko">논리 오류, 경계 조건, null/undefined, 레이스 컨디션, 누락된 에러 핸들링</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>reviewer-security</code></td>
+              <td>
+                <span data-lang="en">Injection, auth, authorization, crypto misuse, data exposure</span>
+                <span data-lang="ko">인젝션, 인증, 인가, 암호화 오용, 데이터 노출</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>reviewer-performance</code></td>
+              <td>
+                <span data-lang="en">Algorithmic complexity, unnecessary allocations, sync I/O on hot paths, cache misses</span>
+                <span data-lang="ko">알고리즘 복잡도, 불필요한 할당, 핫 경로의 동기 I/O, 캐시 미스</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>reviewer-test-coverage</code></td>
+              <td>
+                <span data-lang="en">Missing tests, happy-path only, uncovered edge cases</span>
+                <span data-lang="ko">누락된 테스트, 해피 패스만 존재, 커버되지 않은 엣지 케이스</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>reviewer-consistency</code></td>
+              <td>
+                <span data-lang="en">Convention drift, duplication, missing reuse of existing utilities</span>
+                <span data-lang="ko">컨벤션 드리프트, 중복, 기존 유틸리티의 재사용 누락</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Verification -->
+      <section class="doc-section" id="verification">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Verification &amp; Synthesis</span><span data-lang="ko">검증 및 종합</span>
+        </h2>
+
+        <h3>
+          <code>reviewer-verifier</code>
+        </h3>
+        <p data-lang="en">
+          Receives the aggregated output from all 10 reviewers. Performs three actions:
+        </p>
+        <p data-lang="ko">
+          10개 리뷰어의 집계된 출력을 받습니다. 세 가지 작업을 수행합니다:
+        </p>
+        <ul>
+          <li>
+            <span data-lang="en"><strong>Deduplicate</strong> — removes findings reported by multiple reviewers for the same location.</span>
+            <span data-lang="ko"><strong>중복 제거</strong> — 동일한 위치에 대해 여러 리뷰어가 보고한 발견을 제거합니다.</span>
+          </li>
+          <li>
+            <span data-lang="en"><strong>Filter false positives</strong> — discards findings that don't hold against the actual codebase.</span>
+            <span data-lang="ko"><strong>위양성 필터</strong> — 실제 코드베이스에서 성립하지 않는 발견을 버립니다.</span>
+          </li>
+          <li>
+            <span data-lang="en"><strong>Attach ratings</strong> — assigns <code>severity</code> (low / medium / high / critical) and <code>confidence</code> to each surviving finding.</span>
+            <span data-lang="ko"><strong>등급 부여</strong> — 각 생존 발견에 <code>심각도</code>(low / medium / high / critical)와 <code>신뢰도</code>를 부여합니다.</span>
+          </li>
+        </ul>
+
+        <h3>
+          <code>review-synthesis</code>
+        </h3>
+        <p data-lang="en">
+          Takes the verified findings and produces the final structured review report. Writes to <code>docs/engineering-discipline/reviews/&lt;YYYY-MM-DD&gt;-&lt;topic&gt;-review.md</code>. The report includes a summary, per-file findings ranked by severity, and a top-priority list streamed to chat.
+        </p>
+        <p data-lang="ko">
+          검증된 발견을 받아 최종 구조화된 리뷰 리포트를 생성합니다. <code>docs/engineering-discipline/reviews/&lt;YYYY-MM-DD&gt;-&lt;topic&gt;-review.md</code>에 작성합니다. 리포트에는 요약, 심각도별 순위의 파일별 발견, 채팅에 스트리밍되는 최우선 목록이 포함됩니다.
+        </p>
+      </section>
+
+      <!-- Choosing Modes -->
+      <section class="doc-section" id="choosing-modes">
+        <h2>
+          <span class="icon">▶</span>
+          <span data-lang="en">Choosing Between Modes</span><span data-lang="ko">모드 선택 가이드</span>
+        </h2>
+
+        <div class="grid-2" style="margin-top: 1.5rem;">
+          <div class="card">
+            <span class="feature-icon">▶</span>
+            <div class="feature-title"><code>/review</code></div>
+            <div class="feature-desc">
+              <p data-lang="en">
+                Quick feedback on small changes. Single-pass, no subagents, instant output to chat. Ideal for PRs under ~200 lines or when you just need a second pair of eyes.
+              </p>
+              <p data-lang="ko">
+                작은 변경 사항에 대한 빠른 피드백. 단일 패스, 서브에이전트 없음, 채팅에 즉시 출력. 약 200줄 미만의 PR이나 간단한 검토가 필요할 때 적합합니다.
+              </p>
+            </div>
+          </div>
+          <div class="card">
+            <span class="feature-icon">★</span>
+            <div class="feature-title"><code>/ultrareview</code></div>
+            <div class="feature-desc">
+              <p data-lang="en">
+                Major PRs, architectural changes, or when thorough coverage is critical. 10 parallel reviewers + verification + synthesis. Takes several minutes but produces a saved, structured report.
+              </p>
+              <p data-lang="ko">
+                주요 PR, 아키텍처 변경, 철저한 커버리지가 중요할 때. 10개 병렬 리뷰어 + 검증 + 종합. 몇 분이 걸리지만 저장되는 구조화된 리포트를 생성합니다.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div><!-- /.doc-with-sidebar -->
+  </div><!-- /.doc-container -->
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/compaction.html
+++ b/docs/features/compaction.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Compaction — ROACH PI</title>
+  <meta name="description" content="Deep-dive into ROACH PI context management: phase-aware compaction, microcompaction, and plan execution interaction.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html" class="active"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Content -->
+  <div class="doc-container">
+
+    <!-- Sidebar -->
+    <aside class="doc-sidebar">
+      <ul>
+        <li><a href="#overview"><span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#compaction"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="#summary-format"><span data-lang="en">Summary Format</span><span data-lang="ko">요약 형식</span></a></li>
+        <li><a href="#workflow-phases"><span data-lang="en">Workflow Phases</span><span data-lang="ko">워크플로 단계</span></a></li>
+        <li><a href="#microcompaction"><span data-lang="en">Microcompaction</span><span data-lang="ko">마이크로컴팩션</span></a></li>
+        <li><a href="#configuration"><span data-lang="en">Configuration</span><span data-lang="ko">설정</span></a></li>
+        <li><a href="#plan-execution"><span data-lang="en">Plan Execution</span><span data-lang="ko">계획 실행</span></a></li>
+      </ul>
+    </aside>
+
+    <!-- Main Content -->
+    <div class="doc-with-sidebar doc-prose">
+
+      <!-- Page Title -->
+      <h1>
+        <span data-lang="en">Context Compaction</span>
+        <span data-lang="ko">컨텍스트 컴팩션</span>
+      </h1>
+      <p style="margin-top: 0.5rem; color: #888; font-size: 0.9rem;">
+        <span data-lang="en">Phase-aware summarization and microcompaction for long sessions</span>
+        <span data-lang="ko">긴 세션을 위한 단계 인식 요약 및 마이크로컴팩션</span>
+      </p>
+
+      <!-- Overview -->
+      <section class="doc-section" id="overview">
+        <h2>
+          <span data-lang="en">Overview</span>
+          <span data-lang="ko">개요</span>
+        </h2>
+        <p data-lang="en">
+          Long coding sessions generate large conversation histories that eventually exceed the context window. ROACH PI uses a two-layer approach to context management:
+        </p>
+        <p data-lang="ko">
+          긴 코딩 세션은 결국 컨텍스트 윈도우를 초과하는 대화 기록을 생성합니다. ROACH PI는 컨텍스트 관리를 위해 두 계층 접근 방식을 사용합니다:
+        </p>
+        <ul>
+          <li>
+            <strong data-lang="en">Full compaction</strong><strong data-lang="ko">전체 컴팩션</strong>
+            — <span data-lang="en">Summarizes the entire old conversation into a structured summary, freeing context for new work.</span><span data-lang="ko">전체 이전 대화를 구조화된 요약으로 압축하여 새 작업을 위한 컨텍스트를 확보합니다.</span>
+          </li>
+          <li>
+            <strong data-lang="en">Microcompaction</strong><strong data-lang="ko">마이크로컴팩션</strong>
+            — <span data-lang="en">Truncates old tool results to short placeholders <em>before</em> full compaction is needed, extending session lifetime.</span><span data-lang="ko">전체 컴팩션이 필요하기 <em>전에</em> 오래된 도구 결과를 짧은 플레이스홀더로 자르고, 세션 수명을 연장합니다.</span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Compaction -->
+      <section class="doc-section" id="compaction">
+        <h2>
+          <span data-lang="en">How Compaction Works</span>
+          <span data-lang="ko">컴팩션 작동 방식</span>
+        </h2>
+        <p data-lang="en">
+          Phase-aware custom compaction takes over during active workflows. When the context window fills up, instead of using the default summarizer, ROACH PI injects a specialized compaction prompt that is tailored to the current workflow phase.
+        </p>
+        <p data-lang="ko">
+          단계 인식 커스텀 컴팩션이 활성 워크플로 중에 작동합니다. 컨텍스트 윈도우가 꽉 차면 기본 요약기를 사용하는 대신, ROACH PI는 현재 워크플로 단계에 맞춤화된 특수 컴팩션 프롬프트를 주입합니다.
+        </p>
+        <p data-lang="en">
+          The prompt starts with a critical directive that prevents the model from making tool calls during compaction:
+        </p>
+        <p data-lang="ko">
+          프롬프트는 컴팩션 중 모델이 도구를 호출하지 못하게 하는 중요 지시문으로 시작합니다:
+        </p>
+        <div class="doc-code">
+CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.
+
+- Do NOT use any tool. Tool calls will be REJECTED and will waste your only turn.
+- Your entire response must be plain text: an &lt;analysis&gt; block followed by a &lt;summary&gt; block.
+        </div>
+        <p data-lang="en">
+          The model is required to produce two XML blocks in its response:
+        </p>
+        <p data-lang="ko">
+          모델은 응답에 두 개의 XML 블록을 생성해야 합니다:
+        </p>
+        <ul>
+          <li><code>&lt;analysis&gt;</code> — <span data-lang="en">Chronological thought process analyzing the conversation</span><span data-lang="ko">대화를 분석하는 순차적 사고 과정</span></li>
+          <li><code>&lt;summary&gt;</code> — <span data-lang="en">The structured summary in the prescribed 9-section format</span><span data-lang="ko">규정된 9개 섹션 형식의 구조화된 요약</span></li>
+        </ul>
+        <p data-lang="en">
+          After compaction, the <code>&lt;analysis&gt;</code> block is stripped and only the formatted summary is retained in context.
+        </p>
+        <p data-lang="ko">
+          컴팩션 후 <code>&lt;analysis&gt;</code> 블록은 제거되고 형식화된 요약만 컨텍스트에 유지됩니다.
+        </p>
+      </section>
+
+      <!-- Summary Format -->
+      <section class="doc-section" id="summary-format">
+        <h2>
+          <span data-lang="en">Summary Format</span>
+          <span data-lang="ko">요약 형식</span>
+        </h2>
+        <p data-lang="en">
+          Every compaction summary follows this nine-section structure. The model is given an explicit example template to follow.
+        </p>
+        <p data-lang="ko">
+          모든 컴팩션 요약은 이 9개 섹션 구조를 따릅니다. 모델은 명시적인 예제 템플릿을 제공받습니다.
+        </p>
+        <div class="doc-code">
+<span class="comment">1. Primary Request and Intent</span>
+   Capture all of the user's explicit requests and intents in detail.
+
+<span class="comment">2. Key Technical Concepts</span>
+   - [Concept 1]
+   - [Concept 2]
+
+<span class="comment">3. Files and Code Sections</span>
+   - [File Name 1]
+     - [Summary of why this file is important]
+     - [Important Code Snippet]
+
+<span class="comment">4. Errors and Fixes</span>
+    - [Error description]:
+      - [How you fixed it]
+
+<span class="comment">5. Problem Solving</span>
+   [Description]
+
+<span class="comment">6. All User Messages</span>
+    - [Detailed non tool use user message]
+
+<span class="comment">7. Pending Tasks</span>
+   - [Task 1]
+
+<span class="comment">8. Current Work</span>
+   [Precise description of current work]
+
+<span class="comment">9. Optional Next Step</span>
+   [Optional next step to take]
+        </div>
+      </section>
+
+      <!-- Workflow Phases -->
+      <section class="doc-section" id="workflow-phases">
+        <h2>
+          <span data-lang="en">Workflow Phases</span>
+          <span data-lang="ko">워크플로 단계</span>
+        </h2>
+        <p data-lang="en">
+          Compaction is phase-aware. When an active workflow is running, the compaction prompt is augmented with phase-specific instructions that tell the model what to preserve.
+        </p>
+        <p data-lang="ko">
+          컴팩션은 단계를 인식합니다. 활성 워크플로가 실행 중일 때, 컴팩션 프롬프트는 모델이 보존해야 할 내용을 알려주는 단계별 지시문으로 보강됩니다.
+        </p>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Phase</span><span data-lang="ko">단계</span></th>
+              <th><span data-lang="en">When</span><span data-lang="ko">시점</span></th>
+              <th><span data-lang="en">Survives Compaction</span><span data-lang="ko">컴팩션 후 유지</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>idle</code></td>
+              <td><span data-lang="en">Default</span><span data-lang="ko">기본</span></td>
+              <td><span data-lang="en">Yes (no special handling)</span><span data-lang="ko">예 (특별한 처리 없음)</span></td>
+            </tr>
+            <tr>
+              <td><code>clarifying</code></td>
+              <td><span data-lang="en">During <code>/clarify</code></span><span data-lang="ko"><code>/clarify</code> 중</span></td>
+              <td><span data-lang="en">Yes (phase preserved)</span><span data-lang="ko">예 (단계 유지)</span></td>
+            </tr>
+            <tr>
+              <td><code>planning</code></td>
+              <td><span data-lang="en">During <code>/plan</code></span><span data-lang="ko"><code>/plan</code> 중</span></td>
+              <td><span data-lang="en">Yes (phase + goal preserved)</span><span data-lang="ko">예 (단계 + 목표 유지)</span></td>
+            </tr>
+            <tr>
+              <td><code>ultraplanning</code></td>
+              <td><span data-lang="en">During <code>/ultraplan</code></span><span data-lang="ko"><code>/ultraplan</code> 중</span></td>
+              <td><span data-lang="en">Yes (phase preserved)</span><span data-lang="ko">예 (단계 유지)</span></td>
+            </tr>
+            <tr>
+              <td><code>reviewing</code></td>
+              <td><span data-lang="en">During <code>/review</code></span><span data-lang="ko"><code>/review</code> 중</span></td>
+              <td><span data-lang="en">Yes (phase preserved)</span><span data-lang="ko">예 (단계 유지)</span></td>
+            </tr>
+            <tr>
+              <td><code>ultrareviewing</code></td>
+              <td><span data-lang="en">During <code>/ultrareview</code></span><span data-lang="ko"><code>/ultrareview</code> 중</span></td>
+              <td><span data-lang="en">Yes (phase preserved)</span><span data-lang="ko">예 (단계 유지)</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p data-lang="en">
+          Each non-idle phase injects additional instructions into the compaction prompt, emphasizing what the model must preserve. For example, during <code>planning</code>, the prompt requires the summary to capture task progress, implementation decisions, and the current task state.
+        </p>
+        <p data-lang="ko">
+          각 비유휴(non-idle) 단계는 컴팩션 프롬프트에 추가 지시문을 주입하여 모델이 보존해야 할 내용을 강조합니다. 예를 들어, <code>planning</code> 중에는 프롬프트가 요약에 작업 진행 상황, 구현 결정, 현재 작업 상태를 포함하도록 요구합니다.
+        </p>
+      </section>
+
+      <!-- Microcompaction -->
+      <section class="doc-section" id="microcompaction">
+        <h2>
+          <span data-lang="en">Microcompaction</span>
+          <span data-lang="ko">마이크로컴팩션</span>
+        </h2>
+        <p data-lang="en">
+          Microcompaction is a lightweight pre-compaction pass that replaces old tool results with short placeholders. This extends session lifetime by reducing token usage <em>before</em> a full compaction is triggered.
+        </p>
+        <p data-lang="ko">
+          마이크로컴팩션은 오래된 도구 결과를 짧은 플레이스홀더로 교체하는 경량 사전 컴팩션 패스입니다. 전체 컴팩션이 트리거되기 <em>전에</em> 토큰 사용량을 줄여 세션 수명을 연장합니다.
+        </p>
+        <p data-lang="en">A message is eligible for microcompaction when <strong>all</strong> of these conditions are met:</p>
+        <p data-lang="ko">메시지는 <strong>다음 모든</strong> 조건이 충족될 때 마이크로컴팩션 대상이 됩니다:</p>
+        <ul>
+          <li><code>role === "toolResult"</code></li>
+          <li><code>isError !== true</code> <span data-lang="en">(error results are never compacted)</span><span data-lang="ko">(오류 결과는 절대 컴팩션되지 않음)</span></li>
+          <li><code>toolName</code> <span data-lang="en">is in</span><span data-lang="ko">이</span> <code>PI_TOOL_NAME_SET</code> <span data-lang="en">(known pi tools only)</span><span data-lang="ko">(알려진 pi 도구만)</span></li>
+          <li><span data-lang="en">Message age</span><span data-lang="ko">메시지 나이</span> &gt;= <code>MICROCOMPACT_AGE_MS</code> <span data-lang="en">(1 hour)</span><span data-lang="ko">(1시간)</span></li>
+        </ul>
+        <p data-lang="en">
+          When compacted, the tool result content is replaced with:
+        </p>
+        <p data-lang="ko">
+          컴팩션되면 도구 결과 콘텐츠가 다음으로 교체됩니다:
+        </p>
+        <div class="doc-code">[Compacted] &lt;toolName&gt; result</div>
+        <p data-lang="en">
+          Microcompaction is <strong>opt-in</strong>. It must be explicitly enabled via environment variable.
+        </p>
+        <p data-lang="ko">
+          마이크로컴팩션은 <strong>옵트인</strong>입니다. 환경 변수를 통해 명시적으로 활성화해야 합니다.
+        </p>
+      </section>
+
+      <!-- Configuration -->
+      <section class="doc-section" id="configuration">
+        <h2>
+          <span data-lang="en">Configuration</span><span data-lang="ko">설정</span>
+        </h2>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Env Var</span><span data-lang="ko">환경 변수</span></th>
+              <th><span data-lang="en">Default</span><span data-lang="ko">기본값</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>PI_AGENTIC_MICROCOMPACTION</code></td>
+              <td><span data-lang="en">(unset)</span><span data-lang="ko">(미설정)</span></td>
+              <td><span data-lang="en">Set to <code>1</code> to enable microcompaction</span><span data-lang="ko"><code>1</code>로 설정 시 마이크로컴팩션 활성화</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Plan Execution -->
+      <section class="doc-section" id="plan-execution">
+        <h2>
+          <span data-lang="en">Plan Execution Interaction</span><span data-lang="ko">계획 실행과의 상호작용</span>
+        </h2>
+        <p data-lang="en">
+          During plan execution (<code>plan-compliance</code>, <code>plan-worker</code>, <code>plan-validator</code>), the workflow phase and goal document are critical for continuity. If a compaction occurs mid-execution:
+        </p>
+        <p data-lang="ko">
+          계획 실행 중(<code>plan-compliance</code>, <code>plan-worker</code>, <code>plan-validator</code>), 워크플로 단계와 목표 문서는 연속성에 중요합니다. 실행 중 컴팩션이 발생하면:
+        </p>
+        <ul>
+          <li>
+            <span data-lang="en">The current workflow phase is stored in compaction metadata and restored after the summary is generated.</span>
+            <span data-lang="ko">현재 워크플로 단계가 컴팩션 메타데이터에 저장되고, 요약 생성 후 복원됩니다.</span>
+          </li>
+          <li>
+            <span data-lang="en">The goal document (if present) is referenced in the compaction prompt so the model anchors the user's intent.</span>
+            <span data-lang="ko">목표 문서(있는 경우)가 컴팩션 프롬프트에 참조되어 모델이 사용자의 의도를 고정합니다.</span>
+          </li>
+          <li>
+            <span data-lang="en">Phase-specific instructions ensure that task progress, implementation decisions, and current task state survive the compaction.</span>
+            <span data-lang="ko">단계별 지시문이 작업 진행 상황, 구현 결정, 현재 작업 상태가 컴팩션 후에도 유지되도록 보장합니다.</span>
+          </li>
+        </ul>
+        <p data-lang="en">
+          This means a long-running plan execution will not lose track of its goal or phase even if multiple compactions occur.
+        </p>
+        <p data-lang="ko">
+          즉, 긴 계획 실행 중 여러 컴팩션이 발생해도 목표나 단계를 잃지 않습니다.
+        </p>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/docs.css
+++ b/docs/features/docs.css
@@ -1,0 +1,235 @@
+/* ============================================
+   ROACH PI — Documentation Page Styles
+   Extends ../style.css design tokens
+   ============================================ */
+
+/* --- Doc Layout --- */
+.doc-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.doc-prose {
+  max-width: 780px;
+  line-height: 1.8;
+  font-size: 1rem;
+}
+
+.doc-prose p {
+  margin-bottom: 1.25rem;
+}
+
+/* --- Sidebar Nav --- */
+.doc-sidebar {
+  position: sticky;
+  top: 5rem;
+  float: left;
+  width: 220px;
+  margin-right: 2rem;
+  padding: 1rem 0;
+}
+
+.doc-sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+
+.doc-sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.doc-sidebar a {
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  border-bottom: none;
+  display: block;
+  padding: 0.25rem 0.5rem;
+  border-left: 3px solid transparent;
+  transition: border-color 0.1s, background 0.1s;
+}
+
+.doc-sidebar a:hover,
+.doc-sidebar a.active {
+  border-left-color: var(--blue);
+  background: var(--gray-light);
+}
+
+/* --- Doc Content with Sidebar --- */
+.doc-with-sidebar {
+  margin-left: 240px;
+}
+
+/* --- Section Headers in Docs --- */
+.doc-section {
+  padding: 2.5rem 0;
+  border-bottom: 2px solid var(--black);
+}
+
+.doc-section:last-of-type {
+  border-bottom: none;
+}
+
+.doc-section h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+  border-bottom: none;
+}
+
+.doc-section h3 {
+  font-size: 1.2rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 900;
+}
+
+.doc-section h4 {
+  font-size: 1rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  font-weight: 700;
+  text-transform: none;
+}
+
+/* --- Configuration Table --- */
+.doc-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+}
+
+.doc-table th,
+.doc-table td {
+  border: 3px solid var(--black);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-table th {
+  background: var(--black);
+  color: var(--white);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+
+.doc-table td code {
+  background: var(--gray-light);
+  border: 2px solid var(--black);
+  padding: 0.1rem 0.3rem;
+  font-size: 0.85em;
+}
+
+/* --- Code Example Blocks in Docs --- */
+.doc-code {
+  background: var(--black);
+  color: var(--white);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  border: var(--border);
+  box-shadow: var(--shadow-sm);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 1rem 0;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.doc-code .comment {
+  color: #888;
+}
+
+.doc-code .highlight {
+  color: var(--blue);
+}
+
+/* --- Callout Boxes --- */
+.doc-callout {
+  border: var(--border);
+  box-shadow: var(--shadow-sm);
+  padding: 1rem 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.doc-callout-info {
+  border-color: var(--blue);
+  box-shadow: 4px 4px 0 var(--blue);
+}
+
+.doc-callout-warn {
+  border-color: #CC8800;
+  box-shadow: 4px 4px 0 #CC8800;
+}
+
+.doc-callout-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+/* --- Sub-feature Grid (for power-tools page) --- */
+.doc-subsection {
+  padding: 2rem 0;
+  border-bottom: 2px dashed var(--black);
+}
+
+.doc-subsection:last-of-type {
+  border-bottom: none;
+}
+
+.doc-subsection h3 {
+  font-size: 1.3rem;
+}
+
+/* --- Responsive Doc Overrides --- */
+@media (max-width: 768px) {
+  .doc-sidebar {
+    position: static;
+    float: none;
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 1.5rem;
+    border-bottom: 3px solid var(--black);
+    padding-bottom: 1rem;
+  }
+
+  .doc-with-sidebar {
+    margin-left: 0;
+  }
+
+  .doc-table {
+    font-size: 0.8rem;
+  }
+
+  .doc-table th,
+  .doc-table td {
+    padding: 0.35rem 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .doc-container {
+    padding: 1rem;
+  }
+}
+
+/* --- Print --- */
+@media print {
+  .doc-sidebar {
+    display: none;
+  }
+
+  .doc-with-sidebar {
+    margin-left: 0;
+  }
+
+  .doc-callout,
+  .doc-table th,
+  .doc-table td {
+    box-shadow: none;
+  }
+}

--- a/docs/features/power-tools.html
+++ b/docs/features/power-tools.html
@@ -1,0 +1,649 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ROACH PI — Power Tools</title>
+  <meta name="description" content="Developer deep-dive into ROACH PI power tools: WebFetch, Editor Stash, Artifacts, Lore Commits, Welcome Banner, and Plan Progress.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html" class="active"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Doc Container with Sidebar -->
+  <div class="doc-container">
+
+    <!-- Sidebar -->
+    <div class="doc-sidebar">
+      <ul>
+        <li><a href="#webfetch">WebFetch</a></li>
+        <li><a href="#editor-stash">Editor Stash</a></li>
+        <li><a href="#artifacts">Artifacts</a></li>
+        <li><a href="#lore-commits">Lore Commits</a></li>
+        <li><a href="#welcome-banner">Welcome Banner</a></li>
+        <li><a href="#plan-progress">Plan Progress</a></li>
+      </ul>
+    </div>
+
+    <!-- Main Content -->
+    <div class="doc-with-sidebar doc-prose">
+
+      <h1>
+        <span data-lang="en">Power Tools</span>
+        <span data-lang="ko">파워 툴즈</span>
+      </h1>
+      <p>
+        <span data-lang="en">Six focused features that extend the pi agent's capabilities — URL fetching, editor state management, artifact persistence, structured commit metadata, branded startup, and real-time plan tracking.</span>
+        <span data-lang="ko">pi 에이전트의 기능을 확장하는 6개의 집중 기능 — URL 가져오기, 에디터 상태 관리, 아티팩트 지속성, 구조화된 커밋 메타데이터, 브랜디드 시작 화면, 실시간 계획 추적.</span>
+      </p>
+
+      <!-- ======================== WebFetch ======================== -->
+      <div class="doc-subsection" id="webfetch">
+        <h2>
+          <span class="icon">●</span> WebFetch
+        </h2>
+
+        <p>
+          <span data-lang="en">URL → Markdown conversion tool for agents. Fetches any URL, converts HTML to clean Markdown using Mozilla Readability + Turndown, and caches results for fast repeated access.</span>
+          <span data-lang="ko">에이전트를 위한 URL → Markdown 변환 도구. 모든 URL을 가져와 Mozilla Readability + Turndown으로 HTML을 깔끔한 Markdown으로 변환하고, 빠른 반복 접근을 위해 결과를 캐시합니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Tool Parameters</span>
+          <span data-lang="ko">도구 파라미터</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Parameter</span><span data-lang="ko">파라미터</span></th>
+              <th><span data-lang="en">Type</span><span data-lang="ko">타입</span></th>
+              <th><span data-lang="en">Required</span><span data-lang="ko">필수</span></th>
+              <th><span data-lang="en">Default</span><span data-lang="ko">기본값</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>url</code></td>
+              <td>string</td>
+              <td><span data-lang="en">Yes</span><span data-lang="ko">예</span></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>raw</code></td>
+              <td>boolean</td>
+              <td><span data-lang="en">No</span><span data-lang="ko">아니오</span></td>
+              <td><code>false</code></td>
+            </tr>
+            <tr>
+              <td><code>includeScripts</code></td>
+              <td>boolean</td>
+              <td><span data-lang="en">No</span><span data-lang="ko">아니오</span></td>
+              <td><code>false</code></td>
+            </tr>
+            <tr>
+              <td><code>maxLength</code></td>
+              <td>number</td>
+              <td><span data-lang="en">No</span><span data-lang="ko">아니오</span></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Cache</span>
+          <span data-lang="ko">캐시</span>
+        </h3>
+        <p>
+          <span data-lang="en">In-memory LRU cache. <strong>100 entries</strong> max, <strong>15-minute TTL</strong>. Cache key is derived from <code>JSON.stringify({url, mode, scripts})</code> where <code>mode</code> is <code>"full"</code> (default) or <code>"full"</code> when <code>raw</code> is true.</span>
+          <span data-lang="ko">인메모리 LRU 캐시. 최대 <strong>100개 항목</strong>, <strong>15분 TTL</strong>. 캐시 키는 <code>JSON.stringify({url, mode, scripts})</code>에서 파생됩니다. 여기서 <code>mode</code>는 기본값 <code>"auto"</code> 또는 <code>raw</code>가 true일 때 <code>"full"</code>입니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Limits</span>
+          <span data-lang="ko">제한</span>
+        </h3>
+        <ul>
+          <li>
+            <code>MAX_CONTENT_SIZE</code> = <strong>10 MB</strong>
+            — <span data-lang="en">checked via <code>content-length</code> header and actual byte count</span>
+            <span data-lang="ko"><code>content-length</code> 헤더와 실제 바이트 수로 확인</span>
+          </li>
+          <li>
+            <code>FETCH_TIMEOUT_MS</code> = <strong>30 s</strong>
+            — <span data-lang="en">hard abort via <code>AbortController</code></span>
+            <span data-lang="ko"><code>AbortController</code>를 통한 강제 중단</span>
+          </li>
+        </ul>
+
+        <h3>
+          <span data-lang="en">User Agent</span>
+          <span data-lang="ko">사용자 에이전트</span>
+        </h3>
+        <div class="doc-code">Mozilla/5.0 (compatible; WebFetchTool/1.0)</div>
+
+        <h3>
+          <span data-lang="en">Extraction Modes</span>
+          <span data-lang="ko">추출 모드</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Mode</span><span data-lang="ko">모드</span></th>
+              <th><span data-lang="en">Trigger</span><span data-lang="ko">트리거</span></th>
+              <th><span data-lang="en">Behavior</span><span data-lang="ko">동작</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>full</strong></td>
+              <td><code>raw: false</code> (default)</td>
+              <td><span data-lang="en">Readable content — Mozilla Readability + Turndown + GFM</span><span data-lang="ko">읽을 수 있는 콘텐츠 — Mozilla Readability + Turndown + GFM</span></td>
+            </tr>
+            <tr>
+              <td><strong>raw</strong></td>
+              <td><code>raw: true</code></td>
+              <td><span data-lang="en">Full HTML converted to Markdown via Turndown (no Readability filter)</span><span data-lang="ko">전체 HTML을 Turndown으로 Markdown 변환 (Readability 필터 없음)</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Truncation</span>
+          <span data-lang="ko">자르기</span>
+        </h3>
+        <p>
+          <span data-lang="en">When <code>maxLength</code> is set and content exceeds it, the returned copy is sliced and suffixed with:</span>
+          <span data-lang="ko"><code>maxLength</code>가 설정되고 콘텐츠가 초과하면 반환된 사본은 잘리고 다음 접미사가 붙습니다:</span>
+        </p>
+        <div class="doc-code">... (truncated)</div>
+        <p>
+          <span data-lang="en">The original content stored in cache is <strong>not</strong> truncated.</span>
+          <span data-lang="ko">캐시에 저장된 원본 콘텐츠는 자르지 <strong>않습니다</strong>.</span>
+        </p>
+      </div>
+
+      <!-- ======================== Editor Stash ======================== -->
+      <div class="doc-subsection" id="editor-stash">
+        <h2>
+          <span class="icon">■</span> Editor Stash
+        </h2>
+
+        <p>
+          <span data-lang="en">Session-scoped single-slot stash for editor text. Save a snippet, clear the editor, restore it later — all without leaving the editor.</span>
+          <span data-lang="ko">에디터 텍스트를 위한 세션 범위의 단일 슬롯 스태시. 스니펫을 저장하고, 에디터를 지우고, 나중에 복원 — 에디터를 떠나지 않고 모두 가능합니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Slash Commands</span>
+          <span data-lang="ko">슬래시 명령</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Command</span><span data-lang="ko">명령</span></th>
+              <th><span data-lang="en">Action</span><span data-lang="ko">동작</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>/stash-save</code></td>
+              <td><span data-lang="en">Copy current editor text into the stash slot</span><span data-lang="ko">현재 에디터 텍스트를 스태시 슬롯에 복사</span></td>
+            </tr>
+            <tr>
+              <td><code>/stash-clear</code></td>
+              <td><span data-lang="en">Clear the stash slot contents</span><span data-lang="ko">스태시 슬롯 내용 지우기</span></td>
+            </tr>
+            <tr>
+              <td><code>/stash-restore</code></td>
+              <td><span data-lang="en">Replace editor text with stashed content</span><span data-lang="ko">에디터 텍스트를 스태시된 내용으로 교체</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Keyboard Shortcuts</span>
+          <span data-lang="ko">키보드 단축키</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Shortcut</span><span data-lang="ko">단축키</span></th>
+              <th><span data-lang="en">Byte</span><span data-lang="ko">바이트</span></th>
+              <th><span data-lang="en">Action</span><span data-lang="ko">동작</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>Ctrl+S</code></td>
+              <td><code>\x13</code></td>
+              <td><span data-lang="en">Save to stash</span><span data-lang="ko">스태시에 저장</span></td>
+            </tr>
+            <tr>
+              <td><code>Ctrl+R</code></td>
+              <td><code>\x12</code></td>
+              <td><span data-lang="en">Restore from stash</span><span data-lang="ko">스태시에서 복원</span></td>
+            </tr>
+            <tr>
+              <td><code>Ctrl+K</code></td>
+              <td><code>\x0b</code></td>
+              <td><span data-lang="en">Clear stash</span><span data-lang="ko">스태시 지우기</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Status Indicator</span>
+          <span data-lang="ko">상태 표시기</span>
+        </h3>
+        <p>
+          <span data-lang="en">An editor decorator appends a status line at the bottom of the editor showing stash size and shortcut hints.</span>
+          <span data-lang="ko">에디터 데코레이터가 에디터 하단에 스태시 크기와 단축키 힌트를 보여주는 상태 줄을 추가합니다.</span>
+        </p>
+      </div>
+
+      <!-- ======================== Artifacts ======================== -->
+      <div class="doc-subsection" id="artifacts">
+        <h2>
+          <span class="icon">★</span> Artifacts
+        </h2>
+
+        <p>
+          <span data-lang="en">Structured per-run artifact directories for subagent outputs. Each subagent invocation gets an isolated directory tree for its output, progress, and declared read files.</span>
+          <span data-lang="ko">서브에이전트 출력을 위한 구조화된 실행별 아티팩트 디렉토리. 각 서브에이전트 호출은 출력, 진행, 선언된 읽기 파일을 위한 격리된 디렉토리 트리를 가져옵니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Directory Layout</span>
+          <span data-lang="ko">디렉토리 레이아웃</span>
+        </h3>
+        <div class="doc-code">&lt;base&gt;/&lt;rootRunId&gt;/subagents/&lt;agentName&gt;-&lt;runId&gt;/</div>
+
+        <h3>
+          <span data-lang="en">Base Directory</span>
+          <span data-lang="ko">기본 디렉토리</span>
+        </h3>
+        <div class="doc-code">PI_SUBAGENT_ARTIFACT_ROOT || cwd/.pi/agent/runs</div>
+
+        <h3>
+          <span data-lang="en"><code>run.json</code> Schema</span>
+          <span data-lang="ko"><code>run.json</code> 스키마</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th><span data-lang="en">Type</span><span data-lang="ko">타입</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><code>agentName</code></td><td>string</td><td><span data-lang="en">Subagent identifier</span><span data-lang="ko">서브에이전트 식별자</span></td></tr>
+            <tr><td><code>runId</code></td><td>string</td><td><span data-lang="en">Unique run identifier</span><span data-lang="ko">고유 실행 식별자</span></td></tr>
+            <tr><td><code>rootRunId</code></td><td>string</td><td><span data-lang="en">Parent session run identifier</span><span data-lang="ko">부모 세션 실행 식별자</span></td></tr>
+            <tr><td><code>cwd</code></td><td>string</td><td><span data-lang="en">Working directory at creation time</span><span data-lang="ko">생성 시점의 작업 디렉토리</span></td></tr>
+            <tr><td><code>outputFile</code></td><td>string?</td><td><span data-lang="en">Resolved output path</span><span data-lang="ko">해결된 출력 경로</span></td></tr>
+            <tr><td><code>progressFile</code></td><td>string?</td><td><span data-lang="en">Resolved progress path</span><span data-lang="ko">해결된 진행 경로</span></td></tr>
+            <tr><td><code>readFiles</code></td><td>string[]</td><td><span data-lang="en">Declared read file paths</span><span data-lang="ko">선언된 읽기 파일 경로</span></td></tr>
+            <tr><td><code>createdAt</code></td><td>string</td><td><span data-lang="en">ISO 8601 timestamp</span><span data-lang="ko">ISO 8601 타임스탬프</span></td></tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Path Guards</span>
+          <span data-lang="ko">경로 가드</span>
+        </h3>
+        <p>
+          <span data-lang="en">All user-supplied paths are validated before resolution:</span>
+          <span data-lang="ko">모든 사용자 제공 경로는 해결 전에 검증됩니다:</span>
+        </p>
+        <ul>
+          <li>
+            <span data-lang="en">Rejects <strong>absolute paths</strong> (<code>/etc/passwd</code>)</span>
+            <span data-lang="ko"><strong>절대 경로</strong> 거부 (<code>/etc/passwd</code>)</span>
+          </li>
+          <li>
+            <span data-lang="en">Rejects <strong>home shortcuts</strong> (<code>~</code>, <code>~/...</code>)</span>
+            <span data-lang="ko"><strong>홈 단축키</strong> 거부 (<code>~</code>, <code>~/...</code>)</span>
+          </li>
+          <li>
+            <span data-lang="en">Rejects paths that <strong>escape the run directory</strong> (<code>../../etc</code>)</span>
+            <span data-lang="ko">런 디렉토리를 <strong>벗어나는 경로</strong> 거부 (<code>../../etc</code>)</span>
+          </li>
+          <li>
+            <span data-lang="en">Rejects paths that <strong>escape the workspace</strong> (for declared reads)</span>
+            <span data-lang="ko"><strong>워크스페이스를 벗어나는 경로</strong> 거부 (선언된 읽기용)</span>
+          </li>
+        </ul>
+
+        <h3>
+          <span data-lang="en">Segment Sanitization</span>
+          <span data-lang="ko">세그먼트 정화</span>
+        </h3>
+        <p>
+          <span data-lang="en"><code>sanitizeSegment()</code> replaces non-alphanumeric characters (except <code>.</code>, <code>_</code>, <code>-</code>) with <code>-</code>, then strips leading and trailing dashes. Falls back to <code>"run"</code> if the result is empty.</span>
+          <span data-lang="ko"><code>sanitizeSegment()</code>은 영숫자가 아닌 문자(<code>.</code>, <code>_</code>, <code>-</code> 제외)를 <code>-</code>로 교체하고, 선행 및 후행 대시를 제거합니다. 결과가 비어있으면 <code>"run"</code>을 사용합니다.</span>
+        </p>
+      </div>
+
+      <!-- ======================== Lore Commits ======================== -->
+      <div class="doc-subsection" id="lore-commits">
+        <h2>
+          <span class="icon">◆</span> Lore Commits
+        </h2>
+
+        <p>
+          <span data-lang="en">Structured git trailers that embed decision context directly into commit messages. Future agents and developers can query project knowledge via <code>git log</code>.</span>
+          <span data-lang="ko">커밋 메시지에 결정 컨텍스트를 직접 삽입하는 구조화된 git 트레일러. 미래의 에이전트와 개발자가 <code>git log</code>를 통해 프로젝트 지식을 조회할 수 있습니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Trailer Vocabulary</span>
+          <span data-lang="ko">트레일러 어휘</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Trailer</span><span data-lang="ko">트레일러</span></th>
+              <th><span data-lang="en">Format</span><span data-lang="ko">형식</span></th>
+              <th><span data-lang="en">Example</span><span data-lang="ko">예시</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>Constraint:</code></td>
+              <td><span data-lang="en">Free text</span><span data-lang="ko">자유 텍스트</span></td>
+              <td><code>Constraint: must support Node 18+</code></td>
+            </tr>
+            <tr>
+              <td><code>Rejected:</code></td>
+              <td><code>&lt;alt&gt; | &lt;reason&gt;</code></td>
+              <td><code>Rejected: SQLite | adds native dependency</code></td>
+            </tr>
+            <tr>
+              <td><code>Confidence:</code></td>
+              <td><span data-lang="en">high / medium / low</span><span data-lang="ko">high / medium / low</span></td>
+              <td><code>Confidence: high</code></td>
+            </tr>
+            <tr>
+              <td><code>Scope-risk:</code></td>
+              <td><span data-lang="en">narrow / moderate / broad</span><span data-lang="ko">narrow / moderate / broad</span></td>
+              <td><code>Scope-risk: narrow</code></td>
+            </tr>
+            <tr>
+              <td><code>Reversibility:</code></td>
+              <td><span data-lang="en">clean / moderate / difficult</span><span data-lang="ko">clean / moderate / difficult</span></td>
+              <td><code>Reversibility: clean</code></td>
+            </tr>
+            <tr>
+              <td><code>Directive:</code></td>
+              <td><span data-lang="en">Free text</span><span data-lang="ko">자유 텍스트</span></td>
+              <td><code>Directive: keep backwards compat</code></td>
+            </tr>
+            <tr>
+              <td><code>Tested:</code></td>
+              <td><span data-lang="en">Free text</span><span data-lang="ko">자유 텍스트</span></td>
+              <td><code>Tested: manual verification on macOS</code></td>
+            </tr>
+            <tr>
+              <td><code>Not-tested:</code></td>
+              <td><span data-lang="en">Free text</span><span data-lang="ko">자유 텍스트</span></td>
+              <td><code>Not-tested: Windows path handling</code></td>
+            </tr>
+            <tr>
+              <td><code>Related:</code></td>
+              <td><span data-lang="en">Free text</span><span data-lang="ko">자유 텍스트</span></td>
+              <td><code>Related: #42</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Querying Lore</span>
+          <span data-lang="ko">Lore 조회</span>
+        </h3>
+        <p>
+          <span data-lang="en">Filter commits by any trailer key:</span>
+          <span data-lang="ko">모든 트레일러 키로 커밋 필터링:</span>
+        </p>
+        <div class="doc-code">git log --trailer=Constraint: -- path</div>
+
+        <h3>
+          <span data-lang="en">Setup</span>
+          <span data-lang="ko">설정</span>
+        </h3>
+        <p>
+          <span data-lang="en">The <code>lore-setup</code> skill writes Lore commit format rules to <code>AGENTS.md</code> or <code>CLAUDE.md</code> so all agents automatically use structured git trailers in commit messages.</span>
+          <span data-lang="ko"><code>lore-setup</code> 스킬이 <code>AGENTS.md</code> 또는 <code>CLAUDE.md</code>에 Lore 커밋 형식 규칙을 작성하여 모든 에이전트가 커밋 메시지에 자동으로 구조화된 git 트레일러를 사용하도록 합니다.</span>
+        </p>
+      </div>
+
+      <!-- ======================== Welcome Banner ======================== -->
+      <div class="doc-subsection" id="welcome-banner">
+        <h2>
+          <span class="icon">▶</span> Welcome Banner
+        </h2>
+
+        <p>
+          <span data-lang="en">ROACH PI branded header that replaces the generic pi startup listing. Shows the ASCII art logo and quick-start hints when the session begins.</span>
+          <span data-lang="ko">일반적인 pi 시작 목록을 대체하는 ROACH PI 브랜디드 헤더. 세션 시작 시 ASCII 아트 로고와 빠른 시작 힌트를 표시합니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en"><code>/welcome</code> Command</span>
+          <span data-lang="ko"><code>/welcome</code> 명령</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Input</span><span data-lang="ko">입력</span></th>
+              <th><span data-lang="en">Effect</span><span data-lang="ko">효과</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>off</code>, <code>hide</code>, <code>dismiss</code></td>
+              <td><span data-lang="en">Hide the banner</span><span data-lang="ko">배너 숨기기</span></td>
+            </tr>
+            <tr>
+              <td><code>on</code>, <code>show</code>, <code>restore</code></td>
+              <td><span data-lang="en">Show the banner</span><span data-lang="ko">배너 표시</span></td>
+            </tr>
+            <tr>
+              <td>(bare) <code>/welcome</code></td>
+              <td><span data-lang="en">Toggle visibility</span><span data-lang="ko">가시성 토글</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Interaction with <code>/setup</code></span>
+          <span data-lang="ko"><code>/setup</code>과의 상호작용</span>
+        </h3>
+        <p>
+          <span data-lang="en"><code>/setup</code> sets <code>quietStartup: true</code> so the pi agent's generic startup listing is suppressed, making the ROACH PI banner the main startup surface.</span>
+          <span data-lang="ko"><code>/setup</code>이 <code>quietStartup: true</code>를 설정하여 pi 에이전트의 일반적인 시작 목록이 억제되고, ROACH PI 배너가 주 시작 화면이 됩니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Interaction with <code>/init</code></span>
+          <span data-lang="ko"><code>/init</code>과의 상호작용</span>
+        </h3>
+        <p>
+          <span data-lang="en"><code>/init</code> also configures banner visibility as part of the initial project setup flow.</span>
+          <span data-lang="ko"><code>/init</code>도 초기 프로젝트 설정 흐름의 일부로 배너 가시성을 구성합니다.</span>
+        </p>
+      </div>
+
+      <!-- ======================== Plan Progress ======================== -->
+      <div class="doc-subsection" id="plan-progress">
+        <h2>
+          <span class="icon">◐</span> Plan Progress & Milestone TUI
+        </h2>
+
+        <p>
+          <span data-lang="en">Real-time plan and milestone progress displayed in the TUI footer. Shows task completion, running state, and milestone lifecycle at a glance.</span>
+          <span data-lang="ko">TUI 푸터에 표시되는 실시간 계획 및 마일스톤 진행 상황. 작업 완료, 실행 상태, 마일스톤 수명 주기를 한눈에 보여줍니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Task Statuses</span>
+          <span data-lang="ko">작업 상태</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Status</span><span data-lang="ko">상태</span></th>
+              <th><span data-lang="en">Meaning</span><span data-lang="ko">의미</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><code>pending</code></td><td><span data-lang="en">Not yet started</span><span data-lang="ko">아직 시작 안 됨</span></td></tr>
+            <tr><td><code>running</code></td><td><span data-lang="en">Currently executing</span><span data-lang="ko">현재 실행 중</span></td></tr>
+            <tr><td><code>completed</code></td><td><span data-lang="en">Finished successfully</span><span data-lang="ko">성공적으로 완료</span></td></tr>
+            <tr><td><code>failed</code></td><td><span data-lang="en">Finished with error</span><span data-lang="ko">오류로 완료</span></td></tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Milestone Statuses</span>
+          <span data-lang="ko">마일스톤 상태</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Status</span><span data-lang="ko">상태</span></th>
+              <th><span data-lang="en">Meaning</span><span data-lang="ko">의미</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><code>pending</code></td><td><span data-lang="en">Waiting to start</span><span data-lang="ko">시작 대기 중</span></td></tr>
+            <tr><td><code>planning</code></td><td><span data-lang="en">Plan being drafted</span><span data-lang="ko">계획 작성 중</span></td></tr>
+            <tr><td><code>executing</code></td><td><span data-lang="en">Tasks running</span><span data-lang="ko">작업 실행 중</span></td></tr>
+            <tr><td><code>validating</code></td><td><span data-lang="en">Review underway</span><span data-lang="ko">리뷰 진행 중</span></td></tr>
+            <tr><td><code>completed</code></td><td><span data-lang="en">All tasks passed</span><span data-lang="ko">모든 작업 통과</span></td></tr>
+            <tr><td><code>failed</code></td><td><span data-lang="en">Validation failed</span><span data-lang="ko">검증 실패</span></td></tr>
+            <tr><td><code>skipped</code></td><td><span data-lang="en">Explicitly skipped</span><span data-lang="ko">명시적으로 건너뜀</span></td></tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en">Spinner</span>
+          <span data-lang="ko">스피너</span>
+        </h3>
+        <p>
+          <span data-lang="en">A <strong>400ms interval</strong> spinner (<code>PLAN_PROGRESS_SPINNER_MS</code>) runs only while tasks are in the <code>running</code> state. Frames cycle through <code>◐ ◓ ◑ ◒</code>.</span>
+          <span data-lang="ko">작업이 <code>running</code> 상태인 동안만 <strong>400ms 간격</strong> 스피너(<code>PLAN_PROGRESS_SPINNER_MS</code>)가 실행됩니다. 프레임은 <code>◐ ◓ ◑ ◒</code>을 순환합니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Milestone File Detection</span>
+          <span data-lang="ko">마일스톤 파일 감지</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">File Type</span><span data-lang="ko">파일 유형</span></th>
+              <th><span data-lang="en">Pattern</span><span data-lang="ko">패턴</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span data-lang="en">Milestone file</span><span data-lang="ko">마일스톤 파일</span></td>
+              <td><code>/(M\d+)-([^/\s]+)\.md$/i</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">State table</span><span data-lang="ko">상태 테이블</span></td>
+              <td><code>/state.md$/</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Todo</span><span data-lang="ko">할 일</span></td>
+              <td><code>/todo.md$/</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Completion</span><span data-lang="ko">완료</span></td>
+              <td><code>/completion.md$/</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>
+          <span data-lang="en"><code>/reset-phase</code> Command</span>
+          <span data-lang="ko"><code>/reset-phase</code> 명령</span>
+        </h3>
+        <p>
+          <span data-lang="en">Clears all plan and milestone state from the tracker, returning to a clean slate.</span>
+          <span data-lang="ko">트래커에서 모든 계획 및 마일스톤 상태를 지우고 깨끗한 상태로 돌아갑니다.</span>
+        </p>
+
+        <h3>
+          <span data-lang="en">Footer Integration</span>
+          <span data-lang="ko">푸터 통합</span>
+        </h3>
+        <p>
+          <span data-lang="en">The footer subscribes to <code>PlanProgressTracker</code> change notifications via <code>setOnChange()</code>. When progress changes, the footer calls <code>tui.requestRender(true)</code> to update the display. The spinner timer is started on demand and cleaned up in <code>dispose()</code>.</span>
+          <span data-lang="ko">푸터는 <code>setOnChange()</code>을 통해 <code>PlanProgressTracker</code> 변경 알림을 구독합니다. 진행 상황이 변경되면 푸터는 <code>tui.requestRender(true)</code>를 호출하여 표시를 업데이트합니다. 스피너 타이머는 필요할 때 시작되고 <code>dispose()</code>에서 정리됩니다.</span>
+        </p>
+      </div>
+
+    </div><!-- /doc-with-sidebar -->
+
+  </div><!-- /doc-container -->
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/sandboxed-bash.html
+++ b/docs/features/sandboxed-bash.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ROACH PI — Sandboxed Bash</title>
+  <meta name="description" content="Sandboxed bash execution with platform-specific isolation, policy engine, and approval flow for the ROACH PI pi coding agent extension.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html" class="active"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="doc-container">
+
+    <!-- Sidebar -->
+    <aside class="doc-sidebar">
+      <ul>
+        <li><a href="#overview">● <span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#how-it-works">▶ <span data-lang="en">How It Works</span><span data-lang="ko">작동 원리</span></a></li>
+        <li><a href="#platform-adapters">■ <span data-lang="en">Platform Adapters</span><span data-lang="ko">플랫폼 어댑터</span></a></li>
+        <li><a href="#linux">★ <span data-lang="en">Linux</span><span data-lang="ko">Linux</span></a></li>
+        <li><a href="#macos">◆ <span data-lang="en">macOS</span><span data-lang="ko">macOS</span></a></li>
+        <li><a href="#approval-flow">● <span data-lang="en">Approval Flow</span><span data-lang="ko">승인 흐름</span></a></li>
+        <li><a href="#sensitive-env">▶ <span data-lang="en">Sensitive Env</span><span data-lang="ko">민감한 환경 변수</span></a></li>
+        <li><a href="#configuration">■ <span data-lang="en">Configuration</span><span data-lang="ko">설정</span></a></li>
+        <li><a href="#edge-cases">★ <span data-lang="en">Edge Cases</span><span data-lang="ko">엣지 케이스</span></a></li>
+      </ul>
+    </aside>
+
+    <!-- Main Content -->
+    <div class="doc-with-sidebar">
+      <div class="doc-prose">
+
+        <!-- Overview -->
+        <section class="doc-section" id="overview">
+          <h2>
+            <span class="icon">●</span>
+            <span data-lang="en">Overview</span>
+            <span data-lang="ko">개요</span>
+          </h2>
+          <p data-lang="en">
+            Sandboxed Bash replaces the standard root-session <code>bash</code> tool with a sandboxed execution layer. Every shell command passes through a <strong>policy engine</strong> and a <strong>platform-specific isolation adapter</strong> before reaching the host. If no sandbox tool is available on the current platform, the system falls back to unsandboxed execution with explicit <strong>user approval</strong>.
+          </p>
+          <p data-lang="ko">
+            샌드박스 Bash는 표준 root-session <code>bash</code> 도구를 샌드박스 실행 레이어로 교체합니다. 모든 셸 명령은 호스트에 도달하기 전에 <strong>정책 엔진</strong>과 <strong>플랫폼별 격리 어댑터</strong>를 거칩니다. 현재 플랫폼에 샌드박스 도구가 없으면, 명시적인 <strong>사용자 승인</strong>과 함께 샌드박스 없는 실행으로 폴백합니다.
+          </p>
+        </section>
+
+        <!-- How It Works -->
+        <section class="doc-section" id="how-it-works">
+          <h2>
+            <span class="icon">▶</span>
+            <span data-lang="en">How It Works</span>
+            <span data-lang="ko">작동 원리</span>
+          </h2>
+          <p data-lang="en">
+            Root sessions register a tool labeled <strong>"bash (sandboxed)"</strong>. When the agent issues a bash command, the execution pipeline is:
+          </p>
+          <p data-lang="ko">
+            Root 세션은 <strong>"bash (sandboxed)"</strong>라는 레이블의 도구를 등록합니다. 에이전트가 bash 명령을 발행하면 실행 파이프라인은 다음과 같습니다:
+          </p>
+          <pre class="doc-code"><span data-lang="en">Command → Policy Engine → Platform Adapter (bwrap | sandbox-exec) → Execution</span><span data-lang="ko">명령 → 정책 엔진 → 플랫폼 어댑터 (bwrap | sandbox-exec) → 실행</span></pre>
+          <p data-lang="en">
+            Bash is launched as:
+          </p>
+          <p data-lang="ko">
+            Bash는 다음과 같이 실행됩니다:
+          </p>
+          <pre class="doc-code">bash -lc &lt;command&gt;</pre>
+          <p data-lang="en">
+            The policy engine evaluates platform capability, filesystem mode, and network mode to produce a sandbox decision. If the decision is <code>sandboxed</code>, the platform adapter wraps the command in the appropriate isolation mechanism. If the decision is <code>unsandboxed</code>, the approval flow determines whether execution is permitted.
+          </p>
+          <p data-lang="ko">
+            정책 엔진은 플랫폼 기능, 파일시스템 모드, 네트워크 모드를 평가하여 샌드박스 결정을 내립니다. 결정이 <code>sandboxed</code>이면 플랫폼 어댑터가 명령을 적절한 격리 메커니즘으로 감쌉니다. 결정이 <code>unsandboxed</code>이면 승인 흐름이 실행 허용 여부를 결정합니다.
+          </p>
+        </section>
+
+        <!-- Platform Adapters -->
+        <section class="doc-section" id="platform-adapters">
+          <h2>
+            <span class="icon">■</span>
+            <span data-lang="en">Platform Adapters</span>
+            <span data-lang="ko">플랫폼 어댑터</span>
+          </h2>
+          <p data-lang="en">
+            Each platform has a dedicated adapter that provides sandbox capability detection and launch construction:
+          </p>
+          <p data-lang="ko">
+            각 플랫폼에는 샌드박스 기능 감지 및 실행 구성을 제공하는 전용 어댑터가 있습니다:
+          </p>
+          <table class="doc-table">
+            <thead>
+              <tr>
+                <th><span data-lang="en">Platform</span><span data-lang="ko">플랫폼</span></th>
+                <th><span data-lang="en">Command</span><span data-lang="ko">명령</span></th>
+                <th><span data-lang="en">Mechanism</span><span data-lang="ko">메커니즘</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Linux</td>
+                <td><code>bwrap</code></td>
+                <td><span data-lang="en">bubblewrap namespace isolation</span><span data-lang="ko">bubblewrap 네임스페이스 격리</span></td>
+              </tr>
+              <tr>
+                <td>macOS</td>
+                <td><code>sandbox-exec</code></td>
+                <td><span data-lang="en">Apple sandbox profile</span><span data-lang="ko">Apple 샌드박스 프로필</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- Linux -->
+        <section class="doc-section" id="linux">
+          <h2>
+            <span class="icon">★</span>
+            <span data-lang="en">Linux (bwrap)</span>
+            <span data-lang="ko">Linux (bwrap)</span>
+          </h2>
+          <p data-lang="en">
+            The Linux adapter uses <strong>bubblewrap</strong> for namespace-level isolation. The full launch command:
+          </p>
+          <p data-lang="ko">
+            Linux 어댑터는 네임스페이스 수준 격리를 위해 <strong>bubblewrap</strong>을 사용합니다. 전체 실행 명령:
+          </p>
+          <pre class="doc-code">bwrap \
+  --die-with-parent \
+  --new-session \
+  --ro-bind / / \
+  --proc /proc \
+  --dev /dev \
+  --tmpfs /tmp \
+  --bind &lt;workspace&gt; &lt;workspace&gt; \
+  --chdir &lt;cwd&gt; \
+  [--unshare-net] \
+  -- &lt;command&gt;</pre>
+          <p data-lang="en">
+            <strong>Flags explained:</strong>
+          </p>
+          <p data-lang="ko">
+            <strong>플래그 설명:</strong>
+          </p>
+          <ul>
+            <li>
+              <code>--die-with-parent</code> —
+              <span data-lang="en">Kill the sandbox if the parent process dies.</span>
+              <span data-lang="ko">부모 프로세스가 종료되면 샌드박스를 종료합니다.</span>
+            </li>
+            <li>
+              <code>--new-session</code> —
+              <span data-lang="en">Create a new process session.</span>
+              <span data-lang="ko">새 프로세스 세션을 생성합니다.</span>
+            </li>
+            <li>
+              <code>--ro-bind / /</code> —
+              <span data-lang="en">Mount the root filesystem read-only.</span>
+              <span data-lang="ko">루트 파일시스템을 읽기 전용으로 마운트합니다.</span>
+            </li>
+            <li>
+              <code>--proc /proc</code> —
+              <span data-lang="en">Mount a new proc filesystem.</span>
+              <span data-lang="ko">새 proc 파일시스템을 마운트합니다.</span>
+            </li>
+            <li>
+              <code>--dev /dev</code> —
+              <span data-lang="en">Mount a minimal /dev.</span>
+              <span data-lang="ko">최소한의 /dev를 마운트합니다.</span>
+            </li>
+            <li>
+              <code>--tmpfs /tmp</code> —
+              <span data-lang="en">Mount a fresh tmpfs at /tmp.</span>
+              <span data-lang="ko">/tmp에 새 tmpfs를 마운트합니다.</span>
+            </li>
+            <li>
+              <code>--bind &lt;workspace&gt; &lt;workspace&gt;</code> —
+              <span data-lang="en">Bind-mount the workspace read-write.</span>
+              <span data-lang="ko">워크스페이스를 읽기-쓰기로 바인드 마운트합니다.</span>
+            </li>
+            <li>
+              <code>--chdir &lt;cwd&gt;</code> —
+              <span data-lang="en">Set working directory inside the sandbox.</span>
+              <span data-lang="ko">샌드박스 내 작업 디렉토리를 설정합니다.</span>
+            </li>
+            <li>
+              <code>--unshare-net</code> —
+              <span data-lang="en">Disable network access (when network mode is "off").</span>
+              <span data-lang="ko">네트워크 액세스 비활성화 (네트워크 모드가 "off"일 때).</span>
+            </li>
+          </ul>
+          <div class="doc-callout doc-callout-info">
+            <div class="doc-callout-title">
+              <span data-lang="en">Capability Check</span>
+              <span data-lang="ko">기능 확인</span>
+            </div>
+            <p data-lang="en">
+              The adapter runs <code>which bwrap</code> to detect availability. If bwrap is not installed, the system falls back to unsandboxed execution with approval.
+            </p>
+            <p data-lang="ko">
+              어댑터는 <code>which bwrap</code>를 실행하여 사용 가능 여부를 감지합니다. bwrap이 설치되어 있지 않으면 승인과 함께 샌드박스 없는 실행으로 폴백합니다.
+            </p>
+          </div>
+        </section>
+
+        <!-- macOS -->
+        <section class="doc-section" id="macos">
+          <h2>
+            <span class="icon">◆</span>
+            <span data-lang="en">macOS (sandbox-exec)</span>
+            <span data-lang="ko">macOS (sandbox-exec)</span>
+          </h2>
+          <p data-lang="en">
+            The macOS adapter uses Apple's <strong>sandbox-exec</strong> with a dynamically generated SBPL profile. The profile is written to a temporary file and cleaned up after execution:
+          </p>
+          <p data-lang="ko">
+            macOS 어댑터는 동적으로 생성된 SBPL 프로필과 함께 Apple의 <strong>sandbox-exec</strong>를 사용합니다. 프로필은 임시 파일에 기록되고 실행 후 정리됩니다:
+          </p>
+          <pre class="doc-code">(version 1)
+(deny default)
+(import "system.sb")
+(allow process*)
+(allow sysctl-read)
+(allow file-read*)
+(allow file-write*
+  (subpath "&lt;workspace&gt;")
+  (subpath "/tmp")
+  (subpath "&lt;tmpdir&gt;"))
+(allow network*) <span class="comment"># when network mode is "on"</span></pre>
+          <p data-lang="en">
+            <strong>Profile explained:</strong>
+          </p>
+          <p data-lang="ko">
+            <strong>프로필 설명:</strong>
+          </p>
+          <ul>
+            <li>
+              <code>(deny default)</code> —
+              <span data-lang="en">Deny all operations by default.</span>
+              <span data-lang="ko">기본적으로 모든 작업을 거부합니다.</span>
+            </li>
+            <li>
+              <code>(import "system.sb")</code> —
+              <span data-lang="en">Import macOS system sandbox defaults.</span>
+              <span data-lang="ko">macOS 시스템 샌드박스 기본값을 임포트합니다.</span>
+            </li>
+            <li>
+              <code>(allow process*)</code> —
+              <span data-lang="en">Allow process creation and signal operations.</span>
+              <span data-lang="ko">프로세스 생성 및 시그널 작업을 허용합니다.</span>
+            </li>
+            <li>
+              <code>(allow sysctl-read)</code> —
+              <span data-lang="en">Allow reading system information.</span>
+              <span data-lang="ko">시스템 정보 읽기를 허용합니다.</span>
+            </li>
+            <li>
+              <code>(allow file-read*)</code> —
+              <span data-lang="en">Allow reading any file.</span>
+              <span data-lang="ko">모든 파일 읽기를 허용합니다.</span>
+            </li>
+            <li>
+              <code>(allow file-write* ...)</code> —
+              <span data-lang="en">Restrict writes to workspace, /tmp, and the system tmpdir.</span>
+              <span data-lang="ko">쓰기를 워크스페이스, /tmp, 시스템 tmpdir로 제한합니다.</span>
+            </li>
+            <li>
+              <code>(allow network*)</code> —
+              <span data-lang="en">Enable network access (only when network mode is "on").</span>
+              <span data-lang="ko">네트워크 액세스 활성화 (네트워크 모드가 "on"일 때만).</span>
+            </li>
+          </ul>
+          <div class="doc-callout doc-callout-info">
+            <div class="doc-callout-title">
+              <span data-lang="en">Capability Check</span>
+              <span data-lang="ko">기능 확인</span>
+            </div>
+            <p data-lang="en">
+              The adapter runs <code>which sandbox-exec</code> to detect availability. If sandbox-exec is not available, the system falls back to unsandboxed execution with approval.
+            </p>
+            <p data-lang="ko">
+              어댑터는 <code>which sandbox-exec</code>를 실행하여 사용 가능 여부를 감지합니다. sandbox-exec을 사용할 수 없으면 승인과 함께 샌드박스 없는 실행으로 폴백합니다.
+            </p>
+          </div>
+        </section>
+
+        <!-- Approval Flow -->
+        <section class="doc-section" id="approval-flow">
+          <h2>
+            <span class="icon">●</span>
+            <span data-lang="en">Approval Flow</span>
+            <span data-lang="ko">승인 흐름</span>
+          </h2>
+          <p data-lang="en">
+            When sandbox capability is unavailable or the policy engine decides unsandboxed execution is needed, the approval flow gates command execution. The mode is controlled via the <code>PI_SANDBOX_APPROVAL_MODE</code> environment variable:
+          </p>
+          <p data-lang="ko">
+            샌드박스 기능을 사용할 수 없거나 정책 엔진이 샌드박스 없는 실행이 필요하다고 결정할 때, 승인 흐름이 명령 실행을 제어합니다. 모드는 <code>PI_SANDBOX_APPROVAL_MODE</code> 환경 변수로 제어됩니다:
+          </p>
+          <table class="doc-table">
+            <thead>
+              <tr>
+                <th><span data-lang="en">Mode</span><span data-lang="ko">모드</span></th>
+                <th><span data-lang="en">Behavior</span><span data-lang="ko">동작</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>ask</code></td>
+                <td>
+                  <span data-lang="en">Prompt the user for each unsandboxed command (default).</span>
+                  <span data-lang="ko">샌드박스 없는 각 명령에 대해 사용자에게 프롬프트 (기본값).</span>
+                </td>
+              </tr>
+              <tr>
+                <td><code>always</code></td>
+                <td>
+                  <span data-lang="en">Auto-approve all unsandboxed fallbacks.</span>
+                  <span data-lang="ko">모든 샌드박스 없는 폴백을 자동 승인.</span>
+                </td>
+              </tr>
+              <tr>
+                <td><code>deny</code></td>
+                <td>
+                  <span data-lang="en">Block all unsandboxed execution.</span>
+                  <span data-lang="ko">모든 샌드박스 없는 실행을 차단.</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p data-lang="en">
+            <strong>Approval choices presented to the user:</strong>
+          </p>
+          <p data-lang="ko">
+            <strong>사용자에게 제시되는 승인 선택:</strong>
+          </p>
+          <ul>
+            <li>
+              <span data-lang="en"><strong>Deny</strong> — Block this command.</span>
+              <span data-lang="ko"><strong>거부</strong> — 이 명령을 차단합니다.</span>
+            </li>
+            <li>
+              <span data-lang="en"><strong>Allow once</strong> — Execute this command once, no caching.</span>
+              <span data-lang="ko"><strong>한 번 허용</strong> — 이 명령을 한 번 실행, 캐싱 없음.</span>
+            </li>
+            <li>
+              <span data-lang="en"><strong>Allow for session</strong> — Cache approval for the session (6-hour TTL, persisted).</span>
+              <span data-lang="ko"><strong>세션 동안 허용</strong> — 세션 동안 승인 캐시 (6시간 TTL, 영구 저장).</span>
+            </li>
+            <li>
+              <span data-lang="en"><strong>Always allow</strong> — Persist approval indefinitely.</span>
+              <span data-lang="ko"><strong>항상 허용</strong> — 승인을 무기한 영구 저장.</span>
+            </li>
+          </ul>
+          <p data-lang="en">
+            <strong>Approval scopes:</strong>
+          </p>
+          <p data-lang="ko">
+            <strong>승인 범위:</strong>
+          </p>
+          <ul>
+            <li>
+              <code>once</code> —
+              <span data-lang="en">Single execution, no persistence.</span>
+              <span data-lang="ko">단일 실행, 영속성 없음.</span>
+            </li>
+            <li>
+              <code>session</code> —
+              <span data-lang="en">Cached for the session with a configurable TTL (default 6 hours, <code>PI_SANDBOX_SESSION_APPROVAL_TTL_MS</code>).</span>
+              <span data-lang="ko">구성 가능한 TTL로 세션 동안 캐시됨 (기본 6시간, <code>PI_SANDBOX_SESSION_APPROVAL_TTL_MS</code>).</span>
+            </li>
+            <li>
+              <code>always</code> —
+              <span data-lang="en">Persisted to disk and never expires.</span>
+              <span data-lang="ko">디스크에 영구 저장되며 만료되지 않음.</span>
+            </li>
+          </ul>
+          <p data-lang="en">
+            Approvals are persisted to <code>~/.pi/agent/sandbox-approvals.json</code> using a versioned format (v2) that supports both scope types and expiration timestamps.
+          </p>
+          <p data-lang="ko">
+            승인은 두 범위 유형과 만료 타임스탬프를 모두 지원하는 버전 관리 형식(v2)을 사용하여 <code>~/.pi/agent/sandbox-approvals.json</code>에 영구 저장됩니다.
+          </p>
+        </section>
+
+        <!-- Sensitive Environment Detection -->
+        <section class="doc-section" id="sensitive-env">
+          <h2>
+            <span class="icon">▶</span>
+            <span data-lang="en">Sensitive Environment Detection</span>
+            <span data-lang="ko">민감한 환경 변수 감지</span>
+          </h2>
+          <p data-lang="en">
+            The sandbox system detects files that may contain sensitive environment variables. A file is flagged as sensitive if its basename matches <code>.env</code> or starts with <code>.env.</code> (e.g., <code>.env.local</code>, <code>.env.production</code>).
+          </p>
+          <p data-lang="ko">
+            샌드박스 시스템은 민감한 환경 변수를 포함할 수 있는 파일을 감지합니다. 파일의 베이스네임이 <code>.env</code>와 일치하거나 <code>.env.</code>로 시작하면(예: <code>.env.local</code>, <code>.env.production</code>) 민감한 것으로 표시됩니다.
+          </p>
+          <div class="doc-callout doc-callout-warn">
+            <div class="doc-callout-title">
+              <span data-lang="en">Blocking Behavior</span>
+              <span data-lang="ko">차단 동작</span>
+            </div>
+            <p data-lang="en">
+              When <code>PI_SANDBOX_APPROVAL_MODE=deny</code>, reads of sensitive <code>.env*</code> files are blocked entirely.
+            </p>
+            <p data-lang="ko">
+              <code>PI_SANDBOX_APPROVAL_MODE=deny</code>일 때, 민감한 <code>.env*</code> 파일 읽기가 완전히 차단됩니다.
+            </p>
+          </div>
+        </section>
+
+        <!-- Configuration -->
+        <section class="doc-section" id="configuration">
+          <h2>
+            <span class="icon">■</span>
+            <span data-lang="en">Configuration</span>
+            <span data-lang="ko">설정</span>
+          </h2>
+          <table class="doc-table">
+            <thead>
+              <tr>
+                <th><span data-lang="en">Env Var</span><span data-lang="ko">환경 변수</span></th>
+                <th><span data-lang="en">Values</span><span data-lang="ko">값</span></th>
+                <th><span data-lang="en">Default</span><span data-lang="ko">기본값</span></th>
+                <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>PI_SANDBOX_APPROVAL_MODE</code></td>
+                <td><code>ask</code>, <code>always</code>, <code>deny</code></td>
+                <td><code>ask</code></td>
+                <td>
+                  <span data-lang="en">Approval behavior for unsandboxed fallback execution.</span>
+                  <span data-lang="ko">샌드박스 없는 폴백 실행에 대한 승인 동작.</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <!-- Edge Cases -->
+        <section class="doc-section" id="edge-cases">
+          <h2>
+            <span class="icon">★</span>
+            <span data-lang="en">Edge Cases</span>
+            <span data-lang="ko">엣지 케이스</span>
+          </h2>
+
+          <h3>
+            <span data-lang="en">No Sandbox Tool Available</span>
+            <span data-lang="ko">샌드박스 도구 없음</span>
+          </h3>
+          <p data-lang="en">
+            If neither <code>bwrap</code> nor <code>sandbox-exec</code> is present (or the platform is unsupported), the system falls back to unsandboxed execution. The approval prompt is presented to the user unless <code>PI_SANDBOX_APPROVAL_MODE=always</code> or <code>=deny</code> overrides it.
+          </p>
+          <p data-lang="ko">
+            <code>bwrap</code>이나 <code>sandbox-exec</code>이 없거나 플랫폼이 지원되지 않는 경우, 시스템은 샌드박스 없는 실행으로 폴백합니다. <code>PI_SANDBOX_APPROVAL_MODE=always</code> 또는 <code>=deny</code>가 재정의하지 않는 한 사용자에게 승인 프롬프트가 표시됩니다.
+          </p>
+
+          <h3>
+            <span data-lang="en">Writable Roots</span>
+            <span data-lang="ko">쓰기 가능 루트</span>
+          </h3>
+          <p data-lang="en">
+            In addition to the workspace root, the sandbox allows writes to the Pi agent directory and session directory. These are resolved from <code>PI_CODING_AGENT_DIR</code> and <code>PI_CODING_AGENT_SESSION_DIR</code> (defaulting to <code>~/.pi/agent</code> and the session temp dir respectively).
+          </p>
+          <p data-lang="ko">
+            워크스페이스 루트 외에도 샌드박스는 Pi 에이전트 디렉토리와 세션 디렉토리에 쓰기를 허용합니다. 이들은 <code>PI_CODING_AGENT_DIR</code>과 <code>PI_CODING_AGENT_SESSION_DIR</code>에서 해결됩니다 (기본값은 각각 <code>~/.pi/agent</code>와 세션 임시 디렉토리).
+          </p>
+
+          <h3>
+            <span data-lang="en">Network Mode</span>
+            <span data-lang="ko">네트워크 모드</span>
+          </h3>
+          <p data-lang="en">
+            Network access is configurable per execution. When set to <code>"off"</code>, Linux uses <code>--unshare-net</code> and macOS omits the <code>(allow network*)</code> clause from the SBPL profile. When set to <code>"on"</code>, full network access is permitted within the sandbox.
+          </p>
+          <p data-lang="ko">
+            네트워크 액세스는 실행마다 구성할 수 있습니다. <code>"off"</code>로 설정하면 Linux는 <code>--unshare-net</code>을 사용하고 macOS는 SBPL 프로필에서 <code>(allow network*)</code> 절을 생략합니다. <code>"on"</code>으로 설정하면 샌드박스 내에서 전체 네트워크 액세스가 허용됩니다.
+          </p>
+        </section>
+
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/team-mode.html
+++ b/docs/features/team-mode.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ROACH PI — Team Mode</title>
+  <meta name="description" content="Team Mode: multi-worker coordination with bounded batch execution, task lifecycle tracking, and synthesized results for the pi coding agent.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html" class="active"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Main Content -->
+  <div class="doc-container">
+
+    <div class="doc-sidebar">
+      <ul>
+        <li><a href="#overview"><span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#enabling"><span data-lang="en">Enabling</span><span data-lang="ko">활성화</span></a></li>
+        <li><a href="#command-syntax"><span data-lang="en">Command Syntax</span><span data-lang="ko">명령어 구문</span></a></li>
+        <li><a href="#backends"><span data-lang="en">Backends</span><span data-lang="ko">백엔드</span></a></li>
+        <li><a href="#task-lifecycle"><span data-lang="en">Task Lifecycle</span><span data-lang="ko">태스크 생명주기</span></a></li>
+        <li><a href="#state-file"><span data-lang="en">State File</span><span data-lang="ko">상태 파일</span></a></li>
+        <li><a href="#resume"><span data-lang="en">Resume</span><span data-lang="ko">재개</span></a></li>
+        <li><a href="#worktree"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="#configuration"><span data-lang="en">Configuration</span><span data-lang="ko">설정</span></a></li>
+        <li><a href="#edge-cases"><span data-lang="en">Edge Cases</span><span data-lang="ko">엣지 케이스</span></a></li>
+      </ul>
+    </div>
+
+    <div class="doc-with-sidebar doc-prose">
+
+      <!-- Overview -->
+      <section class="doc-section" id="overview">
+        <h2>
+          <span class="icon">■</span>
+          <span data-lang="en">Overview</span>
+          <span data-lang="ko">개요</span>
+        </h2>
+        <p data-lang="en">
+          Team Mode provides <strong>multi-worker coordination</strong> with bounded batch execution, task lifecycle tracking, and synthesized results. The leader agent decomposes a goal into discrete worker tasks, executes them with concurrency control, and merges outputs into a unified summary.
+        </p>
+        <p data-lang="ko">
+          팀 모드는 <strong>다중 워커 조정</strong>을 제공합니다. 제한된 배치 실행, 태스크 생명주기 추적, 종합 결과를 지원합니다. 리더 에이전트가 목표를 개별 워커 태스크로 분해하고, 동시성 제어로 실행한 후 출력을 통합 요약으로 병합합니다.
+        </p>
+        <p data-lang="en">
+          Supports two execution backends: <strong>native subprocesses</strong> for fast headless operation, or <strong>tmux panes</strong> for human-readable, observable worker output. Workers receive strict guardrails that prevent recursive orchestration and scope creep.
+        </p>
+        <p data-lang="ko">
+          두 가지 실행 백엔드를 지원합니다: 빠른 헤드리스 동작을 위한 <strong>네이티브 서브프로세스</strong>, 또는 사람이 읽을 수 있는 관찰 가능한 워커 출력을 위한 <strong>tmux 페인</strong>. 워커는 재귀적 오케스트레이션과 범위 확장을 방지하는 엄격한 가드레일을 받습니다.
+        </p>
+        <div class="doc-callout doc-callout-info">
+          <div class="doc-callout-title">
+            <span data-lang="en">● Worker Protocol</span>
+            <span data-lang="ko">● 워커 프로토콜</span>
+          </div>
+          <p data-lang="en" style="margin-bottom: 0;">
+            Workers are instructed not to spawn subagents, delegate to other agents, or run orchestration commands (<code>/team</code>, <code>/ultrawork</code>, etc.). They report changed files, verification performed, and remaining blockers before finishing.
+          </p>
+          <p data-lang="ko" style="margin-bottom: 0;">
+            워커는 서브에이전트 생성, 다른 에이전트에 위임, 오케스트레이션 명령(<code>/team</code>, <code>/ultrawork</code> 등) 실행을 금지받습니다. 완료 전 변경된 파일, 수행된 검증, 남은 블로커를 보고합니다.
+          </p>
+        </div>
+      </section>
+
+      <!-- Enabling -->
+      <section class="doc-section" id="enabling">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Enabling</span>
+          <span data-lang="ko">활성화</span>
+        </h2>
+        <p data-lang="en">
+          Team Mode is <strong>opt-in</strong>. Set the environment variable before starting pi:
+        </p>
+        <p data-lang="ko">
+          팀 모드는 <strong>옵트인</strong>입니다. pi를 시작하기 전에 환경 변수를 설정하세요:
+        </p>
+        <div class="doc-code">PI_ENABLE_TEAM_MODE=1 pi</div>
+        <p data-lang="en">
+          When enabled, the <code>team</code> tool is registered in the root session only. Inside workers, <code>PI_TEAM_WORKER=1</code> is automatically set to suppress recursive orchestration — workers cannot register the <code>team</code> or <code>subagent</code> tools.
+        </p>
+        <p data-lang="ko">
+          활성화되면 <code>team</code> 도구가 루트 세션에만 등록됩니다. 워커 내부에서는 재귀적 오케스트레이션을 억제하기 위해 <code>PI_TEAM_WORKER=1</code>이 자동으로 설정됩니다 — 워커는 <code>team</code> 또는 <code>subagent</code> 도구를 등록할 수 없습니다.
+        </p>
+      </section>
+
+      <!-- Command Syntax -->
+      <section class="doc-section" id="command-syntax">
+        <h2>
+          <span class="icon">▶</span>
+          <span data-lang="en">Command Syntax</span>
+          <span data-lang="ko">명령어 구문</span>
+        </h2>
+        <p data-lang="en">
+          The <code>/team</code> slash command accepts a goal and optional key-value parameters:
+        </p>
+        <p data-lang="ko">
+          <code>/team</code> 슬래시 명령은 목표와 선택적 키-값 매개변수를 받습니다:
+        </p>
+        <div class="doc-code"><span class="comment"># Launch a new team run</span>
+/team goal="<span class="highlight">Refactor auth module to use JWT</span>" \
+      agent=worker \
+      backend=auto \
+      worker-count=3 \
+      worktree-policy=auto \
+      max-output=6000
+
+<span class="comment"># Resume an existing run with a follow-up message</span>
+/team resume=<span class="highlight">team-a1b2c3d4e5f6</span> \
+      command=<span class="highlight">worker-1</span> \
+      message="<span class="highlight">Fix the edge case in token refresh</span>"</div>
+        <p data-lang="en">
+          Parameters:
+        </p>
+        <p data-lang="ko">
+          매개변수:
+        </p>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th><span data-lang="en">Type</span><span data-lang="ko">타입</span></th>
+              <th><span data-lang="en">Default</span><span data-lang="ko">기본값</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>goal</code></td>
+              <td><span data-lang="en">string</span><span data-lang="ko">문자열</span></td>
+              <td>—</td>
+              <td><span data-lang="en">Task decomposition goal</span><span data-lang="ko">태스크 분해 목표</span></td>
+            </tr>
+            <tr>
+              <td><code>agent</code></td>
+              <td><span data-lang="en">string</span><span data-lang="ko">문자열</span></td>
+              <td><code>worker</code></td>
+              <td><span data-lang="en">Agent name for workers</span><span data-lang="ko">워커의 에이전트 이름</span></td>
+            </tr>
+            <tr>
+              <td><code>backend</code></td>
+              <td><code>auto</code> / <code>native</code> / <code>tmux</code></td>
+              <td><code>auto</code></td>
+              <td><span data-lang="en">Execution backend</span><span data-lang="ko">실행 백엔드</span></td>
+            </tr>
+            <tr>
+              <td><code>worker-count</code></td>
+              <td><span data-lang="en">number (1–12)</span><span data-lang="ko">숫자 (1–12)</span></td>
+              <td>—</td>
+              <td><span data-lang="en">Number of parallel workers</span><span data-lang="ko">병렬 워커 수</span></td>
+            </tr>
+            <tr>
+              <td><code>worktree-policy</code></td>
+              <td><code>off</code> / <code>on</code> / <code>auto</code></td>
+              <td><code>off</code></td>
+              <td><span data-lang="en">Git worktree isolation</span><span data-lang="ko">Git 워크트리 격리</span></td>
+            </tr>
+            <tr>
+              <td><code>resume</code></td>
+              <td><span data-lang="en">string (runId)</span><span data-lang="ko">문자열 (runId)</span></td>
+              <td>—</td>
+              <td><span data-lang="en">Resume an existing run</span><span data-lang="ko">기존 실행 재개</span></td>
+            </tr>
+            <tr>
+              <td><code>resume-mode</code></td>
+              <td><code>mark-interrupted</code> / <code>retry-stale</code></td>
+              <td><code>mark-interrupted</code></td>
+              <td><span data-lang="en">How to handle stale tasks</span><span data-lang="ko">오래된 태스크 처리 방식</span></td>
+            </tr>
+            <tr>
+              <td><code>max-output</code></td>
+              <td><span data-lang="en">number</span><span data-lang="ko">숫자</span></td>
+              <td>—</td>
+              <td><span data-lang="en">Max output chars per worker</span><span data-lang="ko">워커당 최대 출력 문자 수</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Backends -->
+      <section class="doc-section" id="backends">
+        <h2>
+          <span class="icon">★</span>
+          <span data-lang="en">Backends</span>
+          <span data-lang="ko">백엔드</span>
+        </h2>
+        <p data-lang="en">
+          Team Mode supports two execution backends. The <code>auto</code> mode prefers tmux when available and falls back to native.
+        </p>
+        <p data-lang="ko">
+          팀 모드는 두 가지 실행 백엔드를 지원합니다. <code>auto</code> 모드는 tmux를 사용할 수 있으면 선호하고, 없으면 네이티브로 폴백합니다.
+        </p>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th>Backend</th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+              <th><span data-lang="en">Use Case</span><span data-lang="ko">사용 사례</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>auto</code></td>
+              <td><span data-lang="en">Tries native, falls back to tmux</span><span data-lang="ko">네이티브를 시도하고 tmux로 폴백</span></td>
+              <td><span data-lang="en">Default</span><span data-lang="ko">기본값</span></td>
+            </tr>
+            <tr>
+              <td><code>native</code></td>
+              <td><span data-lang="en">Subprocess workers</span><span data-lang="ko">서브프로세스 워커</span></td>
+              <td><span data-lang="en">Fast, headless</span><span data-lang="ko">빠른 헤드리스</span></td>
+            </tr>
+            <tr>
+              <td><code>tmux</code></td>
+              <td><span data-lang="en">Human-readable tmux panes</span><span data-lang="ko">사람이 읽을 수 있는 tmux 페인</span></td>
+              <td><span data-lang="en">Debugging, observable</span><span data-lang="ko">디버깅, 관찰 가능</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p data-lang="en">
+          When <code>backend=native</code> is forced, tmux detection is skipped entirely. When <code>backend=tmux</code> is forced and tmux is unavailable, pane creation fails immediately.
+        </p>
+        <p data-lang="ko">
+          <code>backend=native</code>가 강제되면 tmux 감지를 완전히 건너뜁니다. <code>backend=tmux</code>가 강제되었는데 tmux를 사용할 수 없으면 페인 생성이 즉시 실패합니다.
+        </p>
+        <p data-lang="en">
+          Tmux panes are created either in the current tmux window (if pi is already inside a tmux client) or in a new detached session. Pane metadata (session, window, pane ID, attach command, log paths) is stored on each task's terminal record.
+        </p>
+        <p data-lang="ko">
+          tmux 페인은 현재 tmux 윈도(pi가 이미 tmux 클라이언트 내부에 있는 경우) 또는 새로운 디태치드 세션에 생성됩니다. 페인 메타데이터(세션, 윈도, 페인 ID, 연결 명령, 로그 경로)는 각 태스크의 터미널 레코드에 저장됩니다.
+        </p>
+      </section>
+
+      <!-- Task Lifecycle -->
+      <section class="doc-section" id="task-lifecycle">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Task Lifecycle</span>
+          <span data-lang="ko">태스크 생명주기</span>
+        </h2>
+        <p data-lang="en">
+          Team Mode tracks three levels of status:
+        </p>
+        <p data-lang="ko">
+          팀 모드는 세 수준의 상태를 추적합니다:
+        </p>
+
+        <h3>
+          <span data-lang="en">Task Statuses</span>
+          <span data-lang="ko">태스크 상태</span>
+        </h3>
+        <div class="doc-code">created → pending → in_progress → completed | failed | interrupted
+                         ↘ blocked</div>
+        <p data-lang="en">
+          Tasks are created during goal decomposition, transition to <code>pending</code> when eligible, and execute through <code>in_progress</code> to a terminal state. The <code>blocked</code> state is reserved for dependency-based scheduling (future).
+        </p>
+        <p data-lang="ko">
+          태스크는 목표 분해 중 생성되고, 실행 가능해지면 <code>pending</code>으로 전환되며, <code>in_progress</code>를 거쳐 종료 상태로 이동합니다. <code>blocked</code> 상태는 의존성 기반 스케줄링용으로 예약되어 있습니다(향후).
+        </p>
+
+        <h3>
+          <span data-lang="en">Run Statuses</span>
+          <span data-lang="ko">실행 상태</span>
+        </h3>
+        <div class="doc-code">created → running → completed | failed | cancelled | interrupted</div>
+        <p data-lang="en">
+          The overall run status reflects aggregate worker progress. <code>cancelled</code> and <code>interrupted</code> are triggered by abort signals or Ctrl+C.
+        </p>
+        <p data-lang="ko">
+          전체 실행 상태는 워커 진행 상황을 집계하여 반영합니다. <code>cancelled</code>과 <code>interrupted</code>는 중단 시그널이나 Ctrl+C에 의해 트리거됩니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Command Statuses</span>
+          <span data-lang="ko">명령 상태</span>
+        </h3>
+        <div class="doc-code">queued → acknowledged → started → completed | blocked | failed
+                                              ↘ stale</div>
+        <p data-lang="en">
+          Commands (follow-up messages) use an optimistic concurrency FSM with a <code>statusVersion</code> counter. Terminal statuses can transition back to <code>queued</code> for retry. Retries are capped at 3 attempts — exceeding this marks the command <code>blocked</code>.
+        </p>
+        <p data-lang="ko">
+          명령(후속 메시지)은 <code>statusVersion</code> 카운터가 있는 낙관적 동시성 FSM을 사용합니다. 종료 상태는 재시도를 위해 <code>queued</code>로 다시 전환할 수 있습니다. 재시도는 최대 3회로 제한되며, 초과하면 명령이 <code>blocked</code>로 표시됩니다.
+        </p>
+      </section>
+
+      <!-- State File -->
+      <section class="doc-section" id="state-file">
+        <h2>
+          <span class="icon">◆</span>
+          <span data-lang="en">State File</span>
+          <span data-lang="ko">상태 파일</span>
+        </h2>
+        <p data-lang="en">
+          Every team run persists its state to a durable JSON file. This enables resume, debugging, and audit of past runs.
+        </p>
+        <p data-lang="ko">
+          모든 팀 실행은 상태를 내구성 있는 JSON 파일에 저장합니다. 이를 통해 재개, 디버깅, 과거 실행 감사가 가능합니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Schema</span>
+          <span data-lang="ko">스키마</span>
+        </h3>
+        <div class="doc-code">{
+  <span class="highlight">schemaVersion</span>: 1,
+  <span class="highlight">runId</span>: "team-a1b2c3d4e5f6g7h8",
+  <span class="highlight">goal</span>: "...",
+  <span class="highlight">createdAt</span>: "2026-04-28T10:00:00.000Z",   <span class="comment">// ISO 8601</span>
+  <span class="highlight">updatedAt</span>: "2026-04-28T10:05:30.000Z",
+  <span class="highlight">status</span>: "completed",                  <span class="comment">// TeamRunStatus</span>
+  <span class="highlight">options</span>: { ... },                     <span class="comment">// TeamRunOptionsSnapshot</span>
+  <span class="highlight">tasks</span>: [ TeamTask ],                  <span class="comment">// worker task records</span>
+  <span class="highlight">commands</span>: [ TeamCommand ],            <span class="comment">// follow-up command records</span>
+  <span class="highlight">events</span>: [ TeamRunEvent ],             <span class="comment">// append-only audit log</span>
+  <span class="highlight">messages</span>: [ TeamMessage ],            <span class="comment">// inbox/outbox history</span>
+  <span class="highlight">summary</span>: { TeamRunSummary }           <span class="comment">// final synthesized result</span>
+}</div>
+
+        <h3>
+          <span data-lang="en">Storage Location</span>
+          <span data-lang="ko">저장 위치</span>
+        </h3>
+        <div class="doc-code">${PI_TEAM_RUN_STATE_ROOT || &lt;cwd&gt;/.pi/agent/runs}/&lt;runId&gt;/team-run.json</div>
+        <p data-lang="en">
+          Tmux logs are stored alongside the state file when using the tmux backend:
+        </p>
+        <p data-lang="ko">
+          tmux 백엔드 사용 시 tmux 로그가 상태 파일과 함께 저장됩니다:
+        </p>
+        <div class="doc-code">&lt;runId&gt;/tmux/task-N.log          <span class="comment"># visible pane log</span>
+&lt;runId&gt;/tmux/task-N.events.jsonl <span class="comment"># raw event log</span></div>
+        <p data-lang="en">
+          Writes are <strong>atomic</strong> — the record is written to a temp file first, then renamed.
+        </p>
+        <p data-lang="ko">
+          쓰기는 <strong>원자적</strong>입니다 — 레코드를 먼저 임시 파일에 쓴 후 이름을 변경합니다.
+        </p>
+      </section>
+
+      <!-- Resume -->
+      <section class="doc-section" id="resume">
+        <h2>
+          <span class="icon">▶</span>
+          <span data-lang="en">Resume &amp; Follow-up</span>
+          <span data-lang="ko">재개 &amp; 후속 메시지</span>
+        </h2>
+        <p data-lang="en">
+          Interrupted or incomplete runs can be resumed by referencing their <code>runId</code>. Two strategies handle stale tasks:
+        </p>
+        <p data-lang="ko">
+          중단되거나 완료되지 않은 실행은 <code>runId</code>를 참조하여 재개할 수 있습니다. 두 가지 전략으로 오래된 태스크를 처리합니다:
+        </p>
+
+        <h4>
+          <span data-lang="en">mark-interrupted (default)</span>
+          <span data-lang="ko">mark-interrupted (기본값)</span>
+        </h4>
+        <p data-lang="en">
+          Marks stale <code>in_progress</code> tasks as <code>interrupted</code>. Stale commands are marked <code>stale</code>. Use this when you want to inspect what was running and decide manually.
+        </p>
+        <p data-lang="ko">
+          오래된 <code>in_progress</code> 태스크를 <code>interrupted</code>로 표시합니다. 오래된 명령은 <code>stale</code>로 표시됩니다. 실행 중이던 작업을 검사하고 수동으로 결정하려면 이 옵션을 사용하세요.
+        </p>
+
+        <h4>
+          <span data-lang="en">retry-stale</span>
+          <span data-lang="ko">retry-stale</span>
+        </h4>
+        <p data-lang="en">
+          Resets stale <code>in_progress</code> tasks to <code>pending</code> for re-execution. Stale commands are retried (attempt incremented, reset to <code>queued</code>). Commands exceeding 3 attempts are marked <code>blocked</code>.
+        </p>
+        <p data-lang="ko">
+          오래된 <code>in_progress</code> 태스크를 <code>pending</code>으로 재설정하여 재실행합니다. 오래된 명령은 재시도됩니다(시도 횟수 증가, <code>queued</code>로 재설정). 3회를 초과한 명령은 <code>blocked</code>로 표시됩니다.
+        </p>
+
+        <h4>
+          <span data-lang="en">Follow-up Messages</span>
+          <span data-lang="ko">후속 메시지</span>
+        </h4>
+        <p data-lang="en">
+          Send targeted messages to a specific worker or task in an existing run. The command creates a durable inbox entry, re-executes the worker with the new context, and records the result.
+        </p>
+        <p data-lang="ko">
+          기존 실행의 특정 워커나 태스크에 대상 메시지를 보냅니다. 명령은 내구성 있는 인박스 항목을 생성하고, 새 컨텍스트로 워커를 재실행하며, 결과를 기록합니다.
+        </p>
+        <div class="doc-code"><span class="comment"># Send a follow-up to a specific worker</span>
+/team resume=team-a1b2c3d4e5f6 command=worker-1 \
+      message="Fix the edge case in token refresh"</div>
+        <p data-lang="en">
+          The target can be a worker identifier (<code>worker-1</code>) or a task identifier (<code>task-1</code>).
+        </p>
+        <p data-lang="ko">
+          대상은 워커 식별자(<code>worker-1</code>) 또는 태스크 식별자(<code>task-1</code>)가 될 수 있습니다.
+        </p>
+      </section>
+
+      <!-- Worktree -->
+      <section class="doc-section" id="worktree">
+        <h2>
+          <span class="icon">★</span>
+          <span data-lang="en">Worktree Integration</span>
+          <span data-lang="ko">워크트리 통합</span>
+        </h2>
+        <p data-lang="en">
+          Git worktree isolation can be controlled via the <code>worktree-policy</code> parameter:
+        </p>
+        <p data-lang="ko">
+          Git 워크트리 격리는 <code>worktree-policy</code> 매개변수로 제어할 수 있습니다:
+        </p>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th>Policy</th>
+              <th><span data-lang="en">Behavior</span><span data-lang="ko">동작</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>off</code></td>
+              <td><span data-lang="en">No worktree isolation. Workers share the working tree.</span><span data-lang="ko">워크트리 격리 없음. 워커가 작업 트리를 공유합니다.</span></td>
+            </tr>
+            <tr>
+              <td><code>on</code></td>
+              <td><span data-lang="en">Always use git worktrees for worker isolation.</span><span data-lang="ko">항상 git 워크트리를 사용하여 워커를 격리합니다.</span></td>
+            </tr>
+            <tr>
+              <td><code>auto</code></td>
+              <td><span data-lang="en">Use worktrees if available (delegates to the legacy <code>worktree</code> boolean). Resolves to <code>!!worktree</code>.</span><span data-lang="ko">사용 가능하면 워크트리 사용(레거시 <code>worktree</code> 불리언에 위임). <code>!!worktree</code>로 해석됩니다.</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p data-lang="en">
+          The resolved boolean is passed to <code>runAgent()</code> as the <code>worktree</code> option.
+        </p>
+        <p data-lang="ko">
+          해석된 불리언은 <code>worktree</code> 옵션으로 <code>runAgent()</code>에 전달됩니다.
+        </p>
+      </section>
+
+      <!-- Configuration -->
+      <section class="doc-section" id="configuration">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Configuration</span>
+          <span data-lang="ko">설정</span>
+        </h2>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Env Var</span><span data-lang="ko">환경 변수</span></th>
+              <th><span data-lang="en">Default</span><span data-lang="ko">기본값</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>PI_ENABLE_TEAM_MODE</code></td>
+              <td><span data-lang="en">(unset)</span><span data-lang="ko">(미설정)</span></td>
+              <td><span data-lang="en">Set to <code>1</code> to enable team mode</span><span data-lang="ko"><code>1</code>로 설정하여 팀 모드 활성화</span></td>
+            </tr>
+            <tr>
+              <td><code>PI_TEAM_WORKER</code></td>
+              <td><span data-lang="en">(unset)</span><span data-lang="ko">(미설정)</span></td>
+              <td><span data-lang="en">Auto-set inside workers to suppress recursive orchestration</span><span data-lang="ko">워커 내부에서 자동 설정되어 재귀적 오케스트레이션 억제</span></td>
+            </tr>
+            <tr>
+              <td><code>PI_TEAM_RUN_STATE_ROOT</code></td>
+              <td><code>cwd/.pi/agent/runs</code></td>
+              <td><span data-lang="en">Override state file storage location</span><span data-lang="ko">상태 파일 저장 위치 재정의</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="doc-callout doc-callout-info">
+          <div class="doc-callout-title">
+            <span data-lang="en">● Guards</span>
+            <span data-lang="ko">● 가드</span>
+          </div>
+          <p data-lang="en" style="margin-bottom: 0;">
+            The team tool is only registered when <code>PI_ENABLE_TEAM_MODE=1</code> AND the session is a root session (not itself a team worker). Workers receive <code>PI_TEAM_WORKER=1</code> and <code>PI_SUBAGENT_MAX_DEPTH=1</code> in their environment.
+          </p>
+          <p data-lang="ko" style="margin-bottom: 0;">
+            team 도구는 <code>PI_ENABLE_TEAM_MODE=1</code>이고 세션이 루트 세션(자신이 팀 워커가 아님)일 때만 등록됩니다. 워커는 환경에 <code>PI_TEAM_WORKER=1</code>과 <code>PI_SUBAGENT_MAX_DEPTH=1</code>을 받습니다.
+          </p>
+        </div>
+      </section>
+
+      <!-- Edge Cases -->
+      <section class="doc-section" id="edge-cases">
+        <h2>
+          <span class="icon">◆</span>
+          <span data-lang="en">Edge Cases</span>
+          <span data-lang="ko">엣지 케이스</span>
+        </h2>
+
+        <h4>
+          <span data-lang="en">Abort / Ctrl+C</span>
+          <span data-lang="ko">중단 / Ctrl+C</span>
+        </h4>
+        <p data-lang="en">
+          When the tool's <code>AbortSignal</code> fires, all <code>pending</code> and <code>in_progress</code> tasks are marked <code>interrupted</code>, registered tmux resources are cleaned up, and the run status is set to <code>interrupted</code>. The abort races against normal worker completion via <code>Promise.race()</code>.
+        </p>
+        <p data-lang="ko">
+          도구의 <code>AbortSignal</code>이 발동하면 모든 <code>pending</code> 및 <code>in_progress</code> 태스크가 <code>interrupted</code>로 표시되고, 등록된 tmux 리소스가 정리되며, 실행 상태가 <code>interrupted</code>로 설정됩니다. 중단은 <code>Promise.race()</code>를 통해 정상 워커 완료와 경쟁합니다.
+        </p>
+
+        <h4>
+          <span data-lang="en">Session Shutdown</span>
+          <span data-lang="ko">세션 종료</span>
+        </h4>
+        <p data-lang="en">
+          Double Ctrl+C during pi interactive shutdown emits <code>session_shutdown</code> during <code>runtimeHost.dispose</code> rather than calling <code>session.abort()</code>. The extension registers a <code>session_shutdown</code> handler that calls <code>cleanupActiveTeamTmuxResources()</code>, ensuring all active tmux sessions and panes are cleaned up even when the abort signal path is bypassed.
+        </p>
+        <p data-lang="ko">
+          pi 인터랙티브 종료 중 이중 Ctrl+C는 <code>session.abort()</code>를 호출하지 않고 <code>runtimeHost.dispose</code> 중 <code>session_shutdown</code>을 발생시킵니다. 익스텐션은 <code>cleanupActiveTeamTmuxResources()</code>를 호출하는 <code>session_shutdown</code> 핸들러를 등록하여, 중단 시그널 경로가 우회되어도 모든 활성 tmux 세션과 페인이 정리되도록 합니다.
+        </p>
+
+        <h4>
+          <span data-lang="en">Partial Pane Cleanup on Setup Failure</span>
+          <span data-lang="ko">설정 실패 시 부분 페인 정리</span>
+        </h4>
+        <p data-lang="en">
+          If pane creation partially fails (e.g., only 2 of 4 panes are created before an error), the already-created panes are cleaned up via <code>cleanupTeamTmuxResources()</code> to prevent orphaned tmux sessions.
+        </p>
+        <p data-lang="ko">
+          페인 생성이 부분적으로 실패하면(예: 오류 전 4개 중 2개만 생성), 고립된 tmux 세션을 방지하기 위해 이미 생성된 페인이 <code>cleanupTeamTmuxResources()</code>를 통해 정리됩니다.
+        </p>
+
+        <h4>
+          <span data-lang="en">Active Team Tmux Resource Registry</span>
+          <span data-lang="ko">활성 팀 tmux 리소스 레지스트리</span>
+        </h4>
+        <p data-lang="en">
+          An in-memory <code>Set&lt;TeamTmuxCleanupRegistration&gt;</code> tracks all active tmux resources across concurrent team runs. Registrations are added when tmux panes are created and removed on normal completion. The registry enables cross-run cleanup during session shutdown.
+        </p>
+        <p data-lang="ko">
+          메모리 내 <code>Set&lt;TeamTmuxCleanupRegistration&gt;</code>이 동시 팀 실행 전체의 모든 활성 tmux 리소스를 추적합니다. 등록은 tmux 페인 생성 시 추가되고 정상 완료 시 제거됩니다. 레지스트리는 세션 종료 중 교차 실행 정리를 가능하게 합니다.
+        </p>
+
+        <h4>
+          <span data-lang="en">Failed Runs Leave Tmux Alive</span>
+          <span data-lang="ko">실패한 실행은 tmux를 유지합니다</span>
+        </h4>
+        <p data-lang="en">
+          On success, tmux resources are cleaned immediately. On failure, tmux panes/sessions are <strong>intentionally left alive</strong> for debugging. Use <code>cleanupActiveTeamTmuxResources()</code> or attach to the session manually to inspect.
+        </p>
+        <p data-lang="ko">
+          성공 시 tmux 리소스는 즉시 정리됩니다. 실패 시 tmux 페인/세션은 디버깅을 위해 <strong>의도적으로 살려둡니다</strong>. <code>cleanupActiveTeamTmuxResources()</code>를 사용하거나 수동으로 세션에 연결하여 검사하세요.
+        </p>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/roach-pi" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/workspace-memory.html
+++ b/docs/features/workspace-memory.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ROACH PI — Workspace Memory</title>
+  <meta name="description" content="Deep developer documentation for ROACH PI workspace memory: automatic knowledge persistence and recall across sessions.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html" class="active"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Doc Content -->
+  <div class="doc-container">
+    <h1>
+      <span data-lang="en">Workspace Memory</span>
+      <span data-lang="ko">워크스페이스 메모리</span>
+    </h1>
+
+    <!-- Sidebar + Main Content -->
+    <div class="doc-sidebar">
+      <ul>
+        <li><a href="#overview"><span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#architecture"><span data-lang="en">Architecture</span><span data-lang="ko">아키텍처</span></a></li>
+        <li><a href="#templates"><span data-lang="en">Templates</span><span data-lang="ko">템플릿</span></a></li>
+        <li><a href="#saving"><span data-lang="en">Saving</span><span data-lang="ko">저장</span></a></li>
+        <li><a href="#recalling"><span data-lang="en">Recalling</span><span data-lang="ko">리콜</span></a></li>
+        <li><a href="#eviction"><span data-lang="en">Eviction</span><span data-lang="ko">축출</span></a></li>
+        <li><a href="#commands"><span data-lang="en">Commands</span><span data-lang="ko">명령어</span></a></li>
+        <li><a href="#configuration"><span data-lang="en">Configuration</span><span data-lang="ko">구성</span></a></li>
+        <li><a href="#edge-cases"><span data-lang="en">Edge Cases</span><span data-lang="ko">엣지 케이스</span></a></li>
+      </ul>
+    </div>
+
+    <div class="doc-with-sidebar doc-prose">
+
+      <!-- Overview -->
+      <section class="doc-section" id="overview">
+        <h2>
+          <span data-lang="en">Overview</span>
+          <span data-lang="ko">개요</span>
+        </h2>
+        <p data-lang="en">
+          Workspace Memory automatically saves important workspace knowledge — bug postmortems, architectural decisions, and compact notes — and injects relevant memories into future agent prompts so the agent avoids rediscovering prior context. Each workspace has an isolated memory store that persists across sessions and survives context compaction.
+        </p>
+        <p data-lang="ko">
+          워크스페이스 메모리는 중요한 워크스페이스 지식 — 버그 포스트모템, 아키텍처 결정, 간결한 메모 — 을 자동으로 저장하고, 이전 문맥을 재발견하지 않도록 관련 메모리를 향후 에이전트 프롬프트에 주입합니다. 각 워크스페이스에는 세션 간에 지속되고 컨텍스트 컴팩션에서도 유지되는 격리된 메모리 저장소가 있습니다.
+        </p>
+        <div class="doc-callout doc-callout-info">
+          <div class="doc-callout-title">
+            <span data-lang="en">Key Insight</span>
+            <span data-lang="ko">핵심 인사이트</span>
+          </div>
+          <p data-lang="en" style="margin-bottom: 0;">
+            Memories are <strong>not instructions</strong> — they are provided as read-only context wrapped in <code>&lt;workspace_memories&gt;</code> tags so the agent can reference past findings without re-executing them.
+          </p>
+          <p data-lang="ko" style="margin-bottom: 0;">
+            메모리는 <strong>지시어가 아닙니다</strong> — <code>&lt;workspace_memories&gt;</code> 태그로 래핑된 읽기 전용 컨텍스트로 제공되어 에이전트가 과거 발견을 재실행하지 않고 참조할 수 있습니다.
+          </p>
+        </div>
+      </section>
+
+      <!-- Architecture -->
+      <section class="doc-section" id="architecture">
+        <h2>
+          <span data-lang="en">Architecture</span>
+          <span data-lang="ko">아키텍처</span>
+        </h2>
+        <p data-lang="en">
+          Storage is per-workspace. The memory directory lives under the agent's data root, keyed by an encoded version of the working directory path.
+        </p>
+        <p data-lang="ko">
+          저장소는 워크스페이스별입니다. 메모리 디렉토리는 에이전트 데이터 루트 아래에 작업 디렉토리 경로의 인코딩된 버전을 키로 하여 위치합니다.
+        </p>
+        <div class="doc-code">
+<span class="comment"># Storage path</span>
+<span class="highlight">${getAgentDir()}</span>/memory/<span class="highlight">${encodeCwd(cwd)}</span>/
+
+<span class="comment"># encodeCwd implementation</span>
+"--" + cwd.replace(/^[\\/]/, "").replace(/[\\/:]/g, "-") + "--"
+        </div>
+        <h3>
+          <span data-lang="en">Files</span>
+          <span data-lang="ko">파일</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">File</span><span data-lang="ko">파일</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>index.json</code></td>
+              <td>
+                <span data-lang="en">Lightweight index with id, file, template, summary, tags, createdAt, lastRecalledAt, recallCount, and score for each memory. Used for ranking without loading full content.</span>
+                <span data-lang="ko">각 메모리의 id, file, template, summary, tags, createdAt, lastRecalledAt, recallCount, score가 포함된 경량 인덱스. 전체 콘텐츠 로드 없이 랭킹에 사용됩니다.</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>mem-${timestamp}-${random}.json</code></td>
+              <td>
+                <span data-lang="en">Individual memory file containing the full structured content, template type, and metadata.</span>
+                <span data-lang="ko">전체 구조화된 콘텐츠, 템플릿 유형 및 메타데이터가 포함된 개별 메모리 파일.</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <h3>
+          <span data-lang="en">Recall Pipeline</span>
+          <span data-lang="ko">리콜 파이프라인</span>
+        </h3>
+        <p data-lang="en">
+          The recall pipeline is designed for zero-token overhead during ranking:
+        </p>
+        <p data-lang="ko">
+          리콜 파이프라인은 랭킹 중 토큰 오버헤드가 없도록 설계되었습니다:
+        </p>
+        <ol>
+          <li>
+            <span data-lang="en">Load lightweight index (summaries + tags only, no full content)</span>
+            <span data-lang="ko">경량 인덱스 로드 (요약 + 태그만, 전체 콘텐츠 없음)</span>
+          </li>
+          <li>
+            <span data-lang="en">Local keyword filter extracted from recent conversation text (zero token cost)</span>
+            <span data-lang="ko">최근 대화 텍스트에서 추출한 로컬 키워드 필터 (토큰 비용 없음)</span>
+          </li>
+          <li>
+            <span data-lang="en">Score-based ranking (local computation)</span>
+            <span data-lang="ko">점수 기반 랭킹 (로컬 계산)</span>
+          </li>
+          <li>
+            <span data-lang="en">Load full content for top-K memories only</span>
+            <span data-lang="ko">상위 K개 메모리에 대해서만 전체 콘텐츠 로드</span>
+          </li>
+        </ol>
+      </section>
+
+      <!-- Templates -->
+      <section class="doc-section" id="templates">
+        <h2>
+          <span data-lang="en">Memory Templates</span>
+          <span data-lang="ko">메모리 템플릿</span>
+        </h2>
+        <p data-lang="en">
+          Three templates define the structure of saved memories. The template is auto-detected from the content or can be specified manually.
+        </p>
+        <p data-lang="ko">
+          세 가지 템플릿이 저장된 메모리의 구조를 정의합니다. 템플릿은 콘텐츠에서 자동 감지되거나 수동으로 지정할 수 있습니다.
+        </p>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Template</span><span data-lang="ko">템플릿</span></th>
+              <th><span data-lang="en">Fields</span><span data-lang="ko">필드</span></th>
+              <th><span data-lang="en">Use When</span><span data-lang="ko">사용 시기</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>post-mortem</code></td>
+              <td>
+                <code>problem</code>, <code>rootCause</code>, <code>fix</code>, <code>prevention</code>
+              </td>
+              <td>
+                <span data-lang="en">After resolving a bug</span>
+                <span data-lang="ko">버그 해결 후</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>decision-record</code></td>
+              <td>
+                <code>context</code>, <code>decision</code>, <code>rationale</code>, <code>alternativesConsidered</code>
+              </td>
+              <td>
+                <span data-lang="en">When making an architectural choice</span>
+                <span data-lang="ko">아키텍처 결정을 내릴 때</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>compact-note</code></td>
+              <td>
+                <code>summary</code>, <code>keyPoints[]</code>
+              </td>
+              <td>
+                <span data-lang="en">Quick knowledge capture</span>
+                <span data-lang="ko">빠른 지식 캡처</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Saving -->
+      <section class="doc-section" id="saving">
+        <h2>
+          <span data-lang="en">Saving Memories</span>
+          <span data-lang="ko">메모리 저장</span>
+        </h2>
+        <p data-lang="en">
+          Memories are saved via the <code>memory_save</code> tool or the <code>/memory save</code> slash command. The agent also auto-detects important moments (bug fixes, decisions, discoveries) and suggests saving them.
+        </p>
+        <p data-lang="ko">
+          메모리는 <code>memory_save</code> 도구 또는 <code>/memory save</code> 슬래시 명령을 통해 저장됩니다. 에이전트는 중요한 순간(버그 수정, 결정, 발견)을 자동으로 감지하여 저장을 제안하기도 합니다.
+        </p>
+        <h3>
+          <span data-lang="en">Tool Parameters</span>
+          <span data-lang="ko">도구 파라미터</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Parameter</span><span data-lang="ko">파라미터</span></th>
+              <th><span data-lang="en">Type</span><span data-lang="ko">타입</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>content</code></td>
+              <td><code>string</code> <span data-lang="en">(required)</span><span data-lang="ko">(필수)</span></td>
+              <td>
+                <span data-lang="en">Structured memory content</span>
+                <span data-lang="ko">구조화된 메모리 콘텐츠</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>template</code></td>
+              <td><code>string</code> <span data-lang="en">(optional)</span><span data-lang="ko">(선택)</span></td>
+              <td>
+                <span data-lang="en">Auto-detected if omitted</span>
+                <span data-lang="ko">생략 시 자동 감지</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>tags</code></td>
+              <td><code>string[]</code> <span data-lang="en">(optional)</span><span data-lang="ko">(선택)</span></td>
+              <td>
+                <span data-lang="en">Tags for relevance matching</span>
+                <span data-lang="ko">관련성 매칭을 위한 태그</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Recalling -->
+      <section class="doc-section" id="recalling">
+        <h2>
+          <span data-lang="en">Recalling Memories</span>
+          <span data-lang="ko">메모리 리콜</span>
+        </h2>
+        <p data-lang="en">
+          Before each agent turn, the recall pipeline extracts keywords from recent conversation text, ranks memories by relevance, and injects the top results into the system prompt.
+        </p>
+        <p data-lang="ko">
+          각 에이전트 턴 전에 리콜 파이프라인이 최근 대화 텍스트에서 키워드를 추출하고, 관련성별로 메모리를 랭킹하여 상위 결과를 시스템 프롬프트에 주입합니다.
+        </p>
+        <h3>
+          <span data-lang="en">Limits</span>
+          <span data-lang="ko">제한</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Parameter</span><span data-lang="ko">파라미터</span></th>
+              <th><span data-lang="en">Value</span><span data-lang="ko">값</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>MAX_MEMORIES</code></td>
+              <td><code>200</code></td>
+              <td>
+                <span data-lang="en">Per-workspace limit</span>
+                <span data-lang="ko">워크스페이스당 최대 메모리 수</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>RECENCY_HALFLIFE_DAYS</code></td>
+              <td><code>30</code></td>
+              <td>
+                <span data-lang="en">Score decay half-life</span>
+                <span data-lang="ko">점수 감쇠 반감기</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>MAX_RECALL_MEMORIES</code></td>
+              <td><code>5</code></td>
+              <td>
+                <span data-lang="en">Injected per prompt</span>
+                <span data-lang="ko">프롬프트당 주입 수</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>MAX_RECALL_CONTEXT_CHARS</code></td>
+              <td><code>8000</code></td>
+              <td>
+                <span data-lang="en">Total recalled text budget</span>
+                <span data-lang="ko">전체 리콜 텍스트 예산</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>MAX_RECALL_MEMORY_CHARS</code></td>
+              <td><code>2000</code></td>
+              <td>
+                <span data-lang="en">Single memory text limit</span>
+                <span data-lang="ko">단일 메모리 텍스트 제한</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <h3>
+          <span data-lang="en">Scoring Formula</span>
+          <span data-lang="ko">점수 공식</span>
+        </h3>
+        <div class="doc-code">
+score = recallCount × exp(-daysSinceLastRecall / 30)
+        </div>
+        <h3>
+          <span data-lang="en">Relevance Matching</span>
+          <span data-lang="ko">관련성 매칭</span>
+        </h3>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Match Type</span><span data-lang="ko">매칭 유형</span></th>
+              <th><span data-lang="en">Score</span><span data-lang="ko">점수</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span data-lang="en">Exact tag match</span><span data-lang="ko">정확한 태그 매칭</span></td>
+              <td><code>+10</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Partial tag match</span><span data-lang="ko">부분 태그 매칭</span></td>
+              <td><code>+5</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Summary keyword match</span><span data-lang="ko">요약 키워드 매칭</span></td>
+              <td><code>+3</code></td>
+            </tr>
+            <tr>
+              <td><span data-lang="en">Learned score boost</span><span data-lang="ko">학습된 점수 부스트</span></td>
+              <td><code>score × 0.5</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Eviction -->
+      <section class="doc-section" id="eviction">
+        <h2>
+          <span data-lang="en">Eviction</span>
+          <span data-lang="ko">축출</span>
+        </h2>
+        <p data-lang="en">
+          When the memory count exceeds <code>MAX_MEMORIES</code> (200), the system evicts the lowest-scoring memories. All scores are recalculated, memories are sorted by score ascending (tie-break: <code>createdAt</code> ascending — oldest first), and the overflow is removed.
+        </p>
+        <p data-lang="ko">
+          메모리 수가 <code>MAX_MEMORIES</code>(200)을 초과하면 시스템은 점수가 가장 낮은 메모리를 축출합니다. 모든 점수가 재계산되고, 점수 오름차순으로 정렬되며(동점 시 <code>createdAt</code> 오름차순 — 가장 오래된 것 우선), 초과분이 제거됩니다.
+        </p>
+        <div class="doc-code">
+<span class="comment"># Eviction algorithm</span>
+1. recalculateAllScores()
+2. sort by score ASC, createdAt ASC
+3. splice top N over MAX_MEMORIES
+4. re-sort remaining by createdAt DESC
+        </div>
+      </section>
+
+      <!-- Commands -->
+      <section class="doc-section" id="commands">
+        <h2>
+          <span data-lang="en">Slash Commands</span>
+          <span data-lang="ko">슬래시 명령어</span>
+        </h2>
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Command</span><span data-lang="ko">명령어</span></th>
+              <th><span data-lang="en">Description</span><span data-lang="ko">설명</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>/memory list</code></td>
+              <td>
+                <span data-lang="en">List all memories with id, template, summary, recall count, and score</span>
+                <span data-lang="ko">id, 템플릿, 요약, 리콜 수, 점수와 함께 모든 메모리 나열</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>/memory show &lt;id&gt;</code></td>
+              <td>
+                <span data-lang="en">Display a specific memory's full content</span>
+                <span data-lang="ko">특정 메모리의 전체 내용 표시</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>/memory save &lt;text&gt;</code></td>
+              <td>
+                <span data-lang="en">Save a manual note (auto-detects template)</span>
+                <span data-lang="ko">수동 메모 저장 (템플릿 자동 감지)</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>/memory delete &lt;id&gt;</code></td>
+              <td>
+                <span data-lang="en">Remove a memory by id</span>
+                <span data-lang="ko">id로 메모리 삭제</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>/memory search &lt;query&gt;</code></td>
+              <td>
+                <span data-lang="en">Search memories by keyword</span>
+                <span data-lang="ko">키워드로 메모리 검색</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>/memory stats</code></td>
+              <td>
+                <span data-lang="en">Show memory statistics (total, by template, total recalls, top recalled)</span>
+                <span data-lang="ko">메모리 통계 표시 (총계, 템플릿별, 총 리콜 수, 최다 리콜)</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- Configuration -->
+      <section class="doc-section" id="configuration">
+        <h2>
+          <span data-lang="en">Configuration</span>
+          <span data-lang="ko">구성</span>
+        </h2>
+        <p data-lang="en">
+          No environment variables or configuration files are required. Workspace Memory operates automatically with per-workspace isolation — each working directory gets its own independent memory store under the agent's data directory.
+        </p>
+        <p data-lang="ko">
+          환경 변수나 구성 파일이 필요하지 않습니다. 워크스페이스 메모리는 자동으로 작동하며 워크스페이스별 격리를 제공합니다 — 각 작업 디렉토리는 에이전트 데이터 디렉토리 아래에 자체 독립적인 메모리 저장소를 갖습니다.
+        </p>
+      </section>
+
+      <!-- Edge Cases -->
+      <section class="doc-section" id="edge-cases">
+        <h2>
+          <span data-lang="en">Edge Cases</span>
+          <span data-lang="ko">엣지 케이스</span>
+        </h2>
+        <ul>
+          <li>
+            <p data-lang="en">
+              <strong>Large memories:</strong> Individual memories are truncated at <code>MAX_RECALL_MEMORY_CHARS</code> (2000 chars). Total recalled context is bounded by <code>MAX_RECALL_CONTEXT_CHARS</code> (8000 chars). Truncated memories include a <code>[Memory truncated to fit prompt budget]</code> marker.
+            </p>
+            <p data-lang="ko">
+              <strong>큰 메모리:</strong> 개별 메모리는 <code>MAX_RECALL_MEMORY_CHARS</code>(2000자)에서 잘립니다. 전체 리콜 컨텍스트는 <code>MAX_RECALL_CONTEXT_CHARS</code>(8000자)로 제한됩니다. 잘린 메모리에는 <code>[Memory truncated to fit prompt budget]</code> 마커가 포함됩니다.
+            </p>
+          </li>
+          <li>
+            <p data-lang="en">
+              <strong>Cross-workspace isolation:</strong> Each workspace is isolated by its encoded cwd path. Memories saved in one project are never visible in another.
+            </p>
+            <p data-lang="ko">
+              <strong>워크스페이스 간 격리:</strong> 각 워크스페이스는 인코딩된 cwd 경로로 격리됩니다. 한 프로젝트에 저장된 메모리는 다른 프로젝트에 표시되지 않습니다.
+            </p>
+          </li>
+          <li>
+            <p data-lang="en">
+              <strong>Compaction survival:</strong> Memories persist across context compaction. They are stored on disk as separate JSON files, independent of the conversation context window.
+            </p>
+            <p data-lang="ko">
+              <strong>컴팩션 생존:</strong> 메모리는 컨텍스트 컴팩션 전반에 걸쳐 지속됩니다. 대화 컨텍스트 윈도우와 독립적으로 별도의 JSON 파일로 디스크에 저장됩니다.
+            </p>
+          </li>
+          <li>
+            <p data-lang="en">
+              <strong>Orphan cleanup:</strong> If a memory file is missing or corrupted, the recall pipeline automatically removes the orphaned index entry.
+            </p>
+            <p data-lang="ko">
+              <strong>고아 정리:</strong> 메모리 파일이 누락되거나 손상된 경우, 리콜 파이프라인이 자동으로 고아 인덱스 항목을 제거합니다.
+            </p>
+          </li>
+          <li>
+            <p data-lang="en">
+              <strong>Index caching:</strong> The index is cached in memory per session. File changes from external processes are not reflected until cache invalidation (session restart).
+            </p>
+            <p data-lang="ko">
+              <strong>인덱스 캐싱:</strong> 인덱스는 세션당 메모리에 캐시됩니다. 외부 프로세스의 파일 변경은 캐시 무효화(세션 재시작)까지 반영되지 않습니다.
+            </p>
+          </li>
+        </ul>
+      </section>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/worktree-isolation.html
+++ b/docs/features/worktree-isolation.html
@@ -1,0 +1,494 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Worktree Isolation — ROACH PI</title>
+  <meta name="description" content="Deep-dive into ROACH PI worktree isolation — temporary git worktrees for subagent and team worker edit isolation with automatic diff capture.">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+  <!-- Language Toggle -->
+  <div class="lang-toggle" id="langToggle">
+    <button class="active" onclick="setLang('en')">EN</button>
+    <button onclick="setLang('ko')">KR</button>
+  </div>
+
+  <script>
+    function setLang(lang) {
+      if (lang === 'ko') {
+        document.body.classList.add('lang-ko');
+      } else {
+        document.body.classList.remove('lang-ko');
+      }
+      var btns = document.querySelectorAll('#langToggle button');
+      btns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
+    }
+  </script>
+
+  <!-- Navigation -->
+  <nav>
+    <div class="container">
+      <ul>
+        <li><a href="../index.html">← <span data-lang="en">ROACH PI</span><span data-lang="ko">ROACH PI</span></a></li>
+        <li><a href="workspace-memory.html"><span data-lang="en">Workspace Memory</span><span data-lang="ko">워크스페이스 메모리</span></a></li>
+        <li><a href="compaction.html"><span data-lang="en">Compaction</span><span data-lang="ko">컴팩션</span></a></li>
+        <li><a href="team-mode.html"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="code-review.html"><span data-lang="en">Code Review</span><span data-lang="ko">코드 리뷰</span></a></li>
+        <li><a href="sandboxed-bash.html"><span data-lang="en">Sandboxed Bash</span><span data-lang="ko">샌드박스 Bash</span></a></li>
+        <li><a href="worktree-isolation.html" class="active"><span data-lang="en">Worktree</span><span data-lang="ko">워크트리</span></a></li>
+        <li><a href="power-tools.html"><span data-lang="en">Power Tools</span><span data-lang="ko">파워 도구</span></a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Page Content -->
+  <div class="doc-container">
+
+    <!-- Sidebar -->
+    <div class="doc-sidebar">
+      <ul>
+        <li><a href="#overview"><span data-lang="en">Overview</span><span data-lang="ko">개요</span></a></li>
+        <li><a href="#how-it-works"><span data-lang="en">How It Works</span><span data-lang="ko">작동 방식</span></a></li>
+        <li><a href="#diff-capture"><span data-lang="en">Diff Capture</span><span data-lang="ko">Diff 캡처</span></a></li>
+        <li><a href="#cleanup-states"><span data-lang="en">Cleanup States</span><span data-lang="ko">정리 상태</span></a></li>
+        <li><a href="#subagents"><span data-lang="en">Subagents</span><span data-lang="ko">서브에이전트</span></a></li>
+        <li><a href="#team-mode"><span data-lang="en">Team Mode</span><span data-lang="ko">팀 모드</span></a></li>
+        <li><a href="#edge-cases"><span data-lang="en">Edge Cases</span><span data-lang="ko">엣지 케이스</span></a></li>
+      </ul>
+    </div>
+
+    <!-- Main Content -->
+    <div class="doc-with-sidebar doc-prose">
+
+      <!-- Title -->
+      <h1 style="margin-bottom: 0.5rem;">
+        <span data-lang="en">Worktree Isolation</span>
+        <span data-lang="ko">워크트리 격리</span>
+      </h1>
+      <p style="color: #888; text-transform: uppercase; font-size: 0.85rem; font-weight: 700; margin-bottom: 2rem;">
+        <span data-lang="en">Developer Deep Dive</span>
+        <span data-lang="ko">개발자 심층 가이드</span>
+      </p>
+
+      <!-- Overview -->
+      <div class="doc-section" id="overview">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Overview</span>
+          <span data-lang="ko">개요</span>
+        </h2>
+
+        <p data-lang="en">
+          ROACH PI uses <strong>temporary git worktrees</strong> to isolate subagent and team worker edits from the main checkout. Every subagent or team worker that requests worktree isolation runs inside a detached worktree — a separate working directory backed by the same repository object store.
+        </p>
+        <p data-lang="ko">
+          ROACH PI는 서브에이전트와 팀 워커의 편집을 메인 체크아웃에서 격리하기 위해 <strong>임시 git 워크트리</strong>를 사용합니다. 워크트리 격리를 요청하는 모든 서브에이전트나 팀 워커는 디태치된 워크트리 — 동일한 저장소 객체 저장소를 기반으로 하는 별도의 작업 디렉토리 — 에서 실행됩니다.
+        </p>
+
+        <p data-lang="en">
+          After the run completes, a <strong>complete diff artifact</strong> is captured before the worktree is cleaned up. This gives you a full record of every change the agent made — files added, modified, or deleted — without any risk of polluting your working tree.
+        </p>
+        <p data-lang="ko">
+          실행이 완료된 후, 워크트리가 정리되기 전에 <strong>완전한 diff 아티팩트</strong>가 캡처됩니다. 작업 트리를 오염시킬 위험 없이 에이전트가 수행한 모든 변경 — 추가, 수정 또는 삭제된 파일 — 에 대한 전체 기록을 얻을 수 있습니다.
+        </p>
+
+        <div class="doc-callout doc-callout-info">
+          <div class="doc-callout-title">
+            <span data-lang="en">● Key Benefit</span>
+            <span data-lang="ko">● 핵심 이점</span>
+          </div>
+          <p data-lang="en" style="margin-bottom: 0;">
+            Even if a subagent makes destructive changes (deletes files, breaks builds), your main checkout remains untouched. The diff artifact preserves the full change set for review or replay.
+          </p>
+          <p data-lang="ko" style="margin-bottom: 0;">
+            서브에이전트가 파괴적인 변경을 수행하더라도(파일 삭제, 빌드 실패), 메인 체크아웃은 영향을 받지 않습니다. Diff 아티팩트는 검토 또는 재생을 위한 전체 변경 세트를 보존합니다.
+          </p>
+        </div>
+      </div>
+
+      <!-- How It Works -->
+      <div class="doc-section" id="how-it-works">
+        <h2>
+          <span class="icon">▶</span>
+          <span data-lang="en">How It Works</span>
+          <span data-lang="ko">작동 방식</span>
+        </h2>
+
+        <p data-lang="en">
+          The worktree lifecycle follows a strict sequence of steps:
+        </p>
+        <p data-lang="ko">
+          워크트리 라이프사이클은 다음 엄격한 단계 순서를 따릅니다:
+        </p>
+
+        <ol class="step-list">
+
+          <li>
+            <h3>
+              <code>git rev-parse --show-toplevel</code>
+              <span data-lang="en"> — Find git root</span>
+              <span data-lang="ko"> — Git 루트 찾기</span>
+            </h3>
+            <p data-lang="en">
+              Resolve the repository root directory. All subsequent git operations use this path.
+            </p>
+            <p data-lang="ko">
+              저장소 루트 디렉토리를 확인합니다. 이후 모든 git 작업은 이 경로를 사용합니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <code>mkdtemp(tmpdir(), pi-subagent-worktree-${runId}-)</code>
+              <span data-lang="en"> — Create temp directory</span>
+              <span data-lang="ko"> — 임시 디렉토리 생성</span>
+            </h3>
+            <p data-lang="en">
+              Allocate a unique temporary directory in the system temp folder. The <code>runId</code> ensures no collisions between concurrent runs.
+            </p>
+            <p data-lang="ko">
+              시스템 임시 폴더에 고유한 임시 디렉토리를 할당합니다. <code>runId</code>는 동시 실행 간 충돌을 방지합니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <code>git worktree add --detach &lt;path&gt; HEAD</code>
+              <span data-lang="en"> — Create detached worktree</span>
+              <span data-lang="ko"> — 디태치된 워크트리 생성</span>
+            </h3>
+            <p data-lang="en">
+              Create a detached worktree at the current <code>HEAD</code> commit. No branch is created — the worktree starts as a clean mirror of the current repository state.
+            </p>
+            <p data-lang="ko">
+              현재 <code>HEAD</code> 커밋에서 디태치된 워크트리를 생성합니다. 브랜치는 생성되지 않습니다 — 워크트리는 현재 저장소 상태의 깨끗한 미러로 시작합니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <span data-lang="en">Subagent/team worker <code>cwd</code> mapped into worktree</span>
+              <span data-lang="ko">서브에이전트/팀 워커 <code>cwd</code>를 워크트리에 매핑</span>
+            </h3>
+            <p data-lang="en">
+              The agent's working directory is translated from the main checkout path to the equivalent path inside the worktree. All file reads, writes, and command executions happen in isolation.
+            </p>
+            <p data-lang="ko">
+              에이전트의 작업 디렉토리가 메인 체크아웃 경로에서 워크트리 내부의 해당 경로로 변환됩니다. 모든 파일 읽기, 쓰기 및 명령 실행이 격리된 상태에서 이루어집니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <span data-lang="en">Capture diff artifacts</span>
+              <span data-lang="ko">Diff 아티팩트 캡처</span>
+            </h3>
+            <p data-lang="en">
+              After the agent finishes: capture <code>git status --short</code>, <code>git diff --stat</code>, <code>git diff</code>, and <code>git diff --cached</code> from the worktree.
+            </p>
+            <p data-lang="ko">
+              에이전트 완료 후: 워크트리에서 <code>git status --short</code>, <code>git diff --stat</code>, <code>git diff</code>, <code>git diff --cached</code>를 캡처합니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <span data-lang="en">Write <code>worktree.diff.md</code> to artifact directory</span>
+              <span data-lang="ko">아티팩트 디렉토리에 <code>worktree.diff.md</code> 작성</span>
+            </h3>
+            <p data-lang="en">
+              All captured output is written to <code>&lt;artifactDir&gt;/worktree.diff.md</code> in a structured markdown format.
+            </p>
+            <p data-lang="ko">
+              캡처된 모든 출력이 구조화된 마크다운 형식으로 <code>&lt;artifactDir&gt;/worktree.diff.md</code>에 작성됩니다.
+            </p>
+          </li>
+
+          <li>
+            <h3>
+              <code>git worktree remove --force &lt;path&gt;</code>
+              <span data-lang="en"> — Cleanup worktree</span>
+              <span data-lang="ko"> — 워크트리 정리</span>
+            </h3>
+            <p data-lang="en">
+              Remove the temporary worktree. The <code>--force</code> flag handles uncommitted changes and locked files. The temp directory is then deleted.
+            </p>
+            <p data-lang="ko">
+              임시 워크트리를 제거합니다. <code>--force</code> 플래그는 커밋되지 않은 변경과 잠긴 파일을 처리합니다. 그 후 임시 디렉토리가 삭제됩니다.
+            </p>
+          </li>
+
+        </ol>
+      </div>
+
+      <!-- Diff Capture -->
+      <div class="doc-section" id="diff-capture">
+        <h2>
+          <span class="icon">■</span>
+          <span data-lang="en">Diff Capture Format</span>
+          <span data-lang="ko">Diff 캡처 형식</span>
+        </h2>
+
+        <p data-lang="en">
+          The diff artifact is written as a structured markdown file. This is the exact format produced at <code>&lt;artifactDir&gt;/worktree.diff.md</code>:
+        </p>
+        <p data-lang="ko">
+          Diff 아티팩트는 구조화된 마크다운 파일로 작성됩니다. <code>&lt;artifactDir&gt;/worktree.diff.md</code>에 생성되는 정확한 형식입니다:
+        </p>
+
+        <div class="doc-code"># Worktree Diff
+Worktree: &lt;path&gt;
+Git root: &lt;gitRoot&gt;
+Max captured diff buffer: 1048576 bytes
+
+## Status
+&lt;git status --short output&gt;
+
+## Diff Stat
+&lt;git diff --stat output&gt;
+
+## Unstaged Diff
+&lt;git diff output&gt;
+
+## Staged Diff
+&lt;git diff --cached output&gt;</div>
+
+        <div class="doc-callout doc-callout-warn">
+          <div class="doc-callout-title">
+            <span data-lang="en">● Buffer Limit</span>
+            <span data-lang="ko">● 버퍼 제한</span>
+          </div>
+          <p data-lang="en" style="margin-bottom: 0;">
+            The total diff output is capped at <strong>1,048,576 bytes</strong> (1 MB). If the combined unstaged and staged diff exceeds this limit, the output is truncated. The header always indicates the max buffer size so consumers know truncation is possible.
+          </p>
+          <p data-lang="ko" style="margin-bottom: 0;">
+            결합된 diff 출력은 <strong>1,048,576 바이트</strong>(1 MB)로 제한됩니다. 결합된 unstaged 및 staged diff가 이 한도를 초과하면 출력이 잘립니다. 헤더에 항상 최대 버퍼 크기가 표시되어 소비자가 잘림 가능성을 알 수 있습니다.
+          </p>
+        </div>
+      </div>
+
+      <!-- Cleanup States -->
+      <div class="doc-section" id="cleanup-states">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Cleanup States</span>
+          <span data-lang="ko">정리 상태</span>
+        </h2>
+
+        <p data-lang="en">
+          The worktree cleanup process tracks its outcome as one of four states:
+        </p>
+        <p data-lang="ko">
+          워크트리 정리 프로세스는 결과를 다음 네 가지 상태 중 하나로 추적합니다:
+        </p>
+
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">State</span><span data-lang="ko">상태</span></th>
+              <th><span data-lang="en">When</span><span data-lang="ko">발생 시점</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>not-needed</code></td>
+              <td>
+                <span data-lang="en">Worktree was never created (worktree isolation disabled or creation was skipped).</span>
+                <span data-lang="ko">워크트리가 생성되지 않음(워크트리 격리 비활성화 또는 생성 생략).</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>removed</code></td>
+              <td>
+                <span data-lang="en">Successfully cleaned up via <code>git worktree remove --force</code> followed by temp directory deletion.</span>
+                <span data-lang="ko"><code>git worktree remove --force</code> 및 임시 디렉토리 삭제로 성공적으로 정리됨.</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>failed</code></td>
+              <td>
+                <span data-lang="en"><code>git worktree remove --force</code> failed. The worktree and temp directory may still exist on disk.</span>
+                <span data-lang="ko"><code>git worktree remove --force</code> 실패. 워크트리와 임시 디렉토리가 디스크에 남아있을 수 있음.</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>kept</code></td>
+              <td>
+                <span data-lang="en">Diff capture required the worktree to be preserved (e.g. the diff artifact needs the worktree to remain accessible for post-processing).</span>
+                <span data-lang="ko">Diff 캡처로 인해 워크트리 보존이 필요함(예: diff 아티팩트가 후처리를 위해 워크트리에 접근 가능해야 함).</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Using with Subagents -->
+      <div class="doc-section" id="subagents">
+        <h2>
+          <span class="icon">★</span>
+          <span data-lang="en">Using with Subagents</span>
+          <span data-lang="ko">서브에이전트와 함께 사용</span>
+        </h2>
+
+        <p data-lang="en">
+          Enable worktree isolation for individual subagent calls by setting <code>worktree: true</code> in the subagent tool options:
+        </p>
+        <p data-lang="ko">
+          서브에이전트 도구 옵션에 <code>worktree: true</code>를 설정하여 개별 서브에이전트 호출에 대해 워크트리 격리를 활성화합니다:
+        </p>
+
+        <div class="doc-code">subagent({
+  agent: 'worker',
+  task: 'Refactor the auth module',
+  worktree: true,        <span class="comment">// enable worktree isolation</span>
+  output: 'artifacts/'   <span class="comment">// diff written to artifacts/worktree.diff.md</span>
+})</div>
+
+        <p data-lang="en">
+          The subagent runs entirely inside the worktree. All file edits, new files, and deletions are isolated. When the subagent finishes, the diff is automatically captured to the specified <code>artifactDir</code>.
+        </p>
+        <p data-lang="ko">
+          서브에이전트는 워크트리 내부에서 완전히 실행됩니다. 모든 파일 편집, 새 파일 및 삭제가 격리됩니다. 서브에이전트가 완료되면 diff가 지정된 <code>artifactDir</code>에 자동으로 캡처됩니다.
+        </p>
+      </div>
+
+      <!-- Using with Team Mode -->
+      <div class="doc-section" id="team-mode">
+        <h2>
+          <span class="icon">◆</span>
+          <span data-lang="en">Using with Team Mode</span>
+          <span data-lang="ko">팀 모드와 함께 사용</span>
+        </h2>
+
+        <p data-lang="en">
+          In team mode, set the worktree policy via the <code>/team</code> command:
+        </p>
+        <p data-lang="ko">
+          팀 모드에서는 <code>/team</code> 명령을 통해 워크트리 정책을 설정합니다:
+        </p>
+
+        <table class="doc-table">
+          <thead>
+            <tr>
+              <th><span data-lang="en">Policy</span><span data-lang="ko">정책</span></th>
+              <th><span data-lang="en">Behavior</span><span data-lang="ko">동작</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>on</code></td>
+              <td>
+                <span data-lang="en">Always use worktree isolation for every team worker. Diffs are captured per-worker.</span>
+                <span data-lang="ko">모든 팀 워커에 대해 항상 워크트리 격리 사용. Diff가 워커별로 캡처됨.</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>auto</code></td>
+              <td>
+                <span data-lang="en">Use worktree isolation if available (git repository detected, worktree creation succeeds). Falls back to no isolation gracefully.</span>
+                <span data-lang="ko">사용 가능한 경우 워크트리 격리 사용(git 저장소 감지, 워크트리 생성 성공). 격리 없이 우아하게 폴백.</span>
+              </td>
+            </tr>
+            <tr>
+              <td><code>off</code></td>
+              <td>
+                <span data-lang="en">No worktree isolation. Team workers edit directly in the main checkout.</span>
+                <span data-lang="ko">워크트리 격리 없음. 팀 워커가 메인 체크아웃에서 직접 편집.</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="doc-code">/team worktree-policy=on  refactor-auth implement-tests</div>
+
+        <p data-lang="en">
+          Each team worker gets its own isolated worktree. Diffs are captured to per-worker artifact directories, so you can review each worker's changes independently.
+        </p>
+        <p data-lang="ko">
+          각 팀 워커는 자체 격리된 워크트리를 갖습니다. Diff가 워커별 아티팩트 디렉토리에 캡처되므로 각 워커의 변경을 독립적으로 검토할 수 있습니다.
+        </p>
+      </div>
+
+      <!-- Edge Cases -->
+      <div class="doc-section" id="edge-cases">
+        <h2>
+          <span class="icon">●</span>
+          <span data-lang="en">Edge Cases</span>
+          <span data-lang="ko">엣지 케이스</span>
+        </h2>
+
+        <h3>
+          <span data-lang="en">Worktree Creation Failure</span>
+          <span data-lang="ko">워크트리 생성 실패</span>
+        </h3>
+        <p data-lang="en">
+          If <code>git worktree add</code> fails (e.g. the repository is in a state that doesn't support worktrees, or the temp directory is unavailable), the system <strong>falls back to no isolation</strong>. The agent runs in the main checkout as usual. This is logged but does not fail the run.
+        </p>
+        <p data-lang="ko">
+          <code>git worktree add</code>가 실패하면(예: 저장소가 워크트리를 지원하지 않는 상태이거나 임시 디렉토리를 사용할 수 없음), 시스템은 <strong>격리 없이 폴백</strong>합니다. 에이전트가 평소처럼 메인 체크아웃에서 실행됩니다. 이는 로그에 기록되지만 실행을 실패시키지 않습니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Diff Buffer Overflow</span>
+          <span data-lang="ko">Diff 버퍼 오버플로우</span>
+        </h3>
+        <p data-lang="en">
+          The combined diff output is capped at <strong>1,048,576 bytes</strong> (1 MB). If the agent generates a diff larger than this, the output is truncated at the buffer boundary. The artifact header always records the max buffer size so consumers can detect potential truncation.
+        </p>
+        <p data-lang="ko">
+          결합된 diff 출력은 <strong>1,048,576 바이트</strong>(1 MB)로 제한됩니다. 에이전트가 이보다 큰 diff를 생성하면 출력이 버퍼 경계에서 잘립니다. 아티팩트 헤더에 항상 최대 버퍼 크기가 기록되어 소비자가 잠재적 잘림을 감지할 수 있습니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Cleanup Failure</span>
+          <span data-lang="ko">정리 실패</span>
+        </h3>
+        <p data-lang="en">
+          If <code>git worktree remove --force</code> fails (e.g. a process still holds a file handle in the worktree), the cleanup state is set to <code>failed</code>. The failure is <strong>logged but does not fail the run</strong>. The temp directory may remain on disk and will be cleaned up by the OS temp directory reaper.
+        </p>
+        <p data-lang="ko">
+          <code>git worktree remove --force</code>가 실패하면(예: 프로세스가 여전히 워크트리의 파일 핸들을 보유 중), 정리 상태가 <code>failed</code>로 설정됩니다. 실패는 <strong>로그에 기록되지만 실행을 실패시키지 않습니다</strong>. 임시 디렉토리가 디스크에 남을 수 있으며 OS 임시 디렉토리 정리기에 의해 정리됩니다.
+        </p>
+
+        <h3>
+          <span data-lang="en">Concurrent Worktrees</span>
+          <span data-lang="ko">동시 워크트리</span>
+        </h3>
+        <p data-lang="en">
+          Each run uses a unique temp directory suffixed with the <code>runId</code>, so concurrent subagents or team workers never conflict. Git itself supports multiple worktrees on the same repository natively.
+        </p>
+        <p data-lang="ko">
+          각 실행은 <code>runId</code>가 접미사로 붙은 고유한 임시 디렉토리를 사용하므로 동시 서브에이전트나 팀 워커가 충돌하지 않습니다. Git 자체가 동일한 저장소에서 여러 워크트리를 기본적으로 지원합니다.
+        </p>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer>
+    <div class="container">
+      <p>
+        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+      </p>
+      <p style="margin-top: 0.5rem;">
+        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+      </p>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,7 @@
         <li><a href="#quickstart">▶ <span data-lang="en">Quick Start</span><span data-lang="ko">빠른 시작</span></a></li>
         <li><a href="#features">■ <span data-lang="en">Features</span><span data-lang="ko">기능</span></a></li>
         <li><a href="#faq">● <span data-lang="en">FAQ</span><span data-lang="ko">FAQ</span></a></li>
+        <li><a href="features/workspace-memory.html">→ <span data-lang="en">Docs</span><span data-lang="ko">문서</span></a></li>
         <li><a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a></li>
       </ul>
     </div>
@@ -270,10 +271,10 @@
           </div>
           <div class="feature-desc">
             <p data-lang="en">
-              12 bundled agents for exploration, execution, planning, and review. Delegate tasks via single, parallel (max 8 tasks, 4 concurrent), or chain modes with cycle detection and depth guards.
+              18+ bundled agents for exploration, execution, planning, and review. Delegate tasks via single, parallel (max 12 tasks, 10 concurrent), or chain modes with cycle detection and depth guards.
             </p>
             <p data-lang="ko">
-              탐색, 실행, 계획, 리뷰를 위한 12개 번들 에이전트. 사이클 감지 및 깊이 가드와 함께 단일, 병렬(최대 8개 작업, 4개 동시), 체인 모드로 작업을 위임하세요.
+              탐색, 실행, 계획, 리뷰를 위한 18개 이상의 번들 에이전트. 사이클 감지 및 깊이 가드와 함께 단일, 병렬(최대 12개 작업, 10개 동시), 체인 모드로 작업을 위임하세요.
             </p>
           </div>
         </div>
@@ -334,10 +335,10 @@
           </div>
           <div class="feature-desc">
             <p data-lang="en">
-              Microcompaction truncates old tool results. Phase-aware summarization preserves workflow state across compaction. Phase and goal document survive context limits.
+              <a href="features/compaction.html">Microcompaction</a> truncates old tool results. Phase-aware summarization preserves workflow state across compaction. Phase and goal document survive context limits.
             </p>
             <p data-lang="ko">
-              마이크로컴팩션이 오래된 도구 결과를 자릅니다. 단계 인식 요약이 컴팩션 전반에 걸쳐 워크플로 상태를 보존합니다. 단계 및 목표 문서가 컨텍스트 한계를 초과합니다.
+              <a href="features/compaction.html">마이크로컴팩션</a>이 오래된 도구 결과를 자릅니다. 단계 인식 요약이 컴팩션 전반에 걸쳐 워크플로 상태를 보존합니다. 단계 및 목표 문서가 컨텍스트 한계를 초과합니다.
             </p>
           </div>
         </div>
@@ -361,15 +362,15 @@
         <div class="card">
           <span class="feature-icon">★</span>
           <div class="feature-title">
-            <span data-lang="en">11 Behavioral Skills</span>
-            <span data-lang="ko">11개 행동 스킬</span>
+            <span data-lang="en">Behavioral Skills</span>
+            <span data-lang="ko">행동 스킬</span>
           </div>
           <div class="feature-desc">
             <p data-lang="en">
-              Bundled LLM skill rulesets: clarification, plan crafting, run plan, review work, simplify, systematic debugging, Karpathy discipline, Rob Pike optimization, and more.
+              Bundled LLM skill rulesets: clarification, plan crafting, run plan, review work, simplify, systematic debugging, Karpathy discipline, Rob Pike optimization, long-run orchestration, milestone planning, and more.
             </p>
             <p data-lang="ko">
-              번들 LLM 스킬 룰셋: 명확화, 계획 작성, 계획 실행, 작업 리뷰, 단순화, 체계적 디버깅, Karpathy 디사이플린, Rob Pike 최적화 등.
+              번들 LLM 스킬 룰셋: 명확화, 계획 작성, 계획 실행, 작업 리뷰, 단순화, 체계적 디버깅, Karpathy 디사이플린, Rob Pike 최적화, 롱런 오케스트레이션, 마일스톤 계획 등.
             </p>
           </div>
         </div>
@@ -389,11 +390,24 @@
             </p>
           </div>
         </div>
+        <div class="card">
+          <span class="feature-icon">→</span>
+          <div class="feature-title">
+            <span data-lang="en">Full Documentation</span>
+            <span data-lang="ko">전체 문서</span>
+          </div>
+          <div class="feature-desc">
+            <p data-lang="en">
+              Deep-dive docs for every feature: <a href="features/workspace-memory.html">Workspace Memory</a>, <a href="features/compaction.html">Compaction</a>, <a href="features/team-mode.html">Team Mode</a>, <a href="features/code-review.html">Code Review</a>, <a href="features/sandboxed-bash.html">Sandboxed Bash</a>, <a href="features/worktree-isolation.html">Worktree Isolation</a>, and <a href="features/power-tools.html">Power Tools</a>.
+            </p>
+            <p data-lang="ko">
+              모든 기능에 대한 심층 문서: <a href="features/workspace-memory.html">워크스페이스 메모리</a>, <a href="features/compaction.html">컴팩션</a>, <a href="features/team-mode.html">팀 모드</a>, <a href="features/code-review.html">코드 리뷰</a>, <a href="features/sandboxed-bash.html">샌드박스 Bash</a>, <a href="features/worktree-isolation.html">워크트리 격리</a>, <a href="features/power-tools.html">파워 툴</a>.
+            </p>
+          </div>
+        </div>
 
       </div>
     </section>
-
-    <!-- FAQ -->
     <section class="section" id="faq">
       <h2>
         <span class="icon">●</span>
@@ -440,13 +454,13 @@
           <div class="faq-body">
             <p data-lang="en">
               <strong>Single:</strong> One-off tasks sent to a specific agent.<br>
-              <strong>Parallel:</strong> Dispatch multiple agents at once (max 8 tasks, 4 concurrent). Each runs independently.<br>
+              <strong>Parallel:</strong> Dispatch multiple agents at once (max 12 tasks, 10 concurrent). Each runs independently.<br>
               <strong>Chain:</strong> Sequential pipeline where each step receives the previous step's output via <code>{previous}</code> placeholder.<br>
               All modes include cycle detection, depth limits (max 3), and concurrency control.
             </p>
             <p data-lang="ko">
               <strong>단일:</strong> 특정 에이전트에 보내는 일회성 작업.<br>
-              <strong>병렬:</strong> 여러 에이전트를 한 번에 디스패치(최대 8개 작업, 4개 동시). 각각 독립적으로 실행.<br>
+              <strong>병렬:</strong> 여러 에이전트를 한 번에 디스패치(최대 12개 작업, 10개 동시). 각각 독립적으로 실행.<br>
               <strong>체인:</strong> 각 단계가 이전 단계의 출력을 <code>{previous}</code> 플레이스홀더로 받는 순차 파이프라인.<br>
               모든 모드에 사이클 감지, 깊이 제한(최대 3), 동시성 제어가 포함됩니다.
             </p>

--- a/extensions/agentic-harness/editor-composition.ts
+++ b/extensions/agentic-harness/editor-composition.ts
@@ -26,6 +26,8 @@ const SHORTCUT_CLEAR = "\x0b"; // Ctrl+K
 const SHORTCUT_SAVE_KEY = "ctrl+s";
 const SHORTCUT_RESTORE_KEY = "ctrl+r";
 const SHORTCUT_CLEAR_KEY = "ctrl+k";
+const DECORATED_EDITOR_SYMBOL = Symbol.for("roach-pi.editor-composition.decorated-editor");
+const BASE_FACTORY_SYMBOL = Symbol.for("roach-pi.editor-composition.base-factory");
 
 function renderStatusLine(width: number, stash: EditorStash): string {
   const state = stash.hasValue() ? `stash ${stash.getLength()}c` : "stash empty";
@@ -38,6 +40,9 @@ function colorBorder(editor: EditorComponent, theme: EditorTheme): void {
 }
 
 export function decorateEditor(editor: EditorComponent, ui: EditorTextUi, stash: EditorStash = defaultEditorStash): EditorComponent {
+  const decoratedEditor = editor as EditorComponent & Record<symbol, unknown>;
+  if (decoratedEditor[DECORATED_EDITOR_SYMBOL]) return editor;
+
   const originalRender = editor.render.bind(editor);
   editor.render = (width: number) => {
     const lines = originalRender(width);
@@ -67,6 +72,7 @@ export function decorateEditor(editor: EditorComponent, ui: EditorTextUi, stash:
     originalHandleInput(data);
   };
 
+  decoratedEditor[DECORATED_EDITOR_SYMBOL] = true;
   return editor;
 }
 
@@ -76,15 +82,18 @@ export function installEditorComposition(ui: EditorCompositionUi, options: Edito
 
   const editorUi = ui as EditorTextUi;
   const stash = options.stash ?? defaultEditorStash;
-  const previousFactory = ui.getEditorComponent?.();
+  const currentFactory = ui.getEditorComponent?.() as (EditorFactory & Record<symbol, unknown>) | undefined;
+  const previousFactory = (currentFactory?.[BASE_FACTORY_SYMBOL] as EditorFactory | undefined) ?? currentFactory;
 
-  ui.setEditorComponent((tui, theme, keybindings) => {
+  const composedFactory = ((tui, theme, keybindings) => {
     const editor = previousFactory
       ? previousFactory(tui, theme, keybindings)
       : new CustomEditor(tui, theme, keybindings as any);
     colorBorder(editor, theme);
     return decorateEditor(editor, editorUi, stash);
-  });
+  }) as EditorFactory & Record<symbol, unknown>;
+  composedFactory[BASE_FACTORY_SYMBOL] = previousFactory;
+  ui.setEditorComponent(composedFactory);
 }
 
 export const editorCompositionShortcuts = {

--- a/extensions/agentic-harness/tests/editor-composition.test.ts
+++ b/extensions/agentic-harness/tests/editor-composition.test.ts
@@ -80,6 +80,23 @@ describe("editor composition", () => {
     expect(editor.render(80).join("\n")).toContain("stash empty");
   });
 
+  it("does not stack stash status lines when installed repeatedly on reload", () => {
+    let currentFactory: any;
+    const ui = {
+      ...createUi(),
+      getEditorComponent: vi.fn(() => currentFactory),
+      setEditorComponent: vi.fn((factory: any) => { currentFactory = factory; }),
+    };
+
+    installEditorComposition(ui as any, { stash: new EditorStash() });
+    installEditorComposition(ui as any, { stash: new EditorStash() });
+
+    const editor = currentFactory({} as any, theme, {} as any);
+    const statusLines = editor.render(80).filter((line: string) => line.includes("stash empty"));
+
+    expect(statusLines).toHaveLength(1);
+  });
+
   it("keeps the appended status line width-safe", () => {
     const stash = new EditorStash();
     stash.save("x".repeat(100));


### PR DESCRIPTION
## Summary

Add 7 new multi-page HTML documentation files for ROACH PI features, plus update `index.html` with navigation links and refreshed content.

### New pages (`docs/features/`)

| Page | Content |
|------|---------|
| `workspace-memory.html` | Storage architecture, memory templates, scoring algorithm, eviction, `/memory` commands |
| `compaction.html` | Phase-aware summarization, microcompaction, workflow phases, `PI_AGENTIC_MICROCOMPACTION` |
| `team-mode.html` | `/team` command syntax, backends (native/tmux), state file schema, resume, worktree policy |
| `code-review.html` | `/review` + `/ultrareview`, 5 reviewer roles, 3-stage pipeline, report output |
| `sandboxed-bash.html` | `bwrap` (Linux), `sandbox-exec` (macOS), approval flow, sensitive env detection |
| `worktree-isolation.html` | Git worktree lifecycle, diff capture format, cleanup states |
| `power-tools.html` | WebFetch, Editor Stash, Artifacts, Lore Commits, Welcome Banner, Plan Progress TUI |
| `docs.css` | Shared doc-page stylesheet extending design tokens with readability-adapted layout |

### `index.html` updates
- Added "Docs" navigation link
- Updated agent count: 12 → 18+
- Updated parallel limits: max 8/4 → max 12/10 concurrent
- Added "Full Documentation" feature card linking to all 7 pages
- Linked Context Management card to compaction docs
- Updated FAQ with correct parallel limits
- Updated behavioral skills description

### Design
- Neo-brutalist design tokens preserved (thick borders, offset shadows, ASCII icons)
- Doc layout adapted for readability: wider max-width, sidebar navigation, configuration tables
- All pages bilingual EN/KR using existing `data-lang` pattern
- Consistent cross-page navigation between all feature pages
- Responsive breakpoints maintained