### PR TITLE
[codex] Let async subagents declare and join required results

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It is intentionally inspectable: commands, tools, hooks, agents, and skills are 
 ### Subagents and review fleets
 
 - `subagent` runs specialized pi subprocesses in single, parallel, or chain mode.
-- Async subagents can run in the background and be inspected or interrupted later.
+- Async subagents can run in the background, declare when their answer is needed before the final response, and be waited on, inspected, or interrupted later by run id.
 - `/ultrareview` dispatches 10 independent reviewers, then verifies and synthesizes the findings.
 - Optional team mode can coordinate bounded worker batches with durable run state and tmux-backed panes.
 
@@ -150,7 +150,7 @@ Supported modes:
 | Single | One focused investigation or execution task. |
 | Parallel | Independent reviewers, explorers, or workers. |
 | Chain | Sequential pipelines where each step consumes the previous output. |
-| Async | Background tasks that can be checked or interrupted by run id. |
+| Async | Background tasks that can be waited on, checked, or interrupted by run id. Use `asyncDependency: "needed-before-final"` when the lead must join before finalizing. |
 
 Bundled agents include `explorer`, `planner`, `worker`, `plan-compliance`, `plan-worker`, `plan-validator`, reviewer agents for feasibility/architecture/risk/dependency/user value, and review agents for bugs/security/performance/test coverage/consistency.
 

--- a/extensions/agentic-harness/async-registry.ts
+++ b/extensions/agentic-harness/async-registry.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile, mkdir, readdir, rename } from "fs/promises";
 import { join, dirname } from "path";
 import { execFile } from "child_process";
 import { killTmuxPane } from "./tmux.js";
-import { emptyUsage, type AsyncRunRecord, type AsyncRunStatus, type RunProgress, type SingleResult } from "./types.js";
+import { emptyUsage, type AsyncDependency, type AsyncRunRecord, type AsyncRunStatus, type RunProgress, type SingleResult } from "./types.js";
 
 export type RunRegistryListener = (runId: string, record: AsyncRunRecord) => void;
 export type CompletionNotifier = (record: AsyncRunRecord) => void;
@@ -30,7 +30,7 @@ export class RunRegistry {
   private killTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private completionNotifier?: CompletionNotifier;
 
-  register(agent: string, task: string, backend: "native" | "tmux", abortController?: AbortController): string {
+  register(agent: string, task: string, backend: "native" | "tmux", abortController?: AbortController, dependency?: AsyncDependency): string {
     const runId = randomBytes(8).toString("hex");
     const now = new Date().toISOString();
     const record: AsyncRunRecord = {
@@ -38,6 +38,7 @@ export class RunRegistry {
       runId,
       agent,
       task,
+      dependency,
       status: "spawning",
       progress: { usage: emptyUsage(), elapsedMs: 0, startedAt: Date.now() },
       createdAt: now,
@@ -89,6 +90,40 @@ export class RunRegistry {
 
   getStatus(runId: string): AsyncRunRecord | undefined {
     return this.runs.get(runId)?.record;
+  }
+
+  waitForCompletion(runId: string, timeoutMs = 600_000): Promise<{ record?: AsyncRunRecord; timedOut: boolean }> {
+    const record = this.getStatus(runId);
+    if (!record) return Promise.resolve({ record: undefined, timedOut: false });
+    if (isTerminalStatus(record.status)) return Promise.resolve({ record, timedOut: false });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      let unsubscribe: (() => void) | undefined;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const finish = (result: { record?: AsyncRunRecord; timedOut: boolean }) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        unsubscribe?.();
+        resolve(result);
+      };
+
+      unsubscribe = this.subscribe((updatedRunId, updatedRecord) => {
+        if (updatedRunId !== runId) return;
+        if (isTerminalStatus(updatedRecord.status)) {
+          finish({ record: updatedRecord, timedOut: false });
+        }
+      });
+
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          finish({ record: this.getStatus(runId), timedOut: true });
+        }, timeoutMs);
+        timer.unref?.();
+      }
+    });
   }
 
   listActive(): AsyncRunRecord[] {
@@ -232,6 +267,10 @@ export class RunRegistry {
       try { listener(runId, record); } catch { /* ignore listener errors */ }
     }
   }
+}
+
+function isTerminalStatus(status: AsyncRunStatus): boolean {
+  return status === "completed" || status === "failed" || status === "interrupted";
 }
 
 let defaultRegistry: RunRegistry | undefined;

--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -11,7 +11,7 @@ import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { discoverAgents, type SubagentContextMode } from "./agents.js";
 import { runAgent, mapWithConcurrencyLimit, MAX_CONCURRENCY, MAX_PARALLEL_TASKS, resolveDepthConfig, getCycleViolations, spawnAsync } from "./subagent.js";
-import { emptyUsage, isResultError, isResultSuccess, getResultSummaryText, type SingleResult, type SubagentDetails } from "./types.js";
+import { emptyUsage, isResultError, isResultSuccess, getResultSummaryText, type AsyncDependency, type SingleResult, type SubagentDetails } from "./types.js";
 import { renderCall, renderResult } from "./render.js";
 import { parsePlan } from "./plan-parser.js";
 import { buildValidatorPrompt } from "./validator-template.js";
@@ -378,10 +378,14 @@ export default function (pi: ExtensionAPI) {
     planFile: Type.Optional(Type.String({ description: "Path to plan file. Required when agent is plan-validator — the validator prompt is built from this file, not from the task field." })),
     planTaskId: Type.Optional(Type.Number({ description: "Task number in the plan file to validate (e.g. 1 for Task 1). Required when agent is plan-validator." })),
     async: Type.Optional(Type.Boolean({ description: "Execute in background, return runId immediately. Only works with single mode (agent + task)." })),
-    action: Type.Optional(stringEnum(["status", "interrupt"], {
-      description: 'Run management action. "status" lists or inspects runs; "interrupt" stops a run.',
+    asyncDependency: Type.Optional(stringEnum(["background", "needed-before-final"], {
+      description: 'Agent-declared dependency for async:true runs. Use "needed-before-final" when the lead must wait for this answer before finalizing.',
     })),
-    id: Type.Optional(Type.String({ description: "Run ID for status/interrupt actions." })),
+    action: Type.Optional(stringEnum(["status", "interrupt", "wait"], {
+      description: 'Run management action. "status" lists or inspects runs; "interrupt" stops a run; "wait" blocks until a run completes and returns its result.',
+    })),
+    id: Type.Optional(Type.String({ description: "Run ID for status/interrupt/wait actions." })),
+    waitTimeoutMs: Type.Optional(Type.Number({ description: "Maximum milliseconds for action:\"wait\" before returning a timeout. Default 600000. Set 0 to wait indefinitely." })),
   });
 
   type AgentScope = "user" | "project" | "both";
@@ -426,6 +430,11 @@ export default function (pi: ExtensionAPI) {
     worktree?: boolean;
     planFile?: string;
     planTaskId?: number;
+    async?: boolean;
+    asyncDependency?: AsyncDependency;
+    action?: "status" | "interrupt" | "wait";
+    id?: string;
+    waitTimeoutMs?: number;
   };
 
   const makeDetails = (mode: "single" | "parallel") => (results: SingleResult[]): SubagentDetails => ({ mode, results });
@@ -604,6 +613,8 @@ export default function (pi: ExtensionAPI) {
         "ONLY use these exact agent names — do NOT invent or guess agent names: explorer, worker, planner, plan-worker, plan-validator, plan-compliance, reviewer-feasibility, reviewer-architecture, reviewer-risk, reviewer-bug, reviewer-security, reviewer-performance, reviewer-test-coverage, reviewer-consistency, reviewer-verifier, review-synthesis.",
         "All agents use the default model. Do NOT specify or mention specific models (no Haiku, Sonnet, etc.).",
         "For codebase exploration: use 'explorer'. For general execution: use 'worker'. For plan execution: use 'plan-compliance' → 'plan-worker' → 'plan-validator'.",
+        "Use async:true only when the lead can safely continue. If the subagent answer is needed before the final response, set asyncDependency:'needed-before-final' and later call action:'wait' with the returned run id.",
+        "Use action:'wait' to join an async run and retrieve its completed result. Use action:'status' for inspection and action:'interrupt' to stop a running async run.",
         "For ultraplan milestone reviews: dispatch all 3 reviewers in parallel: reviewer-feasibility, reviewer-architecture, reviewer-risk.",
         "For ultrareview code reviews: dispatch 10 tasks in parallel (5 reviewers × 2 seeds): reviewer-bug, reviewer-security, reviewer-performance, reviewer-test-coverage, reviewer-consistency. Then run reviewer-verifier on the aggregated findings, then review-synthesis on the verified result.",
         "Max 12 parallel tasks with 10 concurrent. Chain mode stops on first error.",
@@ -699,6 +710,7 @@ export default function (pi: ExtensionAPI) {
                 `Agent: ${record.agent}`,
                 `Task: ${record.task}`,
                 `Status: ${record.status}`,
+                record.dependency ? `Dependency: ${record.dependency}` : null,
                 `Backend: ${record.backend}`,
                 record.pid ? `PID: ${record.pid}` : null,
                 `Elapsed: ${Math.round(record.progress.elapsedMs / 1000)}s`,
@@ -719,7 +731,7 @@ export default function (pi: ExtensionAPI) {
               };
             }
             const statusText = runs.map(r =>
-              `${r.runId} [${r.status}] ${r.agent}: ${r.task.slice(0, 60)}${r.task.length > 60 ? "..." : ""} (${Math.round(r.progress.elapsedMs / 1000)}s)`
+              `${r.runId} [${r.status}${r.dependency ? `/${r.dependency}` : ""}] ${r.agent}: ${r.task.slice(0, 60)}${r.task.length > 60 ? "..." : ""} (${Math.round(r.progress.elapsedMs / 1000)}s)`
             ).join("\n");
             return {
               content: [{ type: "text" as const, text: `Active runs (${runs.length}):\n${statusText}` }],
@@ -745,6 +757,45 @@ export default function (pi: ExtensionAPI) {
             return {
               content: [{ type: "text" as const, text: `Interrupt signal sent to run ${params.id}.` }],
               details: undefined,
+            };
+          }
+          if (params.action === "wait") {
+            if (!params.id) {
+              return {
+                content: [{ type: "text" as const, text: "Error: wait action requires id parameter." }],
+                details: undefined,
+                isError: true,
+              };
+            }
+            const waitTimeoutMs = params.waitTimeoutMs ?? 600_000;
+            const { record, timedOut } = await registry.waitForCompletion(params.id, waitTimeoutMs);
+            if (!record) {
+              return {
+                content: [{ type: "text" as const, text: `No run found with id: ${params.id}` }],
+                details: undefined,
+                isError: true,
+              };
+            }
+            if (timedOut) {
+              return {
+                content: [{ type: "text" as const, text: `Timed out waiting for run ${record.runId}. Current status: ${record.status}.` }],
+                details: { ...makeDetails("single")([]), asyncRun: record },
+                isError: true,
+              };
+            }
+            if (!record.result) {
+              const failed = record.status !== "completed";
+              return {
+                content: [{ type: "text" as const, text: `Run ${record.runId} finished with status ${record.status} and no captured result.` }],
+                details: { ...makeDetails("single")([]), asyncRun: record },
+                isError: failed,
+              };
+            }
+            const failed = isResultError(record.result);
+            return {
+              content: [{ type: "text" as const, text: getResultSummaryText(record.result, maxOutput) }],
+              details: { ...makeDetails("single")([record.result]), asyncRun: record },
+              isError: failed || undefined,
             };
           }
         }
@@ -917,9 +968,12 @@ export default function (pi: ExtensionAPI) {
               reads,
               progress,
               contextMode: context,
-            }, registry);
+            }, registry, params.asyncDependency);
+            const dependencyText = params.asyncDependency === "needed-before-final"
+              ? "\nDependency: needed-before-final. Call subagent action:\"wait\" with this run id before finalizing dependent work."
+              : "";
             return {
-              content: [{ type: "text" as const, text: `Async run started: ${runId}` }],
+              content: [{ type: "text" as const, text: `Async run started: ${runId}${dependencyText}` }],
               details: {
                 ...makeDetails("single")([{
                   agent,

--- a/extensions/agentic-harness/subagent.ts
+++ b/extensions/agentic-harness/subagent.ts
@@ -5,7 +5,7 @@ import { join, basename, dirname, relative } from "path";
 import { randomBytes } from "crypto";
 import { existsSync } from "fs";
 import type { AgentConfig, SubagentContextMode } from "./agents.js";
-import type { SingleResult, SubagentDetails } from "./types.js";
+import type { AsyncDependency, SingleResult, SubagentDetails } from "./types.js";
 import { emptyUsage, getFinalOutput } from "./types.js";
 import { createArtifactContext, readDeclaredFiles, readFilePrefix, type ArtifactContext } from "./artifacts.js";
 import { captureWorktreeDiff, cleanupWorktree, createWorktree, type WorktreeContext } from "./worktree.js";
@@ -1136,6 +1136,7 @@ export interface SpawnAsyncResult {
 export async function spawnAsync(
   opts: RunAgentOptions,
   registry: RunRegistry = getDefaultRegistry(),
+  dependency?: AsyncDependency,
 ): Promise<SpawnAsyncResult> {
   const abortController = new AbortController();
   const runId = registry.register(
@@ -1143,6 +1144,7 @@ export async function spawnAsync(
     opts.task,
     opts.executionMode === "tmux" ? "tmux" : "native",
     abortController,
+    dependency,
   );
 
   Promise.resolve().then(async () => {

--- a/extensions/agentic-harness/tests/async-registry.test.ts
+++ b/extensions/agentic-harness/tests/async-registry.test.ts
@@ -20,6 +20,13 @@ describe("RunRegistry", () => {
     expect(record!.progress.usage.input).toBe(0);
   });
 
+  it("register records async dependency when provided", () => {
+    const registry = new RunRegistry();
+    const runId = registry.register("test-agent", "test task", "native", undefined, "needed-before-final");
+
+    expect(registry.getStatus(runId)!.dependency).toBe("needed-before-final");
+  });
+
   it("update changes status and pid", () => {
     const registry = new RunRegistry();
     const runId = registry.register("agent", "task", "native");
@@ -144,6 +151,40 @@ describe("RunRegistry", () => {
   it("getStatus returns undefined for unknown runId", () => {
     const registry = new RunRegistry();
     expect(registry.getStatus("nonexistent")).toBeUndefined();
+  });
+
+  it("waitForCompletion resolves immediately for completed runs", async () => {
+    const registry = new RunRegistry();
+    const runId = registry.register("agent", "task", "native");
+    registry.complete(runId, "completed");
+
+    await expect(registry.waitForCompletion(runId)).resolves.toMatchObject({
+      record: expect.objectContaining({ runId, status: "completed" }),
+      timedOut: false,
+    });
+  });
+
+  it("waitForCompletion resolves when a running async run completes", async () => {
+    const registry = new RunRegistry();
+    const runId = registry.register("agent", "task", "native");
+
+    const wait = registry.waitForCompletion(runId, 1000);
+    registry.complete(runId, "completed");
+
+    await expect(wait).resolves.toMatchObject({
+      record: expect.objectContaining({ runId, status: "completed" }),
+      timedOut: false,
+    });
+  });
+
+  it("waitForCompletion times out with the current record", async () => {
+    const registry = new RunRegistry();
+    const runId = registry.register("agent", "task", "native");
+
+    await expect(registry.waitForCompletion(runId, 1)).resolves.toMatchObject({
+      record: expect.objectContaining({ runId, status: "spawning" }),
+      timedOut: true,
+    });
   });
 
   it("update is no-op for unknown runId", () => {

--- a/extensions/agentic-harness/tests/extension.test.ts
+++ b/extensions/agentic-harness/tests/extension.test.ts
@@ -32,6 +32,7 @@ vi.mock("../ui-settings.js", () => ({
 
 import extension from "../index.js";
 import { resolveAgenticUiSettings } from "../ui-settings.js";
+import { getDefaultRegistry } from "../async-registry.js";
 
 const originalSubagentEnv = {
   PI_SUBAGENT_DEPTH: process.env.PI_SUBAGENT_DEPTH,
@@ -144,7 +145,7 @@ describe("Extension Registration", () => {
     expect(tool.name).toBe("subagent");
     expect(tool.promptSnippet).toBeDefined();
     expect(tool.promptGuidelines).toBeDefined();
-    expect(tool.promptGuidelines.length).toBe(8);
+    expect(tool.promptGuidelines.length).toBe(10);
     expect(tool.renderCall).toBeTypeOf("function");
     expect(tool.renderResult).toBeTypeOf("function");
   });
@@ -827,6 +828,12 @@ describe("Validator Information Barrier", () => {
     // Verify schema has planFile and planTaskId properties
     expect(schema.properties.planFile).toBeDefined();
     expect(schema.properties.planTaskId).toBeDefined();
+    expect(schema.properties.asyncDependency).toMatchObject({
+      type: "string",
+      enum: ["background", "needed-before-final"],
+    });
+    expect(schema.properties.action.enum).toEqual(["status", "interrupt", "wait"]);
+    expect(schema.properties.waitTimeoutMs).toBeDefined();
     expect(schema.properties.tasks.items.properties.planFile).toBeDefined();
     expect(schema.properties.tasks.items.properties.planTaskId).toBeDefined();
     expect(schema.properties.chain.items.properties.planFile).toBeDefined();
@@ -841,6 +848,41 @@ describe("Validator Information Barrier", () => {
     expect(subagentTool).toBeDefined();
     const guidelines = subagentTool!.promptGuidelines || [];
     expect(guidelines.some((g: string) => g.includes("planFile") && g.includes("planTaskId"))).toBe(true);
+    expect(guidelines.some((g: string) => g.includes("asyncDependency") && g.includes("needed-before-final"))).toBe(true);
+    expect(guidelines.some((g: string) => g.includes("action:'wait'"))).toBe(true);
+  });
+});
+
+describe("subagent async wait action", () => {
+  it("returns a completed async run result", async () => {
+    const { mockPi, tools } = createMockPi();
+    extension(mockPi);
+    const subagentTool = tools.get("subagent");
+    expect(subagentTool).toBeDefined();
+
+    const registry = getDefaultRegistry();
+    const runId = registry.register("explorer", "inspect issue", "native", undefined, "needed-before-final");
+    registry.complete(runId, "completed", {
+      agent: "explorer",
+      agentSource: "bundled",
+      task: "inspect issue",
+      exitCode: 0,
+      messages: [{ role: "assistant", content: [{ type: "text", text: "root cause found" }] }],
+      stderr: "",
+      usage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 3, turns: 1 },
+    });
+
+    const result = await subagentTool.execute(
+      "wait-call",
+      { action: "wait", id: runId },
+      undefined,
+      undefined,
+      { cwd: process.cwd(), hasUI: false, ui: {} },
+    );
+
+    expect(result.content[0].text).toBe("root cause found");
+    expect(result.details.asyncRun.runId).toBe(runId);
+    expect(result.details.results[0].asyncRunId).toBeUndefined();
   });
 });
 

--- a/extensions/agentic-harness/types.ts
+++ b/extensions/agentic-harness/types.ts
@@ -5,6 +5,7 @@ export interface ToolActivity {
 }
 
 export type AsyncRunStatus = "spawning" | "running" | "completed" | "failed" | "interrupted";
+export type AsyncDependency = "background" | "needed-before-final";
 
 export interface RunProgress {
   lastActivity?: ToolActivity;
@@ -18,6 +19,7 @@ export interface AsyncRunRecord {
   runId: string;
   agent: string;
   task: string;
+  dependency?: AsyncDependency;
   status: AsyncRunStatus;
   pid?: number;
   pgid?: number;


### PR DESCRIPTION
## Summary

- add `asyncDependency` metadata so agents can mark async subagent runs as background-only or needed before the final answer
- add `action: "wait"` to join an async run by id and return its captured result
- update subagent guidance, status output, tests, and README docs for dependency-aware async orchestration

## Root cause

Async subagents returned immediately with only a run id. Lead agents could continue and finalize work without joining dependency-critical subagent results, so late async failures or findings could be missed.

## Impact

Existing `async:true`, `status`, and `interrupt` behavior remains compatible. Agents now have an explicit, test-backed path to declare dependency-critical async work and wait for the result before finalizing.

## Validation

- `cd extensions/agentic-harness && npm test -- --run tests/async-registry.test.ts tests/extension.test.ts`
- `cd extensions/agentic-harness && npm run build`
- `cd extensions/agentic-harness && npm test`
