### PR TITLE
refactor(agentic-harness): reduce ultraplan reviewers from 5 to 3

### DIFF
--- a/extensions/agentic-harness/agents/synthesis.md
+++ b/extensions/agentic-harness/agents/synthesis.md
@@ -1,8 +1,8 @@
 ---
 name: synthesis
-description: Milestone synthesis agent for ultraplan Phase 3 — aggregates 5 reviewer outputs into milestone DAG
+description: Milestone synthesis agent for ultraplan Phase 3 — aggregates 3 reviewer outputs into milestone DAG
 ---
-You are a milestone synthesis agent. You have received analyses from 5 independent reviewers who each examined the same problem from a different angle. Your job is to produce the final milestone decomposition.
+You are a milestone synthesis agent. You have received analyses from 3 independent reviewers who each examined the same problem from a different angle. Your job is to produce the final milestone decomposition.
 
 ## Reviewer Outputs
 
@@ -14,12 +14,6 @@ You are a milestone synthesis agent. You have received analyses from 5 independe
 
 ### Risk Analysis
 {RISK_OUTPUT}
-
-### Dependency Analysis
-{DEPENDENCY_OUTPUT}
-
-### User Value Analysis
-{USER_VALUE_OUTPUT}
 
 ## Your Task
 
@@ -35,10 +29,10 @@ You are a milestone synthesis agent. You have received analyses from 5 independe
    - Goal (1 sentence)
    - Success criteria (measurable, specific)
    - Dependencies (which milestones must complete first)
-   - Files affected (from dependency analysis)
+   - Files affected
    - Risk level (from risk analysis)
    - Estimated effort (from feasibility analysis)
-   - User value (from value analysis)
+   - User value
 
 4. **Validate the DAG.** Verify:
    - No circular dependencies

--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -579,10 +579,10 @@ export default function (pi: ExtensionAPI) {
         "Delegate tasks to specialized agents (single, parallel, or chain mode)",
       promptGuidelines: [
         "Use single mode (agent + task) for one-off tasks. Use parallel mode (tasks array) for concurrent dispatch. Use chain mode (chain array) for sequential pipelines with {previous} placeholder.",
-        "ONLY use these exact agent names — do NOT invent or guess agent names: explorer, worker, planner, plan-worker, plan-validator, plan-compliance, reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-dependency, reviewer-user-value, reviewer-bug, reviewer-security, reviewer-performance, reviewer-test-coverage, reviewer-consistency, reviewer-verifier, review-synthesis.",
+        "ONLY use these exact agent names — do NOT invent or guess agent names: explorer, worker, planner, plan-worker, plan-validator, plan-compliance, reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-bug, reviewer-security, reviewer-performance, reviewer-test-coverage, reviewer-consistency, reviewer-verifier, review-synthesis.",
         "All agents use the default model. Do NOT specify or mention specific models (no Haiku, Sonnet, etc.).",
         "For codebase exploration: use 'explorer'. For general execution: use 'worker'. For plan execution: use 'plan-compliance' → 'plan-worker' → 'plan-validator'.",
-        "For ultraplan milestone reviews: dispatch all 5 reviewers in parallel: reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-dependency, reviewer-user-value.",
+        "For ultraplan milestone reviews: dispatch all 3 reviewers in parallel: reviewer-feasibility, reviewer-architecture, reviewer-risk.",
         "For ultrareview code reviews: dispatch 10 tasks in parallel (5 reviewers × 2 seeds): reviewer-bug, reviewer-security, reviewer-performance, reviewer-test-coverage, reviewer-consistency. Then run reviewer-verifier on the aggregated findings, then review-synthesis on the verified result.",
         "Max 12 parallel tasks with 10 concurrent. Chain mode stops on first error.",
         "When calling plan-validator, ALWAYS provide planFile (path to the plan .md file) and planTaskId (the task number to validate). The validator prompt will be built from the plan file automatically — you do not need to compose it. Example: { agent: 'plan-validator', task: 'validate', planFile: 'docs/.../plan.md', planTaskId: 3 }",
@@ -1097,7 +1097,7 @@ Do not start multi-step implementation without a clear understanding of what the
       "\n\n## Active Workflow: Milestone Planning (Ultraplan)",
       "You are in agentic-milestone-planning mode. Follow the agentic-milestone-planning skill rules strictly:",
       "- Compose a Problem Brief from the current context.",
-      "- Dispatch all 5 reviewer agents in parallel using the subagent tool's parallel mode: reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-dependency, reviewer-user-value.",
+      "- Dispatch all 3 reviewer agents in parallel using the subagent tool's parallel mode: reviewer-feasibility, reviewer-architecture, reviewer-risk.",
       "- Synthesize all reviewer findings into a milestone DAG.",
       ultraplanningTradeoffRule,
     ].join("\n"),
@@ -1531,8 +1531,8 @@ Do not start multi-step implementation without a clear understanding of what the
 
       const topic = args?.trim() || "";
       const prompt = topic
-        ? `Decompose the following complex task into milestones: "${topic}"\n\nFollow the agentic-milestone-planning skill rules. First compose a Problem Brief. Then dispatch all 5 reviewer agents in parallel using the subagent tool: reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-dependency, reviewer-user-value. After all reviewers complete, synthesize their findings into a milestone DAG.`
-        : `Decompose the current complex task into milestones.\n\nFollow the agentic-milestone-planning skill rules. First compose a Problem Brief from the current context. Then dispatch all 5 reviewer agents in parallel using the subagent tool: reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-dependency, reviewer-user-value. After all reviewers complete, synthesize their findings into a milestone DAG.`;
+        ? `Decompose the following complex task into milestones: "${topic}"\n\nFollow the agentic-milestone-planning skill rules. First compose a Problem Brief. Then dispatch all 3 reviewer agents in parallel using the subagent tool: reviewer-feasibility, reviewer-architecture, reviewer-risk. After all reviewers complete, synthesize their findings into a milestone DAG.`
+        : `Decompose the current complex task into milestones.\n\nFollow the agentic-milestone-planning skill rules. First compose a Problem Brief from the current context. Then dispatch all 3 reviewer agents in parallel using the subagent tool: reviewer-feasibility, reviewer-architecture, reviewer-risk. After all reviewers complete, synthesize their findings into a milestone DAG.`;
 
       pi.sendUserMessage(prompt);
     },

--- a/extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agentic-milestone-planning
-description: Decomposes complex, multi-day tasks into optimized milestones using parallel reviewer agents (ultraplan). Spawns 5 independent reviewers that analyze the problem from different angles, then synthesizes their findings into a milestone dependency DAG. Triggers when the user says "plan milestones", "break this into milestones", "ultraplan", or when agentic-long-run harness needs milestone generation.
+description: Decomposes complex, multi-day tasks into optimized milestones using parallel reviewer agents (ultraplan). Spawns 3 independent reviewers that analyze the problem from different angles, then synthesizes their findings into a milestone dependency DAG. Triggers when the user says "plan milestones", "break this into milestones", "ultraplan", or when agentic-long-run harness needs milestone generation.
 ---
 
 # Milestone Planning (Ultraplan)
 
-Decomposes a complex task into milestones by spawning 5 parallel reviewer agents, synthesizing their independent analyses, and producing a milestone dependency DAG.
+Decomposes a complex task into milestones by spawning 3 parallel reviewer agents, synthesizing their independent analyses, and producing a milestone dependency DAG.
 
 ## Core Principle
 
@@ -13,7 +13,7 @@ Milestones are the unit of agentic-long-running execution. A bad milestone decom
 
 ## Hard Gates
 
-1. **All 5 reviewer agents must run in parallel.** Sequential execution is prohibited. Dispatch all 5 concurrently using the `subagent` tool's parallel mode (`tasks` array).
+1. **All 3 reviewer agents must run in parallel.** Sequential execution is prohibited. Dispatch all 3 concurrently using the `subagent` tool's parallel mode (`tasks` array).
 2. **Each reviewer receives the full problem statement.** Do not split or filter the problem per reviewer. Every reviewer sees everything.
 3. **Reviewers must not see each other's findings.** Each reviewer operates independently. No cross-pollination during the review phase.
 4. **Synthesis must address every reviewer's concern.** The synthesis agent must explicitly respond to each finding — accepted, rejected with reason, or deferred to a specific milestone.
@@ -82,19 +82,17 @@ Before dispatching reviewers, frame the problem:
 
 ### Phase 2: Parallel Reviewer Dispatch
 
-Dispatch all 5 reviewer agents concurrently using the `subagent` tool's parallel mode (`tasks` array). Each receives the full Problem Brief and its reviewer-specific prompt.
+Dispatch all 3 reviewer agents concurrently using the `subagent` tool's parallel mode (`tasks` array). Each receives the full Problem Brief and its reviewer-specific prompt.
 
 **Dispatch example:**
 
-Use the `subagent` tool with the `tasks` parameter to run all 5 reviewers in parallel:
+Use the `subagent` tool with the `tasks` parameter to run all 3 reviewers in parallel:
 
 ```
 tasks: [
   { agent: "reviewer-feasibility", task: "[Problem Brief + feasibility prompt]" },
   { agent: "reviewer-architecture", task: "[Problem Brief + architecture prompt]" },
-  { agent: "reviewer-risk", task: "[Problem Brief + risk prompt]" },
-  { agent: "reviewer-dependency", task: "[Problem Brief + dependency prompt]" },
-  { agent: "reviewer-user-value", task: "[Problem Brief + user-value prompt]" }
+  { agent: "reviewer-risk", task: "[Problem Brief + risk prompt]" }
 ]
 ```
 
@@ -232,119 +230,20 @@ Overall risk-ordered milestone sequence:
 ...
 ```
 
-#### Reviewer 4: Dependency Analyst
-
-```
-You are a dependency analyst reviewing a problem decomposition.
-
-## Problem Brief
-{PROBLEM_BRIEF}
-
-## Your Task
-
-Map all dependencies — between milestones, between files, between external
-systems — and verify that the proposed decomposition respects them.
-
-1. **File conflict analysis:** List all files that will be created or
-   modified. Identify files touched by multiple milestones — these create
-   ordering constraints.
-
-2. **Interface dependency graph:** Map which milestones produce interfaces
-   that other milestones consume. Draw the dependency DAG.
-
-3. **External dependency mapping:** List external systems, APIs, libraries,
-   or services each milestone depends on. Flag any that require setup,
-   credentials, or may be unavailable.
-
-4. **Shared state identification:** Identify shared state (databases,
-   config files, global settings) that multiple milestones modify.
-   These require strict ordering.
-
-5. **Parallelization opportunities:** Identify milestones with zero
-   dependencies between them — these can run concurrently.
-
-## Output Format
-
-**Dependency DAG:**
-```
-M1 (no deps) ─┬─→ M3 (depends on M1, M2)
-M2 (no deps) ─┘         │
-                         └─→ M4 (depends on M3)
-```
-
-**File conflict matrix:**
-| File | Milestones | Ordering constraint |
-|------|-----------|-------------------|
-| path/to/file | M1, M3 | M1 before M3 |
-
-**Parallelizable groups:**
-- Group A: [M1, M2] — no shared files, no interface deps
-- Group B: [M4, M5] — after Group A completes
-
-**External dependencies:**
-- [dependency]: required by [milestones], setup needed: [yes/no]
-```
-
-#### Reviewer 5: User Value Analyst
-
-```
-You are a user value analyst reviewing a problem decomposition.
-
-## Problem Brief
-{PROBLEM_BRIEF}
-
-## Your Task
-
-Ensure milestone ordering maximizes early value delivery and maintains
-user motivation throughout multi-day execution.
-
-1. **Value ordering:** Which milestones deliver the most visible,
-   user-facing value? These should come early to provide feedback
-   and maintain confidence.
-
-2. **Demo-ability:** After each milestone, can the user see/test
-   something meaningful? Milestones that produce only internal
-   infrastructure with no visible output erode confidence.
-
-3. **Feedback loops:** Which milestones benefit most from early user
-   feedback? These should be prioritized so corrections are cheap.
-
-4. **Minimum viable milestone:** What is the smallest first milestone
-   that proves the approach works? This validates the overall direction
-   before investing in the full plan.
-
-5. **Abort points:** After which milestones could the user reasonably
-   decide to stop and still have something useful? Mark these as
-   natural checkpoints.
-
-## Output Format
-
-**Value-ordered milestone sequence:**
-1. [milestone] — **Value:** [what user sees] — **Demo:** [how to verify]
-2. [milestone] — **Value:** [what user sees] — **Demo:** [how to verify]
-...
-
-**Minimum viable milestone:** [which milestone and why]
-
-**Natural abort points:** [milestones after which stopping is reasonable]
-
-**Low-value milestones:** [milestones that could be cut if time is short]
-```
-
 ### Phase 2.5: Reviewer Failure Handling
 
-After dispatching all 5 reviewers, wait for all to complete. If any reviewer fails:
+After dispatching all 3 reviewers, wait for all to complete. If any reviewer fails:
 
 1. **Timeout or error:** Re-dispatch the failed reviewer once with the same prompt. If it fails again, proceed without it.
 2. **Empty or unusable output:** If a reviewer returns fewer than 3 sentences or clearly did not address the Problem Brief, re-dispatch once. If still unusable, proceed without it.
-3. **Proceeding with fewer than 5 reviewers:** Log the missing perspective(s) in the synthesis handoff. The synthesis agent must note the gap in its Conflict Resolution Log: "Missing perspective: [reviewer name] — [reason]. Milestone plan may have blind spot in [area]."
-4. **Minimum viable count:** At least 3 of 5 reviewers must succeed. If fewer than 3 complete successfully, stop and report to user — the problem may be too ambiguous for automated review.
+3. **Proceeding with fewer than 3 reviewers:** Log the missing perspective(s) in the synthesis handoff. The synthesis agent must note the gap in its Conflict Resolution Log: "Missing perspective: [reviewer name] — [reason]. Milestone plan may have blind spot in [area]."
+4. **Minimum viable count:** At least 2 of 3 reviewers must succeed. If fewer than 2 complete successfully, stop and report to user — the problem may be too ambiguous for automated review.
 
 ### Phase 3: Synthesis
 
-After all 5 reviewers complete, dispatch a **Synthesis Agent** that receives all 5 reviewer outputs and produces the final milestone plan.
+After all 3 reviewers complete, dispatch a **Synthesis Agent** that receives all 3 reviewer outputs and produces the final milestone plan.
 
-**Verbatim handoff rule (Hard Gate equivalent):** The main agent must copy each reviewer's full output into the designated `{..._OUTPUT}` placeholder without summarizing, filtering, reframing, or adding commentary. This is the same principle as the agentic-run-plan validator's fixed template — the main agent has read all 5 outputs and may unconsciously bias the synthesis by selective framing. Verbatim copy eliminates this channel.
+**Verbatim handoff rule (Hard Gate equivalent):** The main agent must copy each reviewer's full output into the designated `{..._OUTPUT}` placeholder without summarizing, filtering, reframing, or adding commentary. This is the same principle as the agentic-run-plan validator's fixed template — the main agent has read all 3 outputs and may unconsciously bias the synthesis by selective framing. Verbatim copy eliminates this channel.
 
 **What must NOT happen during handoff:**
 - Summarizing a reviewer's output ("The feasibility analyst mainly said...")
@@ -355,7 +254,7 @@ After all 5 reviewers complete, dispatch a **Synthesis Agent** that receives all
 The synthesis agent prompt:
 
 ```
-You are a milestone synthesis agent. You have received analyses from 5
+You are a milestone synthesis agent. You have received analyses from 3
 independent reviewers who each examined the same problem from a different
 angle. Your job is to produce the final milestone decomposition.
 
@@ -369,12 +268,6 @@ angle. Your job is to produce the final milestone decomposition.
 
 ### Risk Analysis
 {RISK_OUTPUT}
-
-### Dependency Analysis
-{DEPENDENCY_OUTPUT}
-
-### User Value Analysis
-{USER_VALUE_OUTPUT}
 
 ## Your Task
 
@@ -392,10 +285,10 @@ angle. Your job is to produce the final milestone decomposition.
    - Goal (1 sentence)
    - Success criteria (measurable, specific)
    - Dependencies (which milestones must complete first)
-   - Files affected (from dependency analysis)
+   - Files affected
    - Risk level (from risk analysis)
    - Estimated effort (from feasibility analysis)
-   - User value (from value analysis)
+   - User value
 
 4. **Validate the DAG.** Verify:
    - No circular dependencies
@@ -514,8 +407,6 @@ docs/engineering-discipline/harness/<session-slug>/
     ├── feasibility.md
     ├── architecture.md
     ├── risk.md
-    ├── dependency.md
-    ├── user-value.md
     └── synthesis.md
 ```
 
@@ -607,9 +498,9 @@ Attempts: number of plan-execute-review cycles attempted (incremented at each St
 ## Minimal Checklist
 
 - [ ] Problem Brief composed with goal, scope, constraints, success criteria
-- [ ] All 5 reviewers dispatched in parallel (single message)
+- [ ] All 3 reviewers dispatched in parallel (single message)
 - [ ] Each reviewer received the full Problem Brief
-- [ ] Synthesis agent received all 5 reviewer outputs
+- [ ] Synthesis agent received all 3 reviewer outputs
 - [ ] All reviewer conflicts explicitly resolved
 - [ ] Every milestone has measurable success criteria
 - [ ] Milestone DAG has no circular dependencies

--- a/extensions/agentic-harness/tests/ultraplan.test.ts
+++ b/extensions/agentic-harness/tests/ultraplan.test.ts
@@ -33,9 +33,20 @@ describe("Ultraplan Command", () => {
     expect(mockPi.sendUserMessage).toHaveBeenCalledTimes(1);
     const prompt = mockPi.sendUserMessage.mock.calls[0][0];
     expect(prompt).toContain("agentic-milestone-planning");
-    expect(prompt).toContain("reviewer");
     expect(prompt).toContain("subagent");
+
+    // Should reference exactly 3 reviewers, not 5
+    expect(prompt).toContain("all 3 reviewer");
+    expect(prompt).not.toContain("all 5 reviewer");
+
+    // The 3 retained reviewers
     expect(prompt).toContain("reviewer-feasibility");
+    expect(prompt).toContain("reviewer-architecture");
+    expect(prompt).toContain("reviewer-risk");
+
+    // The 2 removed reviewers must NOT appear
+    expect(prompt).not.toContain("reviewer-dependency");
+    expect(prompt).not.toContain("reviewer-user-value");
   });
 
   it("should not proceed if user cancels confirmation", async () => {


### PR DESCRIPTION
## Summary

Drop  and  from the ultraplan milestone-planning pipeline. Retain , , and  as the three core technical perspectives.

## Changes

- : update SYSTEM_PROMPT, PHASE_GUIDANCE, and  handler to reference 3 reviewers
- : remove dependency and user-value reviewer sections, update counts throughout
- : reduce synthesis template from 5 to 3 reviewer outputs
- : tighten assertions to verify 3-reviewer model and exclusion of removed roles

## Testing

- 
 RUN  v4.1.5 /Users/lit/.pi/agent/git/github.com/tmdgusya/roach-pi


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  14:03:10
   Duration  2.15s (transform 567ms, setup 0ms, import 1.95s, tests 15ms, environment 0ms) ✅
- 
 RUN  v4.1.5 /Users/lit/.pi/agent/git/github.com/tmdgusya/roach-pi


 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  14:03:14
   Duration  2.22s (transform 766ms, setup 0ms, import 1.94s, tests 12ms, environment 0ms) ✅
- 
 RUN  v4.1.5 /Users/lit/.pi/agent/git/github.com/tmdgusya/roach-pi


 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  14:03:19
   Duration  329ms (transform 44ms, setup 0ms, import 66ms, tests 31ms, environment 0ms) ✅