### PR TITLE
feat: add pi-code-previews as default dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-engineering-discipline-extension",
-  "version": "1.22.1",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-engineering-discipline-extension",
-      "version": "1.22.1",
+      "version": "1.25.0",
       "bundleDependencies": [
         "@code-yeongyu/pi-nested-agents-md",
         "pi-lsp-client"

--- a/package.json
+++ b/package.json
@@ -15,17 +15,20 @@
       "extensions/fff-search/index.ts",
       "extensions/workspace-memory/index.ts",
       "node_modules/@code-yeongyu/pi-nested-agents-md/src/index.ts",
-      "node_modules/pi-lsp-client/src/index.ts"
+      "node_modules/pi-lsp-client/src/index.ts",
+      "node_modules/pi-code-previews/index.ts"
     ]
   },
   "dependencies": {
     "@code-yeongyu/pi-nested-agents-md": "github:code-yeongyu/pi-nested-agents-md",
     "@ff-labs/fff-node": "^0.6.4",
     "@sinclair/typebox": "^0.34.49",
+    "pi-code-previews": "github:mattleong/pi-code-previews",
     "pi-lsp-client": "github:code-yeongyu/pi-lsp-client"
   },
   "bundledDependencies": [
     "@code-yeongyu/pi-nested-agents-md",
+    "pi-code-previews",
     "pi-lsp-client"
   ],
   "devDependencies": {


### PR DESCRIPTION
## Summary

Integrates [pi-code-previews](https://github.com/mattleong/pi-code-previews) into roach-pi's default extension set so users get syntax-highlighted tool call previews automatically without manual install.

## What changed

- **dependencies**: Added  (github:mattleong/pi-code-previews)
- **bundledDependencies**: Added  for packaging
- **pi.extensions**: Registered  in the extensions array

## Why

pi-code-previews makes , , , , , , and AGENTS.md
assets
CHANGELOG.md
CONTRIBUTING.md
docs
extensions
known-issue
linkedin-update.md
node_modules
package-lock.json
package.json
README.md
tasks
TEAM_ARCH.md output easier to scan in the pi TUI. It skips tools already owned by other extensions (like our custom / renderers), so there are no conflicts.

## Risk assessment

- **Low risk**: The extension gracefully skips tools owned by other extensions.
- **Custom renderers preserved**: Our , , , and  custom renderers remain untouched.
- **Optional sandboxed bash**: If  is set, pi-code-previews will detect the sandboxed  as owned by another extension and skip it — built-in bash previews still work.