### PR TITLE
feat: vendor pi-code-previews as internal extension

### DIFF
--- a/extensions/pi-code-previews/LICENSE
+++ b/extensions/pi-code-previews/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi-code-previews/README.md
+++ b/extensions/pi-code-previews/README.md
@@ -1,0 +1,129 @@
+# pi-code-previews
+
+Syntax-highlighted previews for pi's built-in tool calls.
+
+`pi-code-previews` makes `bash`, `read`, `write`, `edit`, `grep`, `find`, and `ls` output easier to scan in the pi TUI without changing what the tools do. If another extension already owns one of those tools, `pi-code-previews` skips that preview instead of conflicting with it.
+
+## Install
+
+Install from npm:
+
+```bash
+pi install npm:pi-code-previews
+```
+
+Install from GitHub:
+
+```bash
+pi install git:github.com/mattleong/pi-code-previews
+```
+
+## Features
+
+- Syntax-highlighted previews for commands, files, diffs, and search results.
+- Clearer `edit` and `write` diffs, including pending edit previews.
+- Readable `grep` results grouped by file.
+- Compact `find` and `ls` path lists with optional icons.
+- Optional visual warnings for risky-looking shell commands and secret-looking output.
+- Configurable themes, line counts, icons, and highlighting behavior.
+
+## Usage
+
+Once installed, previews are enhanced automatically for:
+
+- `bash`
+- `read`
+- `write`
+- `edit`
+- `grep`
+- `find`
+- `ls`
+
+Open settings inside pi with:
+
+```text
+/code-preview-settings
+```
+
+Check status with:
+
+```text
+/code-preview-health
+```
+
+The health panel shows configured tools, active previews, disabled tools, and previews skipped because another extension owns that tool. Individual tool toggles are available in the Preview tools submenu in `/code-preview-settings` and take effect after `/reload`.
+
+Settings are stored globally in Pi's agent config directory:
+
+```text
+$PI_CODING_AGENT_DIR/code-previews.json
+```
+
+When `PI_CODING_AGENT_DIR` is not set, this defaults to:
+
+```text
+~/.pi/agent/code-previews.json
+```
+
+## Environment variables
+
+Optional defaults can be set before pi starts:
+
+```bash
+CODE_PREVIEW_THEME=github-dark
+CODE_PREVIEW_READ_LINES=20
+CODE_PREVIEW_READ_CONTENT=false # true/false, on/off, yes/no, or 1/0
+CODE_PREVIEW_WRITE_LINES=20
+CODE_PREVIEW_EDIT_LINES=120 # or all
+CODE_PREVIEW_WORD_EMPHASIS=all # all, smart, or off
+CODE_PREVIEW_GREP_LINES=40
+CODE_PREVIEW_GREP_RESULTS=false # true/false, on/off, yes/no, or 1/0
+CODE_PREVIEW_FIND_RESULTS=false # true/false, on/off, yes/no, or 1/0
+CODE_PREVIEW_LS_RESULTS=false # true/false, on/off, yes/no, or 1/0
+CODE_PREVIEW_BASH_RESULTS=false # true/false, on/off, yes/no, or 1/0
+CODE_PREVIEW_PATH_LIST_LINES=40
+CODE_PREVIEW_PATH_ICONS=unicode # unicode, nerd, or off
+CODE_PREVIEW_TOOLS=write,edit,grep # comma/space list, all, or none
+```
+
+`CODE_PREVIEW_TOOLS` overrides `codePreview.tools` for the current pi process.
+When result previews are disabled, collapsed successful output is hidden while the tool call stays visible; use pi's expand shortcut to view the output on demand. `CODE_PREVIEW_BASH_RESULTS=false` applies to all successful `bash` output, while grep/find/ls result toggles also hide matching `bash` commands that start with `grep`, `find`, or `ls`.
+
+## Project settings
+
+You can also set defaults in `.pi/settings.json`:
+
+```json
+{
+  "codePreview": {
+    "shikiTheme": "dark-plus",
+    "wordEmphasis": "all",
+    "readContentPreview": false,
+    "grepResultPreview": false,
+    "findResultPreview": false,
+    "lsResultPreview": false,
+    "bashResultPreview": false,
+    "grepCollapsedLines": 40,
+    "pathListCollapsedLines": 40,
+    "pathIcons": "unicode",
+    "tools": ["bash", "write", "edit", "find", "ls"]
+  }
+}
+```
+
+## Screenshot
+
+Write:
+<img width="780" height="482" alt="Screenshot 2026-04-30 at 11 47 26 PM" src="https://github.com/user-attachments/assets/98241dc0-192c-4549-8467-381d0abd0d18" />
+
+Read:
+<img width="781" height="465" alt="Screenshot 2026-04-30 at 11 47 38 PM" src="https://github.com/user-attachments/assets/beabf2e4-e453-4548-bde4-1af9e7f8ce6a" />
+
+Edit:
+<img width="780" height="497" alt="Screenshot 2026-04-30 at 11 47 52 PM" src="https://github.com/user-attachments/assets/b6f17d63-667f-4bfc-acbf-892012b930f4" />
+
+Bash, ls, find:
+<img width="1034" height="276" alt="Screenshot 2026-04-30 at 11 47 59 PM" src="https://github.com/user-attachments/assets/99d769c2-f987-4844-a9de-fe01f2018e52" />
+
+Grep:
+<img width="780" height="541" alt="Screenshot 2026-04-30 at 11 48 10 PM" src="https://github.com/user-attachments/assets/56169abf-deef-4b6f-b647-c2b6a668ac06" />

--- a/extensions/pi-code-previews/index.ts
+++ b/extensions/pi-code-previews/index.ts
@@ -1,0 +1,198 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getSettingsListTheme } from "@mariozechner/pi-coding-agent";
+import { SettingsList, truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import { registerToolRenderers } from "./src/renderers.ts";
+import { getSettingsPath, loadSettingsFromDisk, saveSettingsToDisk } from "./src/settings-store.ts";
+import { createSettingsItems } from "./src/settings-ui.ts";
+import {
+  setCodePreviewSettings,
+  codePreviewSettings,
+  updateSetting,
+  type CodePreviewSettings,
+} from "./src/settings.ts";
+import { getShikiStatus, initializeShiki } from "./src/shiki.ts";
+import {
+  formatActiveCodePreviewTools,
+  formatDisabledCodePreviewTools,
+  formatPendingCodePreviewTools,
+  formatSkippedCodePreviewToolLines,
+} from "./src/tool-status.ts";
+import { type CodePreviewToolName, formatEnabledCodePreviewTools } from "./src/tool-selection.ts";
+
+/**
+ * Syntax-highlighted code previews for pi.
+ */
+export default async function codePreviews(pi: ExtensionAPI) {
+  const savedSettings = await loadSettingsFromDisk();
+  if (savedSettings) setCodePreviewSettings(savedSettings);
+  if (codePreviewSettings.syntaxHighlighting) void initializeShiki(codePreviewSettings.shikiTheme);
+  const registeredTools = new Set<CodePreviewToolName>();
+
+  pi.registerCommand("code-preview-health", {
+    description: "Show code preview renderer health and settings",
+    handler: async (_args, ctx) => {
+      const status = getShikiStatus();
+      const skippedLines = formatSkippedCodePreviewToolLines();
+      const pendingTools = formatPendingCodePreviewTools();
+      const lines = [
+        "Code preview health",
+        `Shiki initialized: ${status.initialized ? "yes" : "no"}`,
+        `Shiki theme: ${codePreviewSettings.shikiTheme}`,
+        `Syntax highlighting: ${codePreviewSettings.syntaxHighlighting ? "on" : "off"}`,
+        `Read content preview: ${codePreviewSettings.readContentPreview ? "on" : "off"}`,
+        `Grep result preview: ${codePreviewSettings.grepResultPreview ? "on" : "off"}`,
+        `Find result preview: ${codePreviewSettings.findResultPreview ? "on" : "off"}`,
+        `Ls result preview: ${codePreviewSettings.lsResultPreview ? "on" : "off"}`,
+        `Bash result preview: ${codePreviewSettings.bashResultPreview ? "on" : "off"}`,
+        `Word-level diff emphasis: ${codePreviewSettings.wordEmphasis}`,
+        `Configured tools: ${formatEnabledCodePreviewTools()}`,
+        `Active previews: ${formatActiveCodePreviewTools()}`,
+        `Skipped previews: ${skippedLines.length ? "" : "none"}`,
+        ...skippedLines,
+        `Disabled by config: ${formatDisabledCodePreviewTools()}`,
+        ...(pendingTools === "none" ? [] : [`Pending registration: ${pendingTools}`]),
+        `Cache: ${status.cacheSize}/${status.cacheLimit}`,
+        `Loaded languages: ${status.loadedLanguages}`,
+        `Pending languages: ${status.pendingLanguages}`,
+        `Max highlight chars: ${status.maxHighlightChars}`,
+        `Path icons: ${codePreviewSettings.pathIcons}`,
+        `Settings file: ${getSettingsPath()}`,
+      ];
+      await ctx.ui.custom(
+        (_tui, theme, _kb, done) =>
+          new HealthPanel(
+            lines.map((line, index) => (index === 0 ? theme.bold(line) : line)).join("\n"),
+            done,
+            (value) => theme.fg("dim", value),
+          ),
+        { overlay: true },
+      );
+    },
+  });
+
+  pi.registerCommand("code-preview-settings", {
+    description: "Configure code preview settings",
+    handler: async (_args, ctx) => {
+      const items = createSettingsItems(codePreviewSettings);
+      await ctx.ui.custom((_tui, _theme, _kb, done) => {
+        let list: SettingsList;
+        list = new SettingsList(
+          items,
+          items.length + 2,
+          getSettingsListTheme(),
+          (id, value) => {
+            const previousTheme = codePreviewSettings.shikiTheme;
+            const resetRequested = id === "resetToDefaults" && value === "reset now";
+            setCodePreviewSettings(updateSetting(codePreviewSettings, id, value));
+            if (resetRequested) syncSettingsListValues(list);
+            if (codePreviewSettings.shikiTheme !== previousTheme)
+              void initializeShiki(codePreviewSettings.shikiTheme);
+            void queueSettingsSave(codePreviewSettings)
+              .then(() => {
+                if (resetRequested)
+                  ctx.ui.notify("Code preview settings reset to defaults", "info");
+              })
+              .catch((error) => {
+                ctx.ui.notify(formatSettingsSaveError(error), "warning");
+              });
+          },
+          () => {
+            void flushSettingsSaveQueue()
+              .catch(() => undefined)
+              .finally(() => done(undefined));
+          },
+        );
+        return list;
+      });
+    },
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    registerToolRenderers(pi, ctx.cwd, { registeredTools });
+  });
+}
+
+class HealthPanel implements Component {
+  private readonly text: string;
+
+  constructor(
+    text: string,
+    private readonly done: (result?: undefined) => void,
+    private readonly border: (value: string) => string,
+  ) {
+    this.text = `${text}\n\nPress any key to close`;
+  }
+
+  render(width: number): string[] {
+    const frameWidth = Math.max(4, width);
+    const innerWidth = frameWidth - 4;
+    const content = this.text.split("\n").map((line) => truncateToWidth(line, innerWidth, "…"));
+    const empty = this.frameLine("", innerWidth);
+    return [
+      this.border(`╭${"─".repeat(frameWidth - 2)}╮`),
+      empty,
+      ...content.map((line) => this.frameLine(line, innerWidth)),
+      empty,
+      this.border(`╰${"─".repeat(frameWidth - 2)}╯`),
+    ];
+  }
+
+  invalidate(): void {
+    // No cached rendering state.
+  }
+
+  handleInput(): void {
+    this.done();
+  }
+
+  private frameLine(line: string, innerWidth: number): string {
+    const padding = " ".repeat(Math.max(0, innerWidth - visibleWidth(line)));
+    return `${this.border("│")} ${line}${padding} ${this.border("│")}`;
+  }
+}
+
+let settingsSaveQueue: Promise<void> = Promise.resolve();
+
+function queueSettingsSave(settings: CodePreviewSettings): Promise<void> {
+  const snapshot = cloneSettingsForSave(settings);
+  const nextSave = settingsSaveQueue
+    .catch(() => undefined)
+    .then(() => saveSettingsToDisk(snapshot));
+  settingsSaveQueue = nextSave;
+  return nextSave;
+}
+
+function flushSettingsSaveQueue(): Promise<void> {
+  return settingsSaveQueue;
+}
+
+function cloneSettingsForSave(settings: CodePreviewSettings): CodePreviewSettings {
+  return { ...settings, tools: [...settings.tools] };
+}
+
+function formatSettingsSaveError(error: unknown): string {
+  return `Failed to save code preview settings: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+function syncSettingsListValues(list: SettingsList): void {
+  list.updateValue("shikiTheme", codePreviewSettings.shikiTheme);
+  list.updateValue("diffIntensity", codePreviewSettings.diffIntensity);
+  list.updateValue("wordEmphasis", codePreviewSettings.wordEmphasis);
+  list.updateValue("tools", codePreviewSettings.tools.join(", "));
+  list.updateValue("readContentPreview", codePreviewSettings.readContentPreview ? "on" : "off");
+  list.updateValue("readCollapsedLines", String(codePreviewSettings.readCollapsedLines));
+  list.updateValue("writeCollapsedLines", String(codePreviewSettings.writeCollapsedLines));
+  list.updateValue("editCollapsedLines", String(codePreviewSettings.editCollapsedLines));
+  list.updateValue("grepResultPreview", codePreviewSettings.grepResultPreview ? "on" : "off");
+  list.updateValue("grepCollapsedLines", String(codePreviewSettings.grepCollapsedLines));
+  list.updateValue("findResultPreview", codePreviewSettings.findResultPreview ? "on" : "off");
+  list.updateValue("lsResultPreview", codePreviewSettings.lsResultPreview ? "on" : "off");
+  list.updateValue("pathListCollapsedLines", String(codePreviewSettings.pathListCollapsedLines));
+  list.updateValue("readLineNumbers", codePreviewSettings.readLineNumbers ? "on" : "off");
+  list.updateValue("pathIcons", codePreviewSettings.pathIcons);
+  list.updateValue("bashResultPreview", codePreviewSettings.bashResultPreview ? "on" : "off");
+  list.updateValue("bashWarnings", codePreviewSettings.bashWarnings ? "on" : "off");
+  list.updateValue("syntaxHighlighting", codePreviewSettings.syntaxHighlighting ? "on" : "off");
+  list.updateValue("secretWarnings", codePreviewSettings.secretWarnings ? "on" : "off");
+  list.updateValue("resetToDefaults", "keep current");
+}

--- a/extensions/pi-code-previews/package.json
+++ b/extensions/pi-code-previews/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "pi-code-previews",
+  "version": "0.1.18",
+  "description": "Syntax-highlighted previews for pi tool calls.",
+  "keywords": [
+    "code-preview",
+    "coding-agent",
+    "pi-extension",
+    "pi-package",
+    "syntax-highlighting"
+  ],
+  "homepage": "https://github.com/mattleong/pi-code-previews#readme",
+  "bugs": {
+    "url": "https://github.com/mattleong/pi-code-previews/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mattleong/pi-code-previews.git"
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "README.md",
+    "LICENSE",
+    "tsconfig.json"
+  ],
+  "type": "module",
+  "scripts": {
+    "check": "npm run typecheck && npm run lint && npm run format:check",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint . --deny-warnings",
+    "lint:fix": "oxlint . --fix",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check .",
+    "bench:diff": "tsx bench/diff-rendering.ts",
+    "test": "vitest run",
+    "prepublishOnly": "npm run check && npm test",
+    "pack:dry": "npm pack --dry-run"
+  },
+  "dependencies": {
+    "diff": "^8.0.4",
+    "shiki": "^4.0.2"
+  },
+  "devDependencies": {
+    "oxfmt": "^0.47.0",
+    "oxlint": "^1.62.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/pi-code-previews/src/async-preview.ts
+++ b/extensions/pi-code-previews/src/async-preview.ts
@@ -1,0 +1,47 @@
+import { Text, type Component } from "@mariozechner/pi-tui";
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { escapeControlChars } from "./terminal-text.ts";
+
+const ASYNC_RENDER_CHAR_THRESHOLD = Number.parseInt(
+  process.env.CODE_PREVIEW_ASYNC_RENDER_CHARS ?? "20000",
+  10,
+);
+
+export function shouldRenderAsync(text: string): boolean {
+  return (
+    Number.isFinite(ASYNC_RENDER_CHAR_THRESHOLD) &&
+    ASYNC_RENDER_CHAR_THRESHOLD > 0 &&
+    text.length > ASYNC_RENDER_CHAR_THRESHOLD
+  );
+}
+
+export class AsyncPreview implements Component {
+  private component: Component;
+
+  constructor(message: string, theme: Theme, compute: () => Component, invalidate: () => void) {
+    this.component = new Text(theme.fg("muted", message), 0, 0);
+    setTimeout(() => {
+      try {
+        this.component = compute();
+      } catch (error) {
+        this.component = new Text(
+          theme.fg(
+            "error",
+            escapeControlChars(error instanceof Error ? error.message : String(error)),
+          ),
+          0,
+          0,
+        );
+      }
+      invalidate();
+    }, 0);
+  }
+
+  render(width: number): string[] {
+    return this.component.render(width);
+  }
+
+  invalidate(): void {
+    this.component.invalidate();
+  }
+}

--- a/extensions/pi-code-previews/src/bash-warnings.ts
+++ b/extensions/pi-code-previews/src/bash-warnings.ts
@@ -1,0 +1,29 @@
+export interface BashWarning {
+  label: string;
+  pattern: RegExp;
+}
+
+const BASH_WARNINGS: BashWarning[] = [
+  {
+    label: "recursive delete",
+    pattern:
+      /\brm\b(?=[^;&|]*(?:-[\w-]*r[\w-]*|--recursive)\b)(?=[^;&|]*(?:-[\w-]*f[\w-]*|--force)\b)/i,
+  },
+  { label: "elevated privileges", pattern: /(^|[;&|]\s*)sudo\b/ },
+  { label: "recursive permission change", pattern: /\bchmod\s+(?:-[\w-]*R|--recursive)\b/ },
+  { label: "recursive ownership change", pattern: /\bchown\s+(?:-[\w-]*R|--recursive)\b/ },
+  { label: "discards git changes", pattern: /\bgit\s+reset\s+--hard\b/ },
+  { label: "removes untracked files", pattern: /\bgit\s+clean\s+-[\w-]*[fd][\w-]*\b/ },
+  { label: "removes Docker data", pattern: /\bdocker\s+system\s+prune\b/ },
+  {
+    label: "writes to a system path",
+    pattern: />{1,2}\s*\/?(?:etc|bin|sbin|usr|var|System|Library)\b/,
+  },
+];
+
+export function getBashWarnings(command: string): string[] {
+  const compact = command.replace(/\\\n/g, " ").replace(/\s+/g, " ").trim();
+  return BASH_WARNINGS.filter((warning) => warning.pattern.test(compact)).map(
+    (warning) => warning.label,
+  );
+}

--- a/extensions/pi-code-previews/src/data.ts
+++ b/extensions/pi-code-previews/src/data.ts
@@ -1,0 +1,36 @@
+export function getObjectValue(value: unknown, key: string): unknown {
+  return value && typeof value === "object" ? Reflect.get(value, key) : undefined;
+}
+
+export function isTruncated(details: unknown): boolean {
+  const truncation = getObjectValue(details, "truncation");
+  return getObjectValue(truncation, "truncated") === true;
+}
+
+export function getEditDiff(details: unknown): string | undefined {
+  const diff = getObjectValue(details, "diff");
+  return typeof diff === "string" ? diff : undefined;
+}
+
+export function getPathArg(args: unknown): string {
+  const path = getObjectValue(args, "path") ?? getObjectValue(args, "file_path");
+  return typeof path === "string" ? path : "";
+}
+
+export function getReadStartLine(args: unknown): number {
+  const offset = getObjectValue(args, "offset");
+  return typeof offset === "number" && Number.isFinite(offset) && offset > 0
+    ? Math.floor(offset)
+    : 1;
+}
+
+export function getTextContent(
+  content: Array<{ type: string; text?: string }> | undefined,
+): string {
+  return (
+    content
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text ?? "")
+      .join("\n") ?? ""
+  );
+}

--- a/extensions/pi-code-previews/src/diff-word-emphasis.ts
+++ b/extensions/pi-code-previews/src/diff-word-emphasis.ts
@@ -1,0 +1,438 @@
+import { codePreviewSettings } from "./settings.ts";
+
+export type WordChangeRanges = {
+  removed: Array<[number, number]>;
+  added: Array<[number, number]>;
+};
+
+type DiffToken = {
+  value: string;
+  start: number;
+  end: number;
+};
+
+export function wordEmphasisTokenValues(text: string): string[] {
+  return tokenizeForWordEmphasis(text).map((token) => token.value);
+}
+
+export function changedRanges(before: string, after: string): WordChangeRanges {
+  const beforeTokens = tokenizeForWordEmphasis(before);
+  const afterTokens = tokenizeForWordEmphasis(after);
+  const removedTokens = new Set<number>();
+  const addedTokens = new Set<number>();
+  collectChangedTokenIndexes(
+    beforeTokens,
+    0,
+    beforeTokens.length,
+    afterTokens,
+    0,
+    afterTokens.length,
+    {
+      removed: removedTokens,
+      added: addedTokens,
+    },
+  );
+  const ranges = refinedRangesForChangedTokens(
+    beforeTokens,
+    afterTokens,
+    removedTokens,
+    addedTokens,
+  );
+  return codePreviewSettings.wordEmphasis === "smart"
+    ? filterLowSignalWordEmphasis(before, after, ranges)
+    : ranges;
+}
+
+const WORD_EMPHASIS_EXACT_LCS_MAX_CELLS = 4096;
+
+function tokenizeForWordEmphasis(text: string): DiffToken[] {
+  const tokens: DiffToken[] = [];
+  const tokenPattern = /[A-Za-z_$][\w$]*|\d+(?:\.\d+)?|===|!==|=>|==|!=|<=|>=|&&|\|\||[^\s]/g;
+  for (const match of text.matchAll(tokenPattern)) {
+    const value = match[0] ?? "";
+    const start = match.index ?? 0;
+    tokens.push({ value, start, end: start + value.length });
+  }
+  return tokens;
+}
+
+function isIdentifierToken(value: string): boolean {
+  return /^[A-Za-z_$][\w$]*$/.test(value);
+}
+
+function splitIdentifierToken(value: string, start: number): DiffToken[] {
+  const parts: DiffToken[] = [];
+  const partPattern = /[$_]+|[A-Z]+(?=[A-Z][a-z]|[0-9]|$)|[A-Z]?[a-z]+|\d+|[A-Z]+/g;
+  for (const match of value.matchAll(partPattern)) {
+    const part = match[0] ?? "";
+    const offset = match.index ?? 0;
+    parts.push({ value: part, start: start + offset, end: start + offset + part.length });
+  }
+  return parts.length > 0 ? parts : [{ value, start, end: start + value.length }];
+}
+
+function collectChangedTokenIndexes(
+  before: DiffToken[],
+  beforeStart: number,
+  beforeEnd: number,
+  after: DiffToken[],
+  afterStart: number,
+  afterEnd: number,
+  changed: { removed: Set<number>; added: Set<number> },
+): void {
+  while (
+    beforeStart < beforeEnd &&
+    afterStart < afterEnd &&
+    before[beforeStart]!.value === after[afterStart]!.value
+  ) {
+    beforeStart++;
+    afterStart++;
+  }
+
+  while (
+    beforeStart < beforeEnd &&
+    afterStart < afterEnd &&
+    before[beforeEnd - 1]!.value === after[afterEnd - 1]!.value
+  ) {
+    beforeEnd--;
+    afterEnd--;
+  }
+
+  if (beforeStart === beforeEnd || afterStart === afterEnd) {
+    markTokenRange(changed.removed, beforeStart, beforeEnd);
+    markTokenRange(changed.added, afterStart, afterEnd);
+    return;
+  }
+
+  const beforeLength = beforeEnd - beforeStart;
+  const afterLength = afterEnd - afterStart;
+  if (beforeLength * afterLength <= WORD_EMPHASIS_EXACT_LCS_MAX_CELLS) {
+    collectChangedTokenIndexesByLcs(
+      before,
+      beforeStart,
+      beforeEnd,
+      after,
+      afterStart,
+      afterEnd,
+      changed,
+    );
+    return;
+  }
+
+  const anchors = uniqueOrderedAnchors(before, beforeStart, beforeEnd, after, afterStart, afterEnd);
+  if (anchors.length === 0) {
+    markTokenRange(changed.removed, beforeStart, beforeEnd);
+    markTokenRange(changed.added, afterStart, afterEnd);
+    return;
+  }
+
+  let previousBefore = beforeStart;
+  let previousAfter = afterStart;
+  for (const anchor of anchors) {
+    collectChangedTokenIndexes(
+      before,
+      previousBefore,
+      anchor.beforeIndex,
+      after,
+      previousAfter,
+      anchor.afterIndex,
+      changed,
+    );
+    previousBefore = anchor.beforeIndex + 1;
+    previousAfter = anchor.afterIndex + 1;
+  }
+  collectChangedTokenIndexes(
+    before,
+    previousBefore,
+    beforeEnd,
+    after,
+    previousAfter,
+    afterEnd,
+    changed,
+  );
+}
+
+function collectChangedTokenIndexesByLcs(
+  before: DiffToken[],
+  beforeStart: number,
+  beforeEnd: number,
+  after: DiffToken[],
+  afterStart: number,
+  afterEnd: number,
+  changed: { removed: Set<number>; added: Set<number> },
+): void {
+  const beforeLength = beforeEnd - beforeStart;
+  const afterLength = afterEnd - afterStart;
+  const dp = Array.from({ length: beforeLength + 1 }, () => new Uint16Array(afterLength + 1));
+
+  for (let i = beforeLength - 1; i >= 0; i--) {
+    for (let j = afterLength - 1; j >= 0; j--) {
+      dp[i]![j] =
+        before[beforeStart + i]!.value === after[afterStart + j]!.value
+          ? dp[i + 1]![j + 1]! + 1
+          : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+
+  let i = 0;
+  let j = 0;
+  while (i < beforeLength && j < afterLength) {
+    if (before[beforeStart + i]!.value === after[afterStart + j]!.value) {
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      changed.removed.add(beforeStart + i);
+      i++;
+    } else {
+      changed.added.add(afterStart + j);
+      j++;
+    }
+  }
+  while (i < beforeLength) {
+    changed.removed.add(beforeStart + i);
+    i++;
+  }
+  while (j < afterLength) {
+    changed.added.add(afterStart + j);
+    j++;
+  }
+}
+
+function uniqueOrderedAnchors(
+  before: DiffToken[],
+  beforeStart: number,
+  beforeEnd: number,
+  after: DiffToken[],
+  afterStart: number,
+  afterEnd: number,
+): Array<{ beforeIndex: number; afterIndex: number }> {
+  const beforeCounts = tokenCounts(before, beforeStart, beforeEnd);
+  const afterCounts = tokenCounts(after, afterStart, afterEnd);
+  const afterUniqueIndexes = new Map<string, number>();
+  for (let index = afterStart; index < afterEnd; index++) {
+    const value = after[index]!.value;
+    if (beforeCounts.get(value) === 1 && afterCounts.get(value) === 1)
+      afterUniqueIndexes.set(value, index);
+  }
+  const candidates: Array<{ beforeIndex: number; afterIndex: number }> = [];
+  for (let index = beforeStart; index < beforeEnd; index++) {
+    const value = before[index]!.value;
+    if (beforeCounts.get(value) !== 1 || afterCounts.get(value) !== 1) continue;
+    const afterIndex = afterUniqueIndexes.get(value);
+    if (afterIndex !== undefined) candidates.push({ beforeIndex: index, afterIndex });
+  }
+  return longestIncreasingAfterIndexes(candidates);
+}
+
+function longestIncreasingAfterIndexes(
+  candidates: Array<{ beforeIndex: number; afterIndex: number }>,
+): Array<{ beforeIndex: number; afterIndex: number }> {
+  if (candidates.length <= 1) return candidates;
+  const tails: number[] = [];
+  const previous = Array.from({ length: candidates.length }, () => -1);
+  const tailCandidateIndexes: number[] = [];
+
+  for (let index = 0; index < candidates.length; index++) {
+    const afterIndex = candidates[index]!.afterIndex;
+    let low = 0;
+    let high = tails.length;
+    while (low < high) {
+      const middle = (low + high) >> 1;
+      if (tails[middle]! < afterIndex) low = middle + 1;
+      else high = middle;
+    }
+    if (low > 0) previous[index] = tailCandidateIndexes[low - 1]!;
+    tails[low] = afterIndex;
+    tailCandidateIndexes[low] = index;
+  }
+
+  const ordered: Array<{ beforeIndex: number; afterIndex: number }> = [];
+  let index = tailCandidateIndexes[tails.length - 1] ?? -1;
+  while (index >= 0) {
+    ordered.push(candidates[index]!);
+    index = previous[index] ?? -1;
+  }
+  return ordered.reverse();
+}
+
+function tokenCounts(tokens: DiffToken[], start: number, end: number): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let index = start; index < end; index++) {
+    const value = tokens[index]!.value;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function markTokenRange(changed: Set<number>, start: number, end: number): void {
+  for (let index = start; index < end; index++) changed.add(index);
+}
+
+type TokenGroup = { start: number; end: number };
+
+function refinedRangesForChangedTokens(
+  beforeTokens: DiffToken[],
+  afterTokens: DiffToken[],
+  removedTokens: Set<number>,
+  addedTokens: Set<number>,
+): WordChangeRanges {
+  const removedGroups = changedTokenGroups(beforeTokens, removedTokens);
+  const addedGroups = changedTokenGroups(afterTokens, addedTokens);
+  const removed: Array<[number, number]> = [];
+  const added: Array<[number, number]> = [];
+  const groupCount = Math.max(removedGroups.length, addedGroups.length);
+
+  for (let index = 0; index < groupCount; index++) {
+    const removedGroup = removedGroups[index];
+    const addedGroup = addedGroups[index];
+    const refined =
+      removedGroup && addedGroup
+        ? refinedIdentifierTokenRanges(beforeTokens, removedGroup, afterTokens, addedGroup)
+        : undefined;
+    if (refined) {
+      removed.push(...refined.removed);
+      added.push(...refined.added);
+      continue;
+    }
+    if (removedGroup) removed.push(...rangesForTokenGroup(beforeTokens, removedGroup));
+    if (addedGroup) added.push(...rangesForTokenGroup(afterTokens, addedGroup));
+  }
+
+  return { removed: mergeRanges(removed), added: mergeRanges(added) };
+}
+
+function changedTokenGroups(tokens: DiffToken[], changed: Set<number>): TokenGroup[] {
+  const groups: TokenGroup[] = [];
+  let start: number | undefined;
+  for (let index = 0; index < tokens.length; index++) {
+    if (changed.has(index)) {
+      start ??= index;
+      continue;
+    }
+    if (start !== undefined) {
+      groups.push({ start, end: index });
+      start = undefined;
+    }
+  }
+  if (start !== undefined) groups.push({ start, end: tokens.length });
+  return groups;
+}
+
+function refinedIdentifierTokenRanges(
+  beforeTokens: DiffToken[],
+  beforeGroup: TokenGroup,
+  afterTokens: DiffToken[],
+  afterGroup: TokenGroup,
+): WordChangeRanges | undefined {
+  if (beforeGroup.end - beforeGroup.start !== 1 || afterGroup.end - afterGroup.start !== 1)
+    return undefined;
+  const beforeToken = beforeTokens[beforeGroup.start]!;
+  const afterToken = afterTokens[afterGroup.start]!;
+  if (!isIdentifierToken(beforeToken.value) || !isIdentifierToken(afterToken.value))
+    return undefined;
+  const beforeParts = splitIdentifierToken(beforeToken.value, beforeToken.start);
+  const afterParts = splitIdentifierToken(afterToken.value, afterToken.start);
+  if (beforeParts.length <= 1 && afterParts.length <= 1) return undefined;
+
+  const removed = new Set<number>();
+  const added = new Set<number>();
+  collectChangedTokenIndexes(beforeParts, 0, beforeParts.length, afterParts, 0, afterParts.length, {
+    removed,
+    added,
+  });
+  return {
+    removed: rangesForChangedTokens(beforeParts, removed),
+    added: rangesForChangedTokens(afterParts, added),
+  };
+}
+
+function rangesForTokenGroup(tokens: DiffToken[], group: TokenGroup): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (let index = group.start; index < group.end; index++)
+    appendTokenRange(ranges, tokens[index]!);
+  return ranges;
+}
+
+function rangesForChangedTokens(
+  tokens: DiffToken[],
+  changed: Set<number>,
+): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (let index = 0; index < tokens.length; index++) {
+    if (changed.has(index)) appendTokenRange(ranges, tokens[index]!);
+  }
+  return ranges;
+}
+
+function appendTokenRange(ranges: Array<[number, number]>, token: DiffToken): void {
+  const previous = ranges.at(-1);
+  if (previous && token.start - previous[1] <= 1) previous[1] = token.end;
+  else ranges.push([token.start, token.end]);
+}
+
+function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
+  const merged: Array<[number, number]> = [];
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (previous && range[0] - previous[1] <= 1) previous[1] = range[1];
+    else merged.push([...range]);
+  }
+  return merged;
+}
+
+function filterLowSignalWordEmphasis(
+  before: string,
+  after: string,
+  ranges: WordChangeRanges,
+): WordChangeRanges {
+  const hasRemovedSignal = ranges.removed.some((range) => hasSmartRangeSignal(before, range));
+  const hasAddedSignal = ranges.added.some((range) => hasSmartRangeSignal(after, range));
+  return {
+    removed: ranges.removed.filter((range) =>
+      shouldKeepSmartRange(before.slice(range[0], range[1]), hasAddedSignal),
+    ),
+    added: ranges.added.filter((range) =>
+      shouldKeepSmartRange(after.slice(range[0], range[1]), hasRemovedSignal),
+    ),
+  };
+}
+
+function hasSmartRangeSignal(content: string, range: [number, number]): boolean {
+  return /[A-Za-z0-9_$]/.test(content.slice(range[0], range[1]));
+}
+
+function shouldKeepSmartRange(text: string, oppositeSideHasSignal: boolean): boolean {
+  if (!/[A-Za-z0-9_$]/.test(text)) return false;
+  const tokens = text.match(/[A-Za-z_$][\w$]*|\d+(?:\.\d+)?/g) ?? [];
+  if (tokens.length === 0) return false;
+  if (!oppositeSideHasSignal && tokens.every((token) => LOW_SIGNAL_SYNTAX_TOKENS.has(token)))
+    return false;
+  if (!oppositeSideHasSignal && isWrapperCallNoise(text, tokens)) return false;
+  return true;
+}
+
+const LOW_SIGNAL_SYNTAX_TOKENS = new Set([
+  "as",
+  "async",
+  "await",
+  "const",
+  "else",
+  "export",
+  "from",
+  "function",
+  "if",
+  "import",
+  "let",
+  "return",
+  "var",
+]);
+
+const WRAPPER_CALL_TOKENS = new Set(["filter", "flatMap", "forEach", "map", "reduce"]);
+
+function isWrapperCallNoise(text: string, tokens: string[]): boolean {
+  return (
+    tokens.length === 1 &&
+    WRAPPER_CALL_TOKENS.has(tokens[0]!) &&
+    /^[\s.()[\]{};,]*[A-Za-z_$][\w$]*[\s.()[\]{};,]*$/.test(text)
+  );
+}

--- a/extensions/pi-code-previews/src/diff.ts
+++ b/extensions/pi-code-previews/src/diff.ts
@@ -1,0 +1,641 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import {
+  changedRanges,
+  wordEmphasisTokenValues,
+  type WordChangeRanges,
+} from "./diff-word-emphasis.ts";
+import { codePreviewSettings } from "./settings.ts";
+import { renderWithShiki } from "./shiki.ts";
+import { escapeControlChars, visibleLength, wrapAnsiToWidth } from "./terminal-text.ts";
+
+const DIFF_ADD_MARKER = "\u0000PI_DIFF_ADD\u0000";
+const DIFF_REMOVE_MARKER = "\u0000PI_DIFF_REMOVE\u0000";
+
+export class FullWidthDiffText implements Component {
+  private cachedWidth: number | undefined;
+  private cachedRows: string[] | undefined;
+
+  constructor(
+    private text: string,
+    private readonly theme?: Theme,
+  ) {}
+
+  setText(text: string): void {
+    if (this.text === text) return;
+    this.text = text;
+    this.invalidate();
+  }
+
+  render(width: number): string[] {
+    if (this.cachedWidth === width && this.cachedRows) return this.cachedRows;
+    const rows = this.text.split("\n").flatMap((rawLine) => {
+      const kind = rawLine.startsWith(DIFF_ADD_MARKER)
+        ? "add"
+        : rawLine.startsWith(DIFF_REMOVE_MARKER)
+          ? "remove"
+          : undefined;
+      const line =
+        kind === "add"
+          ? rawLine.slice(DIFF_ADD_MARKER.length)
+          : kind === "remove"
+            ? rawLine.slice(DIFF_REMOVE_MARKER.length)
+            : rawLine;
+
+      const rows = wrapAnsiToWidth(line, width, DIFF_WRAP_ROWS, continuationPrefix(line));
+      if (!kind) return rows.map((row) => truncateToWidth(row, width, ""));
+
+      return rows.map((row) => {
+        const truncated = truncateToWidth(row, width, "");
+        const padding = " ".repeat(Math.max(0, width - visibleWidth(truncated)));
+        return diffLineBg(kind, truncated + padding, this.theme);
+      });
+    });
+    this.cachedWidth = width;
+    this.cachedRows = rows;
+    return rows;
+  }
+
+  invalidate(): void {
+    this.cachedWidth = undefined;
+    this.cachedRows = undefined;
+  }
+}
+
+const DIFF_WRAP_ROWS = envPositiveInteger("CODE_PREVIEW_DIFF_WRAP_ROWS", 3);
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function continuationPrefix(line: string): string {
+  const pipe = line.indexOf("│ ");
+  if (pipe < 0) return "";
+  return " ".repeat(visibleLength(line.slice(0, pipe + 2)));
+}
+
+export function summarizeDiff(diff: string): {
+  additions: number;
+  removals: number;
+  replacements: number;
+  insertions: number;
+  deletions: number;
+  totalLines: number;
+  hunks: number;
+} {
+  let additions = 0;
+  let removals = 0;
+  let replacements = 0;
+  let insertions = 0;
+  let deletions = 0;
+  let hunks = 0;
+  let groupAdditions = 0;
+  let groupRemovals = 0;
+  const lines = diff.split("\n");
+
+  function flushChangeGroup() {
+    if (groupAdditions === 0 && groupRemovals === 0) return;
+    hunks++;
+    if (groupAdditions > 0 && groupRemovals > 0) {
+      replacements++;
+      insertions += Math.max(0, groupAdditions - groupRemovals);
+      deletions += Math.max(0, groupRemovals - groupAdditions);
+    } else if (groupAdditions > 0) {
+      insertions += groupAdditions;
+    } else {
+      deletions += groupRemovals;
+    }
+    groupAdditions = 0;
+    groupRemovals = 0;
+  }
+
+  for (const line of lines) {
+    const isAddition = line.startsWith("+") && !line.startsWith("+++");
+    const isRemoval = line.startsWith("-") && !line.startsWith("---");
+
+    if (isAddition) {
+      additions++;
+      groupAdditions++;
+    } else if (isRemoval) {
+      removals++;
+      groupRemovals++;
+    } else {
+      flushChangeGroup();
+    }
+  }
+  flushChangeGroup();
+
+  return {
+    additions,
+    removals,
+    replacements,
+    insertions,
+    deletions,
+    totalLines: lines.length,
+    hunks,
+  };
+}
+
+export function renderSyntaxHighlightedDiff(
+  diff: string,
+  lang: string | undefined,
+  theme: Theme,
+  limit: number,
+  invalidate?: () => void,
+): string {
+  return renderSyntaxHighlightedDiffWithWordEmphasis(
+    diff,
+    lang,
+    theme,
+    limit,
+    invalidate,
+    codePreviewSettings.wordEmphasis !== "off",
+  );
+}
+
+export function createProgressiveSyntaxHighlightedDiffText(
+  diff: string,
+  lang: string | undefined,
+  theme: Theme,
+  limit: number,
+  options: { decorate?: (body: string) => string; invalidate?: () => void } = {},
+): FullWidthDiffText {
+  const decorate = options.decorate ?? ((body: string) => body);
+  const initialBody = renderSyntaxHighlightedDiffWithWordEmphasis(
+    diff,
+    lang,
+    theme,
+    limit,
+    options.invalidate,
+    codePreviewSettings.wordEmphasis !== "off",
+  );
+  const component = new FullWidthDiffText(decorate(initialBody), theme);
+  return component;
+}
+
+function renderSyntaxHighlightedDiffWithWordEmphasis(
+  diff: string,
+  lang: string | undefined,
+  theme: Theme,
+  limit: number,
+  invalidate: (() => void) | undefined,
+  emphasizeChangedPairs: boolean,
+): string {
+  return renderDiff(diff, {
+    lang,
+    theme,
+    limit,
+    invalidate,
+    syntaxHighlight: true,
+    emphasizeChangedPairs,
+  });
+}
+
+export function renderPlainDiff(diff: string, theme: Theme, limit: number): string {
+  return renderDiff(diff, {
+    theme,
+    limit,
+    syntaxHighlight: false,
+    emphasizeChangedPairs: false,
+  });
+}
+
+type DiffRenderOptions = {
+  lang?: string;
+  theme: Theme;
+  limit: number;
+  invalidate?: () => void;
+  syntaxHighlight: boolean;
+  emphasizeChangedPairs: boolean;
+};
+
+function renderDiff(diff: string, options: DiffRenderOptions): string {
+  const lines = diff.split("\n");
+  const max = Math.min(lines.length, Math.max(0, Math.floor(options.limit)));
+  const out: string[] = [];
+  const lang = options.syntaxHighlight ? options.lang : undefined;
+
+  for (let i = 0; i < max; i++) {
+    const line = lines[i]!;
+    const parsed = parseDiffLine(line);
+    if (!parsed) {
+      out.push(renderSeparator(line, options.theme));
+      continue;
+    }
+
+    if (options.emphasizeChangedPairs && isChangedDiffLine(parsed)) {
+      const block: ParsedDiffLine[] = [];
+      let end = i;
+      while (end < max) {
+        const next = parseDiffLine(lines[end]!);
+        if (!next || !isChangedDiffLine(next)) break;
+        block.push(next);
+        end++;
+      }
+      out.push(...renderChangeBlock(block, lang, options.theme, options.invalidate));
+      i = end - 1;
+      continue;
+    }
+
+    out.push(renderDiffParsedLine(parsed, lang, options.theme, options.invalidate));
+  }
+
+  return out.join("\n");
+}
+
+function renderSeparator(line: string, theme: Theme): string {
+  const safeLine = escapeControlChars(line);
+  const trimmed = safeLine.trim();
+  if (trimmed === "...") return theme.fg("muted", "      --- unchanged lines hidden ---");
+  if (trimmed.startsWith("@@")) return theme.fg("accent", theme.bold(safeLine));
+  if (trimmed.startsWith("---") || trimmed.startsWith("+++")) return theme.fg("muted", safeLine);
+  if (trimmed.startsWith("diff ") || trimmed.startsWith("index "))
+    return theme.fg("muted", safeLine);
+  return theme.fg("toolDiffContext", safeLine);
+}
+
+function renderDiffParsedLine(
+  parsed: ParsedDiffLine,
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+): string {
+  const highlighted = highlightSingleLine(
+    parsed.content.replace(/\t/g, "   "),
+    lang,
+    theme,
+    invalidate,
+  );
+  if (parsed.kind === "+")
+    return `${DIFF_ADD_MARKER}${theme.fg("toolDiffAdded", `+${parsed.lineNumber} │ `)}${highlighted}`;
+  if (parsed.kind === "-")
+    return `${DIFF_REMOVE_MARKER}${theme.fg("toolDiffRemoved", `-${parsed.lineNumber} │ `)}${highlighted}`;
+  return dimAnsi(
+    `${theme.fg("toolDiffContext", ` ${parsed.lineNumber} │ `)}${highlighted || theme.fg("toolDiffContext", "")}`,
+  );
+}
+
+function renderChangeBlock(
+  block: ParsedDiffLine[],
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+): string[] {
+  const removed = block.flatMap((line, index) =>
+    isRemovedDiffLine(line) ? [{ index, line }] : [],
+  );
+  const added = block.flatMap((line, index) => (isAddedDiffLine(line) ? [{ index, line }] : []));
+  const emphasis = new Map<number, { ranges: Array<[number, number]>; kind: "add" | "remove" }>();
+
+  for (const [removedIndex, addedIndex] of matchChangedLines(removed, added)) {
+    const removedLine = block[removedIndex] as RemovedDiffLine;
+    const addedLine = block[addedIndex] as AddedDiffLine;
+    // Compute ranges against the same normalized text that Shiki/fallback rendering displays.
+    // Otherwise tabs or escaped control chars shift the emphasis range by multiple cells.
+    const removedContent = normalizeDiffContent(removedLine.content);
+    const addedContent = normalizeDiffContent(addedLine.content);
+    const ranges = changedRanges(removedContent, addedContent);
+    if (!shouldEmphasizeChangedPair(ranges)) continue;
+    emphasis.set(removedIndex, { ranges: ranges.removed, kind: "remove" });
+    emphasis.set(addedIndex, { ranges: ranges.added, kind: "add" });
+  }
+
+  return block.map((line, index) => {
+    const rendered = renderDiffParsedLine(line, lang, theme, invalidate);
+    const match = emphasis.get(index);
+    return match ? emphasizeChangedSpans(rendered, match.ranges, match.kind) : rendered;
+  });
+}
+
+type IndexedChangedLine<T extends AddedDiffLine | RemovedDiffLine> = { index: number; line: T };
+
+function matchChangedLines(
+  removed: Array<IndexedChangedLine<RemovedDiffLine>>,
+  added: Array<IndexedChangedLine<AddedDiffLine>>,
+): Array<[number, number]> {
+  if (removed.length === 0 || added.length === 0) return [];
+  if (removed.length * added.length > MAX_CHANGED_LINE_PAIR_CELLS)
+    return matchChangedLinesByPosition(removed, added);
+  const removedTokens = removed.map(({ line }) =>
+    similarityTokens(normalizeDiffContent(line.content)),
+  );
+  const addedTokens = added.map(({ line }) => similarityTokens(normalizeDiffContent(line.content)));
+  const scores = removedTokens.map((tokens) =>
+    addedTokens.map((addedLineTokens) => tokenSimilarity(tokens, addedLineTokens)),
+  );
+  const dp = Array.from({ length: removed.length + 1 }, () =>
+    Array.from({ length: added.length + 1 }, () => 0),
+  );
+
+  for (let i = 1; i <= removed.length; i++) {
+    for (let j = 1; j <= added.length; j++) {
+      const score = scores[i - 1]?.[j - 1] ?? 0;
+      const pair =
+        score >= MIN_CHANGED_LINE_PAIR_SCORE
+          ? dp[i - 1]![j - 1]! + score + 0.01
+          : Number.NEGATIVE_INFINITY;
+      dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!, pair);
+    }
+  }
+
+  const pairs: Array<[number, number]> = [];
+  let i = removed.length;
+  let j = added.length;
+  while (i > 0 && j > 0) {
+    const score = scores[i - 1]?.[j - 1] ?? 0;
+    const pair =
+      score >= MIN_CHANGED_LINE_PAIR_SCORE
+        ? dp[i - 1]![j - 1]! + score + 0.01
+        : Number.NEGATIVE_INFINITY;
+    if (Math.abs(dp[i]![j]! - pair) < 1e-9) {
+      pairs.push([i - 1, j - 1]);
+      i--;
+      j--;
+    } else if (dp[i - 1]![j]! >= dp[i]![j - 1]!) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  const similarPairs = pairs.reverse();
+  if (similarPairs.length === 0 && removed.length === 1 && added.length === 1)
+    return [[removed[0]!.index, added[0]!.index]];
+  return addPositionalFallbackPairs(removed, added, scores, similarPairs);
+}
+
+const MIN_CHANGED_LINE_PAIR_SCORE = 0.45;
+const MIN_POSITIONAL_FALLBACK_PAIR_SCORE = 0.28;
+const MAX_CHANGED_LINE_PAIR_CELLS = 256;
+
+function matchChangedLinesByPosition(
+  removed: Array<IndexedChangedLine<RemovedDiffLine>>,
+  added: Array<IndexedChangedLine<AddedDiffLine>>,
+): Array<[number, number]> {
+  const pairs: Array<[number, number]> = [];
+  for (let index = 0; index < Math.min(removed.length, added.length); index++) {
+    const removedTokens = similarityTokens(normalizeDiffContent(removed[index]!.line.content));
+    const addedTokens = similarityTokens(normalizeDiffContent(added[index]!.line.content));
+    if (tokenSimilarity(removedTokens, addedTokens) >= MIN_POSITIONAL_FALLBACK_PAIR_SCORE)
+      pairs.push([removed[index]!.index, added[index]!.index]);
+  }
+  return pairs;
+}
+
+function addPositionalFallbackPairs(
+  removed: Array<IndexedChangedLine<RemovedDiffLine>>,
+  added: Array<IndexedChangedLine<AddedDiffLine>>,
+  scores: number[][],
+  similarPairs: Array<[number, number]>,
+): Array<[number, number]> {
+  const pairs: Array<[number, number]> = [];
+  let removedCursor = 0;
+  let addedCursor = 0;
+  for (const [removedPosition, addedPosition] of similarPairs) {
+    pairs.push(
+      ...positionPairs(
+        removed,
+        added,
+        scores,
+        removedCursor,
+        removedPosition,
+        addedCursor,
+        addedPosition,
+      ),
+    );
+    pairs.push([removed[removedPosition]!.index, added[addedPosition]!.index]);
+    removedCursor = removedPosition + 1;
+    addedCursor = addedPosition + 1;
+  }
+  pairs.push(
+    ...positionPairs(
+      removed,
+      added,
+      scores,
+      removedCursor,
+      removed.length,
+      addedCursor,
+      added.length,
+    ),
+  );
+  return pairs;
+}
+
+function positionPairs(
+  removed: Array<IndexedChangedLine<RemovedDiffLine>>,
+  added: Array<IndexedChangedLine<AddedDiffLine>>,
+  scores: number[][],
+  removedStart: number,
+  removedEnd: number,
+  addedStart: number,
+  addedEnd: number,
+): Array<[number, number]> {
+  const pairs: Array<[number, number]> = [];
+  const count = Math.min(removedEnd - removedStart, addedEnd - addedStart);
+  for (let offset = 0; offset < count; offset++) {
+    const removedPosition = removedStart + offset;
+    const addedPosition = addedStart + offset;
+    const score = scores[removedPosition]?.[addedPosition] ?? 0;
+    if (score < MIN_POSITIONAL_FALLBACK_PAIR_SCORE) continue;
+    pairs.push([removed[removedPosition]!.index, added[addedPosition]!.index]);
+  }
+  return pairs;
+}
+
+function tokenSimilarity(beforeTokens: string[], afterTokens: string[]): number {
+  if (beforeTokens.length === 0 || afterTokens.length === 0)
+    return beforeTokens.length === afterTokens.length ? 1 : 0;
+  const beforeWeight = tokenListWeight(beforeTokens);
+  const afterWeight = tokenListWeight(afterTokens);
+  const remaining = new Map<string, number>();
+  for (const token of beforeTokens) remaining.set(token, (remaining.get(token) ?? 0) + 1);
+  let sharedWeight = 0;
+  for (const token of afterTokens) {
+    const count = remaining.get(token) ?? 0;
+    if (count === 0) continue;
+    sharedWeight += tokenWeight(token);
+    if (count === 1) remaining.delete(token);
+    else remaining.set(token, count - 1);
+  }
+  return (2 * sharedWeight) / (beforeWeight + afterWeight);
+}
+
+function tokenListWeight(tokens: string[]): number {
+  return tokens.reduce((total, token) => total + tokenWeight(token), 0);
+}
+
+function tokenWeight(token: string): number {
+  if (/^[A-Za-z_$][\w$]*$/.test(token)) return 2;
+  if (/^\d+(?:\.\d+)?$/.test(token)) return 1.5;
+  if (/^(?:===|!==|=>|==|!=|<=|>=|&&|\|\||[+\-*\/%<>=!?:]+)$/.test(token)) return 0.75;
+  if (/^[{}()[\].,;]$/.test(token)) return 0.15;
+  return 1;
+}
+
+function similarityTokens(text: string): string[] {
+  return wordEmphasisTokenValues(text);
+}
+
+function dimAnsi(text: string): string {
+  return `\x1b[2m${text}\x1b[22m`;
+}
+
+function diffLineBg(kind: "add" | "remove", line: string, theme?: Theme): string {
+  // Full-width subtle backgrounds for changed lines. Re-apply after foreground
+  // resets emitted by Shiki so token coloring does not punch holes in the bg.
+  if (codePreviewSettings.diffIntensity === "off") return line;
+  const bg =
+    deriveDiffBg(kind, theme, codePreviewSettings.diffIntensity === "medium" ? 0.24 : 0.14) ??
+    (kind === "add"
+      ? codePreviewSettings.diffIntensity === "medium"
+        ? "\x1b[48;2;22;68;40m"
+        : "\x1b[48;2;10;42;26m"
+      : codePreviewSettings.diffIntensity === "medium"
+        ? "\x1b[48;2;78;36;40m"
+        : "\x1b[48;2;50;24;30m");
+  const coloredLine = line
+    .replace(/\x1b\[39m/g, `\x1b[39m${bg}`)
+    .replace(/\x1b\[49m/g, `\x1b[49m${bg}`);
+  // Leave the diff background active at end-of-line. Pi's surrounding Box adds
+  // the final right-padding cell before resetting the tool background, so that
+  // padding inherits the diff background without the child exceeding its width.
+  return bg + coloredLine;
+}
+
+function deriveDiffBg(
+  kind: "add" | "remove",
+  theme: Theme | undefined,
+  intensity: number,
+): string | undefined {
+  const themed = theme as
+    | (Theme & { getFgAnsi?: (key: string) => string; getBgAnsi?: (key: string) => string })
+    | undefined;
+  const fg = themed?.getFgAnsi?.(kind === "add" ? "toolDiffAdded" : "toolDiffRemoved");
+  const fgRgb = parseAnsiRgb(fg ?? "");
+  if (!fgRgb) return undefined;
+  const base = parseAnsiRgb(
+    themed?.getBgAnsi?.(kind === "add" ? "toolSuccessBg" : "toolErrorBg") ?? "",
+  ) ??
+    parseAnsiRgb(themed?.getBgAnsi?.("toolSuccessBg") ?? "") ?? { r: 0, g: 0, b: 0 };
+  return `\x1b[48;2;${Math.round(base.r + (fgRgb.r - base.r) * intensity)};${Math.round(base.g + (fgRgb.g - base.g) * intensity)};${Math.round(base.b + (fgRgb.b - base.b) * intensity)}m`;
+}
+
+function parseAnsiRgb(ansi: string): { r: number; g: number; b: number } | undefined {
+  const match = ansi.match(/\x1b\[(?:38|48);2;(\d+);(\d+);(\d+)m/);
+  if (!match) return undefined;
+  return { r: Number(match[1]), g: Number(match[2]), b: Number(match[3]) };
+}
+
+function normalizeDiffContent(content: string): string {
+  return escapeControlChars(content.replace(/\t/g, "   "));
+}
+
+function shouldEmphasizeChangedPair(ranges: WordChangeRanges): boolean {
+  return ranges.removed.length > 0 || ranges.added.length > 0;
+}
+
+function emphasizeChangedSpans(
+  line: string,
+  ranges: Array<[number, number]>,
+  kind: "add" | "remove",
+): string {
+  if (ranges.length === 0) return line;
+  const codeStart = findCodeStart(line);
+  return (
+    line.slice(0, codeStart) +
+    injectVisibleRangeEmphasis(line.slice(codeStart), ranges, wordEmphasis(kind))
+  );
+}
+
+function findCodeStart(line: string): number {
+  const pipe = line.indexOf("│ ");
+  if (pipe < 0) return 0;
+  let index = pipe + "│ ".length;
+  // Skip foreground resets emitted by theme.fg() around the gutter. These do not
+  // correspond to visible code cells and should not count toward changed ranges.
+  while (line[index] === "\x1b") {
+    const end = line.indexOf("m", index);
+    if (end < 0) break;
+    index = end + 1;
+  }
+  return index;
+}
+
+function wordEmphasis(kind: "add" | "remove"): string {
+  // Use a strong bg + bold so word emphasis remains visible after the full-line
+  // diff background is re-applied in FullWidthDiffText.render().
+  return kind === "add" ? "\x1b[48;2;64;132;82m\x1b[1m" : "\x1b[48;2;148;62;70m\x1b[1m";
+}
+
+function injectVisibleRangeEmphasis(
+  ansi: string,
+  ranges: Array<[number, number]>,
+  open: string,
+): string {
+  let visible = 0;
+  let rangeIndex = 0;
+  let out = "";
+  let active = false;
+  for (let i = 0; i < ansi.length; i++) {
+    const range = ranges[rangeIndex];
+    if (ansi[i] === "\x1b") {
+      const end = ansi.indexOf("m", i);
+      if (end >= 0) {
+        const seq = ansi.slice(i, end + 1);
+        out += active && (seq === "\x1b[39m" || seq === "\x1b[22m") ? `${seq}${open}` : seq;
+        i = end;
+        continue;
+      }
+    }
+    if (!active && range && visible === range[0]) {
+      out += open;
+      active = true;
+    }
+    if (active && range && visible === range[1]) {
+      out += "\x1b[22m\x1b[49m";
+      active = false;
+      rangeIndex++;
+    }
+    out += ansi[i];
+    visible++;
+  }
+  if (active) out += "\x1b[22m\x1b[49m";
+  return out;
+}
+
+type ParsedDiffLine = { kind: "+" | "-" | " "; lineNumber: string; content: string };
+
+type AddedDiffLine = ParsedDiffLine & { kind: "+" };
+type RemovedDiffLine = ParsedDiffLine & { kind: "-" };
+
+function parseDiffLine(line: string): ParsedDiffLine | null {
+  const match = line.match(/^([+\- ])(\s*\d*)\s(.*)$/);
+  if (!match) return null;
+  const kind = match[1];
+  if (kind !== "+" && kind !== "-" && kind !== " ") return null;
+  return { kind, lineNumber: match[2] ?? "", content: match[3] ?? "" };
+}
+
+function isAddedDiffLine(line: ParsedDiffLine | null): line is AddedDiffLine {
+  return line?.kind === "+";
+}
+
+function isRemovedDiffLine(line: ParsedDiffLine | null): line is RemovedDiffLine {
+  return line?.kind === "-";
+}
+
+function isChangedDiffLine(line: ParsedDiffLine): line is AddedDiffLine | RemovedDiffLine {
+  return line.kind === "+" || line.kind === "-";
+}
+
+function highlightSingleLine(
+  line: string,
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+): string {
+  return (
+    renderWithShiki(line, lang, invalidate)?.[0] ?? theme.fg("toolOutput", escapeControlChars(line))
+  );
+}

--- a/extensions/pi-code-previews/src/format.ts
+++ b/extensions/pi-code-previews/src/format.ts
@@ -1,0 +1,207 @@
+import type { AppKeybinding, Theme } from "@mariozechner/pi-coding-agent";
+import { getKeybindings } from "@mariozechner/pi-tui";
+
+export type PreviewLineEntry<T> =
+  | { kind: "line"; line: T; index: number }
+  | { kind: "hidden"; hidden: number };
+
+export function selectPreviewLines<T>(
+  lines: T[],
+  limit: number,
+): { entries: Array<PreviewLineEntry<T>>; shown: number; hidden: number } {
+  if (lines.length <= limit || limit <= 0) {
+    return {
+      entries: lines.map((line, index) => ({ kind: "line", line, index })),
+      shown: lines.length,
+      hidden: 0,
+    };
+  }
+  if (limit < 8) {
+    return {
+      entries: lines.slice(0, limit).map((line, index) => ({ kind: "line", line, index })),
+      shown: limit,
+      hidden: lines.length - limit,
+    };
+  }
+  const head = Math.ceil(limit * 0.65);
+  const tail = Math.max(1, limit - head - 1);
+  const hidden = lines.length - head - tail;
+  return {
+    entries: [
+      ...lines.slice(0, head).map((line, index) => ({ kind: "line" as const, line, index })),
+      { kind: "hidden", hidden },
+      ...lines.slice(lines.length - tail).map((line, offset) => ({
+        kind: "line" as const,
+        line,
+        index: lines.length - tail + offset,
+      })),
+    ],
+    shown: head + tail,
+    hidden,
+  };
+}
+
+export function previewLines(
+  lines: string[],
+  limit: number,
+  theme: Theme,
+): { lines: string[]; shown: number; hidden: number } {
+  const preview = selectPreviewLines(lines, limit);
+  return {
+    lines: preview.entries.map((entry) =>
+      entry.kind === "hidden" ? hiddenLinesMarker(theme, entry.hidden) : entry.line,
+    ),
+    shown: preview.shown,
+    hidden: preview.hidden,
+  };
+}
+
+export function selectPreviewTextLines(
+  text: string,
+  limit: number,
+): { entries: Array<PreviewLineEntry<string>>; shown: number; hidden: number; total: number } {
+  const total = countTrimmedTextLines(text);
+  if (total === 0) return { entries: [], shown: 0, hidden: 0, total: 0 };
+  if (total <= limit || limit <= 0) {
+    const entries: Array<PreviewLineEntry<string>> = [];
+    forEachTrimmedTextLine(text, (line, index) => entries.push({ kind: "line", line, index }));
+    return { entries, shown: total, hidden: 0, total };
+  }
+  if (limit < 8) {
+    const entries: Array<PreviewLineEntry<string>> = [];
+    forEachTrimmedTextLine(text, (line, index) => {
+      if (index < limit) entries.push({ kind: "line", line, index });
+    });
+    return { entries, shown: limit, hidden: total - limit, total };
+  }
+  const head = Math.ceil(limit * 0.65);
+  const tail = Math.max(1, limit - head - 1);
+  const tailStart = total - tail;
+  const hidden = total - head - tail;
+  const entries: Array<PreviewLineEntry<string>> = [];
+  let markerAdded = false;
+  forEachTrimmedTextLine(text, (line, index) => {
+    if (index < head) {
+      entries.push({ kind: "line", line, index });
+      return;
+    }
+    if (index >= tailStart) {
+      if (!markerAdded) {
+        entries.push({ kind: "hidden", hidden });
+        markerAdded = true;
+      }
+      entries.push({ kind: "line", line, index });
+    }
+  });
+  return { entries, shown: head + tail, hidden, total };
+}
+
+export function hiddenLinesMarker(theme: Theme, hidden: number): string {
+  return theme.fg("muted", `      --- ${hidden} lines hidden ---`);
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function trimSingleTrailingNewline(text: string): string {
+  if (text.endsWith("\r\n")) return text.slice(0, -2);
+  if (text.endsWith("\n")) return text.slice(0, -1);
+  return text;
+}
+
+export function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function metadata(theme: Theme, parts: Array<string | undefined>): string {
+  const present = parts.filter((part): part is string => Boolean(part));
+  return present.length ? theme.fg("dim", ` · ${present.join(" · ")}`) : "";
+}
+
+export function themedKeyHint(
+  theme: Theme,
+  keybinding: AppKeybinding,
+  description: string,
+): string {
+  const keyText = formatKeys(getKeybindings().getKeys(keybinding));
+  if (!keyText) return theme.fg("muted", description);
+  return theme.fg("dim", keyText) + theme.fg("muted", ` ${description}`);
+}
+
+export function hiddenPreviewExpandHint(theme: Theme): string {
+  return theme.fg(
+    "muted",
+    `╰─ output hidden - ${themedKeyHint(theme, "app.tools.expand", "expand")}`,
+  );
+}
+
+export function showingFooter(theme: Theme, shown: number, total: number, label: string): string {
+  return previewFooter(
+    theme,
+    `Showing ${shown} of ${total} ${label} · ${themedKeyHint(theme, "app.tools.expand", "expand")}`,
+  );
+}
+
+export function trimTrailingEmptyLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === "") end--;
+  return lines.slice(0, end);
+}
+
+function formatKeys(keys: string[]): string {
+  if (keys.length === 0) return "";
+  if (keys.length === 1) return keys[0]!;
+  return keys.join("/");
+}
+
+function countTrimmedTextLines(text: string): number {
+  let total = 0;
+  let pendingEmpty = 0;
+  forEachRawTextLine(text, (line) => {
+    if (line === "") pendingEmpty++;
+    else {
+      total += pendingEmpty + 1;
+      pendingEmpty = 0;
+    }
+  });
+  return total;
+}
+
+function forEachTrimmedTextLine(
+  text: string,
+  callback: (line: string, index: number) => void,
+): void {
+  let index = 0;
+  let pendingEmpty = 0;
+  forEachRawTextLine(text, (line) => {
+    if (line === "") {
+      pendingEmpty++;
+      return;
+    }
+    while (pendingEmpty > 0) {
+      callback("", index++);
+      pendingEmpty--;
+    }
+    callback(line, index++);
+  });
+}
+
+function forEachRawTextLine(text: string, callback: (line: string) => void): void {
+  let start = 0;
+  while (start <= text.length) {
+    const newline = text.indexOf("\n", start);
+    if (newline < 0) {
+      callback(text.slice(start));
+      break;
+    }
+    callback(text.slice(start, newline));
+    start = newline + 1;
+  }
+}
+
+export function previewFooter(theme: Theme, text: string): string {
+  return `\n${theme.fg("muted", `╰─ ${text}`)}`;
+}

--- a/extensions/pi-code-previews/src/grep-rendering.ts
+++ b/extensions/pi-code-previews/src/grep-rendering.ts
@@ -1,0 +1,164 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { getLanguageFromPath } from "@mariozechner/pi-coding-agent";
+import { resolvePreviewLanguage } from "./language.ts";
+import { renderHighlightedText } from "./shiki.ts";
+import { escapeControlChars } from "./terminal-text.ts";
+
+export type ParsedGrepOutputLine = {
+  path: string;
+  lineNumber: string;
+  code: string;
+  kind: "match" | "context";
+};
+
+export function renderGrepOutputLines(
+  output: string,
+  theme: Theme,
+  search: { pattern: string; literal: boolean; ignoreCase: boolean },
+  invalidate?: () => void,
+  options: { syntaxHighlight?: boolean } = {},
+): string[] {
+  const rendered: string[] = [];
+  let currentPath = "";
+  for (const rawLine of output.split("\n")) {
+    if (!rawLine) {
+      rendered.push("");
+      continue;
+    }
+    if (rawLine.startsWith("[") && rawLine.endsWith("]")) {
+      rendered.push(theme.fg("warning", escapeControlChars(rawLine)));
+      continue;
+    }
+    const parsed = parseGrepOutputLine(rawLine);
+    if (!parsed) {
+      rendered.push(theme.fg("toolOutput", escapeControlChars(rawLine)));
+      continue;
+    }
+    if (parsed.path !== currentPath) {
+      currentPath = parsed.path;
+      rendered.push(theme.fg("accent", escapeControlChars(currentPath)));
+    }
+    rendered.push(
+      renderGrepParsedLine(parsed, theme, search, invalidate, options.syntaxHighlight !== false),
+    );
+  }
+  return rendered;
+}
+
+export function parseGrepOutputLine(line: string): ParsedGrepOutputLine | undefined {
+  const matchLine = line.match(/^(.+):(\d+):\s(.*)$/);
+  if (matchLine) {
+    return {
+      path: matchLine[1] ?? "",
+      lineNumber: matchLine[2] ?? "",
+      code: matchLine[3] ?? "",
+      kind: "match",
+    };
+  }
+  const contextLine = line.match(/^(.+)-(\d+)-\s(.*)$/);
+  if (contextLine) {
+    return {
+      path: contextLine[1] ?? "",
+      lineNumber: contextLine[2] ?? "",
+      code: contextLine[3] ?? "",
+      kind: "context",
+    };
+  }
+  return undefined;
+}
+
+function renderGrepParsedLine(
+  parsed: ParsedGrepOutputLine,
+  theme: Theme,
+  search: { pattern: string; literal: boolean; ignoreCase: boolean },
+  invalidate: (() => void) | undefined,
+  syntaxHighlight: boolean,
+): string {
+  const lang = syntaxHighlight
+    ? resolvePreviewLanguage({ path: parsed.path, piLanguage: getLanguageFromPath(parsed.path) })
+    : undefined;
+  const code = parsed.code.replace(/\t/g, "   ");
+  let highlighted =
+    renderHighlightedText(code, lang, theme, invalidate)[0] ?? theme.fg("toolOutput", code);
+  const matchRanges = parsed.kind === "match" ? grepMatchRanges(code, search) : [];
+  if (matchRanges.length > 0)
+    highlighted = injectVisibleRangesBg(
+      highlighted,
+      matchRanges,
+      "\x1b[48;2;90;74;28m",
+      getToolBackground(theme),
+    );
+  const paddedLineNumber = parsed.lineNumber.padStart(4);
+  const lineNumber =
+    parsed.kind === "match"
+      ? theme.fg("accent", paddedLineNumber)
+      : theme.fg("dim", paddedLineNumber);
+  const marker = parsed.kind === "match" ? theme.fg("warning", "│") : theme.fg("dim", "┆");
+  return `${theme.fg("dim", "  ")}${lineNumber} ${marker} ${highlighted}`;
+}
+
+function grepMatchRanges(
+  code: string,
+  search: { pattern: string; literal: boolean; ignoreCase: boolean },
+): Array<[number, number]> {
+  if (!search.pattern || !search.literal) return [];
+  const haystack = search.ignoreCase ? code.toLowerCase() : code;
+  const needle = search.ignoreCase ? search.pattern.toLowerCase() : search.pattern;
+  if (!needle) return [];
+  const ranges: Array<[number, number]> = [];
+  let index = haystack.indexOf(needle);
+  while (index >= 0) {
+    ranges.push([index, index + needle.length]);
+    index = haystack.indexOf(needle, index + Math.max(1, needle.length));
+  }
+  return ranges;
+}
+
+function getToolBackground(theme: Theme): string {
+  const themed = theme as Theme & { getBgAnsi?: (key: string) => string };
+  try {
+    return themed.getBgAnsi?.("toolSuccessBg") ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function injectVisibleRangesBg(
+  ansi: string,
+  ranges: Array<[number, number]>,
+  bg: string,
+  restoreBg: string,
+): string {
+  let visible = 0;
+  let out = "";
+  let active = false;
+  let rangeIndex = 0;
+  const sorted = ranges.filter(([start, end]) => end > start).sort((a, b) => a[0] - b[0]);
+  for (let i = 0; i < ansi.length; i++) {
+    if (ansi[i] === "\x1b") {
+      const end = ansi.indexOf("m", i);
+      if (end >= 0) {
+        const seq = ansi.slice(i, end + 1);
+        out += active && seq === "\x1b[39m" ? `${seq}${bg}` : seq;
+        i = end;
+        continue;
+      }
+    }
+    while (rangeIndex < sorted.length && visible >= sorted[rangeIndex]![1]) {
+      if (active) {
+        out += restoreBg || "\x1b[49m";
+        active = false;
+      }
+      rangeIndex++;
+    }
+    const range = sorted[rangeIndex];
+    if (!active && range && visible >= range[0] && visible < range[1]) {
+      out += bg;
+      active = true;
+    }
+    out += ansi[i];
+    visible++;
+  }
+  if (active) out += restoreBg || "\x1b[49m";
+  return out;
+}

--- a/extensions/pi-code-previews/src/hash.ts
+++ b/extensions/pi-code-previews/src/hash.ts
@@ -1,0 +1,14 @@
+export function hashString(value: string): string {
+  let first = 0xdeadbeef;
+  let second = 0x41c6ce57;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    first = Math.imul(first ^ code, 2654435761);
+    second = Math.imul(second ^ code, 1597334677);
+  }
+  first =
+    Math.imul(first ^ (first >>> 16), 2246822507) ^ Math.imul(second ^ (second >>> 13), 3266489909);
+  second =
+    Math.imul(second ^ (second >>> 16), 2246822507) ^ Math.imul(first ^ (first >>> 13), 3266489909);
+  return `${(second >>> 0).toString(36)}${(first >>> 0).toString(36)}`;
+}

--- a/extensions/pi-code-previews/src/icons.ts
+++ b/extensions/pi-code-previews/src/icons.ts
@@ -1,0 +1,58 @@
+import { basename, extname } from "node:path";
+
+export type PathIconMode = "off" | "unicode" | "nerd";
+
+const NERD_FILE = "\uf15b";
+const NERD_DIR = "\ue5ff";
+
+const NERD_BY_NAME: Record<string, string> = {
+  "package.json": "\ue71e",
+  "package-lock.json": "\ue71e",
+  "tsconfig.json": "\ue628",
+  "readme.md": "\ue73e",
+  license: "\ue60a",
+  dockerfile: "\ue7b0",
+  makefile: "\ue615",
+  ".gitignore": "\ue702",
+  ".env": "\ue615",
+  ".envrc": "\ue795",
+};
+
+const NERD_BY_EXT: Record<string, string> = {
+  ts: "\ue628",
+  tsx: "\ue7ba",
+  js: "\ue74e",
+  jsx: "\ue7ba",
+  json: "\ue60b",
+  md: "\ue73e",
+  py: "\ue73c",
+  rs: "\ue7a8",
+  go: "\ue724",
+  java: "\ue738",
+  rb: "\ue739",
+  php: "\ue73d",
+  html: "\ue736",
+  css: "\ue749",
+  scss: "\ue749",
+  yaml: "\ue6a8",
+  yml: "\ue6a8",
+  toml: "\ue6b2",
+  sh: "\ue795",
+  bash: "\ue795",
+  zsh: "\ue795",
+  sql: "\ue706",
+  xml: "\ue619",
+  png: "\uf1c5",
+  jpg: "\uf1c5",
+  jpeg: "\uf1c5",
+  gif: "\uf1c5",
+  svg: "\uf1c5",
+};
+
+export function pathIcon(path: string, isDirectory: boolean, mode: PathIconMode): string {
+  if (mode === "off") return "";
+  if (mode === "unicode") return isDirectory ? "▸" : "•";
+  if (isDirectory) return NERD_DIR;
+  const name = basename(path).toLowerCase();
+  return NERD_BY_NAME[name] ?? NERD_BY_EXT[extname(name).slice(1)] ?? NERD_FILE;
+}

--- a/extensions/pi-code-previews/src/language.ts
+++ b/extensions/pi-code-previews/src/language.ts
@@ -1,0 +1,127 @@
+import { basename, extname } from "node:path";
+import { bundledLanguages } from "shiki";
+
+const EXACT_BASENAMES = new Map<string, string>([
+  ["dockerfile", "dockerfile"],
+  ["makefile", "makefile"],
+  ["gnumakefile", "makefile"],
+  ["justfile", "makefile"],
+  ["procfile", "shellscript"],
+  ["gemfile", "ruby"],
+  ["rakefile", "ruby"],
+  ["cargo.lock", "toml"],
+  ["package-lock.json", "json"],
+  ["composer.lock", "json"],
+  ["pnpm-lock.yaml", "yaml"],
+  ["pnpm-lock.yml", "yaml"],
+  ["yarn.lock", "yaml"],
+]);
+
+const EXTENSION_ALIASES = new Map<string, string>([
+  [".env", "dotenv"],
+  [".sh", "bash"],
+  [".bash", "bash"],
+  [".zsh", "bash"],
+  [".ts", "typescript"],
+  [".tsx", "tsx"],
+  [".ts", "javascript"],
+  [".jsx", "jsx"],
+  [".mjs", "javascript"],
+  [".cjs", "javascript"],
+  [".md", "markdown"],
+  [".yml", "yaml"],
+  [".yaml", "yaml"],
+  [".json", "json"],
+  [".toml", "toml"],
+]);
+
+const SHEBANG_ALIASES = new Map<string, string>([
+  ["bash", "bash"],
+  ["sh", "bash"],
+  ["zsh", "bash"],
+  ["python", "python"],
+  ["python3", "python"],
+  ["node", "javascript"],
+  ["deno", "typescript"],
+  ["ruby", "ruby"],
+  ["php", "php"],
+]);
+
+const CONTENT_LANGUAGE_DETECTION_CHARS = positiveEnvInteger(
+  "CODE_PREVIEW_CONTENT_LANGUAGE_DETECTION_CHARS",
+  50_000,
+);
+
+export function resolvePreviewLanguage({
+  path,
+  content,
+  piLanguage,
+}: {
+  path?: string;
+  content?: string;
+  piLanguage?: string;
+}): string | undefined {
+  return firstSupported(
+    piLanguage,
+    languageFromPath(path),
+    languageFromShebang(content),
+    languageFromContent(content),
+  );
+}
+
+function languageFromPath(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const name = basename(path).toLowerCase();
+  if (name.startsWith(".env")) return "dotenv";
+  if (name === "dockerfile" || name.startsWith("dockerfile.")) return "dockerfile";
+  const exact = EXACT_BASENAMES.get(name);
+  if (exact) return exact;
+  return EXTENSION_ALIASES.get(extname(name));
+}
+
+function languageFromShebang(content: string | undefined): string | undefined {
+  const firstLine = content?.split("\n", 1)[0]?.trim();
+  if (!firstLine?.startsWith("#!")) return undefined;
+  const parts = firstLine
+    .replace(/^#!\s*/, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  const envIndex = parts.findIndex((part) => basename(part) === "env");
+  const command =
+    envIndex >= 0 ? parts.slice(envIndex + 1).find((part) => !part.startsWith("-")) : parts[0];
+  if (!command) return undefined;
+  const rawExecutable = basename(command).toLowerCase();
+  const executable = rawExecutable.replace(/\d+(\.\d+)?$/, "");
+  return SHEBANG_ALIASES.get(executable) ?? SHEBANG_ALIASES.get(rawExecutable);
+}
+
+function languageFromContent(content: string | undefined): string | undefined {
+  if (!content || content.length > CONTENT_LANGUAGE_DETECTION_CHARS) return undefined;
+  const trimmed = content.trim();
+  if (!trimmed) return undefined;
+  if ((trimmed.startsWith("{") || trimmed.startsWith("[")) && isJson(trimmed)) return "json";
+  if (/^<(!doctype\s+html|html)(\s|>)/i.test(trimmed)) return "html";
+  if (/^<\?xml\s/i.test(trimmed)) return "xml";
+  return undefined;
+}
+
+function firstSupported(...languages: Array<string | undefined>): string | undefined {
+  for (const language of languages) {
+    if (language && language in bundledLanguages) return language;
+  }
+  return undefined;
+}
+
+function isJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function positiveEnvInteger(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/extensions/pi-code-previews/src/path-list-rendering.ts
+++ b/extensions/pi-code-previews/src/path-list-rendering.ts
@@ -1,0 +1,70 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { pathIcon } from "./icons.ts";
+import { codePreviewSettings } from "./settings.ts";
+import { renderDisplayPath } from "./paths.ts";
+import { escapeControlChars } from "./terminal-text.ts";
+
+export function renderPathListLines(output: string, cwd: string, theme: Theme): string[] {
+  const lines = output.split("\n");
+  const pathLines = lines.filter((line) => line && !(line.startsWith("[") && line.endsWith("]")));
+  const shouldTree = pathLines.some((line) => line.includes("/"));
+  if (!shouldTree) return lines.map((line) => renderPathListLine(line, cwd, theme));
+
+  const rendered: string[] = [];
+  const seenDirs = new Set<string>();
+  for (const line of lines) {
+    if (!line) {
+      rendered.push("");
+      continue;
+    }
+    if (line.startsWith("[") && line.endsWith("]")) {
+      rendered.push(theme.fg("warning", escapeControlChars(line)));
+      continue;
+    }
+    renderTreePath(line, theme, seenDirs, rendered);
+  }
+  return rendered;
+}
+
+function renderTreePath(
+  path: string,
+  theme: Theme,
+  seenDirs: Set<string>,
+  rendered: string[],
+): void {
+  const clean = path.replace(/^\.\//, "");
+  const isDir = clean.endsWith("/");
+  const parts = clean.replace(/\/$/, "").split("/").filter(Boolean);
+  let prefix = "";
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index] ?? "";
+    const isLeaf = index === parts.length - 1;
+    const key = prefix ? `${prefix}/${part}` : part;
+    const indent = "  ".repeat(index);
+    if (!isLeaf || isDir) {
+      if (!seenDirs.has(key)) {
+        seenDirs.add(key);
+        const icon = pathIcon(part, true, codePreviewSettings.pathIcons);
+        rendered.push(
+          `${theme.fg("dim", icon ? `${indent}${icon}` : indent)}${icon ? " " : ""}${theme.fg("accent", `${escapeControlChars(part)}/`)}`,
+        );
+      }
+    } else {
+      const icon = pathIcon(part, false, codePreviewSettings.pathIcons);
+      rendered.push(
+        `${theme.fg("dim", icon ? `${indent}${icon}` : indent)}${icon ? " " : ""}${theme.fg("toolOutput", escapeControlChars(part))}`,
+      );
+    }
+    prefix = key;
+  }
+}
+
+function renderPathListLine(line: string, cwd: string, theme: Theme): string {
+  if (!line) return "";
+  if (line.startsWith("[") && line.endsWith("]"))
+    return theme.fg("warning", escapeControlChars(line));
+  const prefix = line.match(/^\s*/)?.[0] ?? "";
+  const body = line.slice(prefix.length);
+  const icon = pathIcon(body, body.endsWith("/"), codePreviewSettings.pathIcons);
+  return `${theme.fg("dim", icon ? prefix + icon : prefix)}${icon ? " " : ""}${renderDisplayPath(body, cwd, theme, body)}`;
+}

--- a/extensions/pi-code-previews/src/paths.ts
+++ b/extensions/pi-code-previews/src/paths.ts
@@ -1,0 +1,31 @@
+import { homedir } from "node:os";
+import { isAbsolute, relative } from "node:path";
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { escapeControlChars } from "./terminal-text.ts";
+
+export function formatDisplayPath(path: string, cwd: string): string {
+  if (!path) return "";
+
+  if (isAbsolute(path)) {
+    const fromCwd = relative(cwd, path);
+    if (fromCwd && !fromCwd.startsWith("..") && !isAbsolute(fromCwd)) return fromCwd;
+    if (!fromCwd) return ".";
+
+    const home = homedir();
+    const fromHome = relative(home, path);
+    if (fromHome && !fromHome.startsWith("..") && !isAbsolute(fromHome)) return `~/${fromHome}`;
+    if (!fromHome) return "~";
+  }
+
+  return path;
+}
+
+export function renderDisplayPath(
+  path: string,
+  cwd: string,
+  theme: Theme,
+  fallback = "...",
+): string {
+  const displayPath = formatDisplayPath(path, cwd) || fallback;
+  return theme.fg("accent", escapeControlChars(displayPath));
+}

--- a/extensions/pi-code-previews/src/renderers.ts
+++ b/extensions/pi-code-previews/src/renderers.ts
@@ -1,0 +1,63 @@
+import type { ExtensionAPI, ToolInfo } from "@mariozechner/pi-coding-agent";
+import { registerBash } from "./tool-renderers/bash.ts";
+import { registerEdit } from "./tool-renderers/edit.ts";
+import { registerFind } from "./tool-renderers/find.ts";
+import { registerGrep } from "./tool-renderers/grep.ts";
+import { registerLs } from "./tool-renderers/ls.ts";
+import { registerRead } from "./tool-renderers/read.ts";
+import { registerWrite } from "./tool-renderers/write.ts";
+import { resetCodePreviewToolStatuses, setCodePreviewToolStatus } from "./tool-status.ts";
+import { ALL_CODE_PREVIEW_TOOLS, type CodePreviewToolName } from "./tool-selection.ts";
+import { getEnabledCodePreviewTools } from "./tool-selection.ts";
+
+export interface RegisterToolRenderersOptions {
+  registeredTools?: Set<CodePreviewToolName>;
+}
+
+export function registerToolRenderers(
+  pi: ExtensionAPI,
+  cwd: string,
+  options: RegisterToolRenderersOptions = {},
+) {
+  const enabledTools = getEnabledCodePreviewTools();
+  resetCodePreviewToolStatuses(enabledTools);
+  const existingTools = getExistingToolsByName(pi);
+
+  for (const tool of ALL_CODE_PREVIEW_TOOLS) {
+    if (!enabledTools.has(tool)) continue;
+    if (options.registeredTools?.has(tool)) {
+      setCodePreviewToolStatus(tool, { state: "active" });
+      continue;
+    }
+
+    const existing = existingTools.get(tool);
+    if (existing && existing.sourceInfo.source !== "builtin") {
+      setCodePreviewToolStatus(tool, { state: "skipped-conflict", owner: existing.sourceInfo });
+      continue;
+    }
+
+    registerToolRenderer(tool, pi, cwd);
+    options.registeredTools?.add(tool);
+    setCodePreviewToolStatus(tool, { state: "active" });
+  }
+}
+
+function registerToolRenderer(tool: CodePreviewToolName, pi: ExtensionAPI, cwd: string): void {
+  if (tool === "bash") registerBash(pi, cwd);
+  else if (tool === "read") registerRead(pi, cwd);
+  else if (tool === "write") registerWrite(pi, cwd);
+  else if (tool === "edit") registerEdit(pi, cwd);
+  else if (tool === "grep") registerGrep(pi, cwd);
+  else if (tool === "find") registerFind(pi, cwd);
+  else if (tool === "ls") registerLs(pi, cwd);
+}
+
+function getExistingToolsByName(pi: ExtensionAPI): Map<string, ToolInfo> {
+  const getAllTools = (pi as Partial<ExtensionAPI>).getAllTools;
+  if (typeof getAllTools !== "function") return new Map();
+  try {
+    return new Map(getAllTools.call(pi).map((tool) => [tool.name, tool]));
+  } catch {
+    return new Map();
+  }
+}

--- a/extensions/pi-code-previews/src/search-renderers.ts
+++ b/extensions/pi-code-previews/src/search-renderers.ts
@@ -1,0 +1,3 @@
+export { registerFind } from "./tool-renderers/find.ts";
+export { registerGrep } from "./tool-renderers/grep.ts";
+export { registerLs } from "./tool-renderers/ls.ts";

--- a/extensions/pi-code-previews/src/secret-warnings.ts
+++ b/extensions/pi-code-previews/src/secret-warnings.ts
@@ -1,0 +1,23 @@
+export interface SecretWarning {
+  label: string;
+  pattern: RegExp;
+}
+
+const SECRET_WARNINGS: SecretWarning[] = [
+  { label: "private key", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  { label: "AWS secret key", pattern: /\bAWS_SECRET_ACCESS_KEY\s*=\s*["']?[^\s'\"]{12,}/i },
+  {
+    label: "API key",
+    pattern:
+      /\b(?:OPENAI|ANTHROPIC|GOOGLE|GEMINI|MISTRAL|GROQ|TOGETHER|PERPLEXITY|XAI)_API_KEY\s*=\s*["']?[^\s'\"]{12,}/i,
+  },
+  { label: "GitHub token", pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/ },
+  { label: "JWT", pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
+];
+
+export function getSecretWarnings(text: string): string[] {
+  if (!text) return [];
+  return SECRET_WARNINGS.filter((warning) => warning.pattern.test(text)).map(
+    (warning) => warning.label,
+  );
+}

--- a/extensions/pi-code-previews/src/settings-store.ts
+++ b/extensions/pi-code-previews/src/settings-store.ts
@@ -1,0 +1,91 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import { codePreviewSettings, normalizeSettings, type CodePreviewSettings } from "./settings.ts";
+
+export function getSettingsPath(): string {
+  return join(getAgentDir(), "code-previews.json");
+}
+
+function getLegacyAgentDir(): string {
+  return join(homedir(), ".pi", "agent");
+}
+
+function getLegacySettingsPath(): string {
+  return join(getLegacyAgentDir(), "code-previews.json");
+}
+
+export async function loadSettingsFromDisk(): Promise<CodePreviewSettings | undefined> {
+  let loaded = false;
+  let effective = codePreviewSettings;
+  const settingsPaths = [
+    join(homedir(), ".pi", "settings.json"),
+    join(getLegacyAgentDir(), "settings.json"),
+    join(getAgentDir(), "settings.json"),
+    join(process.cwd(), ".pi", "settings.json"),
+    getLegacySettingsPath(),
+    getSettingsPath(),
+  ];
+  for (const settingsPath of new Set(settingsPaths)) {
+    try {
+      const content = await readFile(settingsPath, "utf8");
+      effective = normalizeSettings(extractCodePreviewSettings(JSON.parse(content)), effective);
+      loaded = true;
+    } catch (error) {
+      if (isFileNotFound(error)) continue;
+      console.warn(`[pi-code-previews] Failed to load settings from ${settingsPath}.`, error);
+    }
+  }
+  return loaded ? effective : undefined;
+}
+
+export async function saveSettingsToDisk(settings: CodePreviewSettings): Promise<void> {
+  const settingsPath = getSettingsPath();
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+}
+
+export function extractCodePreviewSettings(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== "object") return {};
+  const object = data as Record<string, unknown>;
+  const nested = object.codePreview;
+  if (nested && typeof nested === "object") return nested as Record<string, unknown>;
+  if (hasDirectCodePreviewSettings(object)) return object;
+  const extracted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(object)) {
+    if (!key.startsWith("codePreview")) continue;
+    const normalized = key.slice("codePreview".length);
+    if (!normalized) continue;
+    extracted[normalized[0]!.toLowerCase() + normalized.slice(1)] = value;
+  }
+  return extracted;
+}
+
+function hasDirectCodePreviewSettings(object: Record<string, unknown>): boolean {
+  return [
+    "shikiTheme",
+    "diffIntensity",
+    "wordEmphasis",
+    "readCollapsedLines",
+    "readContentPreview",
+    "writeCollapsedLines",
+    "editCollapsedLines",
+    "grepCollapsedLines",
+    "grepResultPreview",
+    "findResultPreview",
+    "lsResultPreview",
+    "pathListCollapsedLines",
+    "readLineNumbers",
+    "bashResultPreview",
+    "bashWarnings",
+    "syntaxHighlighting",
+    "secretWarnings",
+    "pathIcons",
+    "tools",
+  ].some((key) => key in object);
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/extensions/pi-code-previews/src/settings-ui.ts
+++ b/extensions/pi-code-previews/src/settings-ui.ts
@@ -1,0 +1,289 @@
+import { getSelectListTheme, getSettingsListTheme } from "@mariozechner/pi-coding-agent";
+import {
+  Container,
+  SelectList,
+  SettingsList,
+  Spacer,
+  Text,
+  type SelectItem,
+  type SettingItem,
+} from "@mariozechner/pi-tui";
+import { bundledThemes } from "shiki";
+import { getSettingsPath } from "./settings-store.ts";
+import type { CodePreviewSettings } from "./settings.ts";
+import {
+  ALL_CODE_PREVIEW_TOOLS,
+  parseCodePreviewTools,
+  type CodePreviewToolName,
+} from "./tool-names.ts";
+import {
+  formatToolOwner,
+  getCodePreviewToolStatuses,
+  type CodePreviewToolStatus,
+} from "./tool-status.ts";
+
+export function createSettingsItems(current: CodePreviewSettings): SettingItem[] {
+  return [
+    {
+      id: "shikiTheme",
+      label: "Syntax theme",
+      description: "Theme used for Shiki syntax highlighting in code previews.",
+      currentValue: current.shikiTheme,
+      submenu: (currentValue, done) => new ThemeSelectSubmenu(currentValue, done),
+    },
+    {
+      id: "diffIntensity",
+      label: "Diff background",
+      description: "Background intensity for added and removed edit diff lines.",
+      currentValue: current.diffIntensity,
+      values: ["off", "subtle", "medium"],
+    },
+    {
+      id: "wordEmphasis",
+      label: "Word-level diff emphasis",
+      description:
+        "Highlight changed words inside edit diffs. All mode is the default; smart suppresses low-signal punctuation and wrapper syntax.",
+      currentValue: current.wordEmphasis,
+      values: ["all", "smart", "off"],
+    },
+    {
+      id: "tools",
+      label: "Preview tools",
+      description:
+        "Open granular tool preview toggles. Changes take effect after /reload. Tools already owned by another extension are skipped automatically.",
+      currentValue: current.tools.join(", "),
+      submenu: (currentValue, done) => new ToolPreviewSettingsSubmenu(currentValue, done),
+    },
+    {
+      id: "readContentPreview",
+      label: "Read content preview",
+      description:
+        "Show file contents in read results. Turn off to hide collapsed output while still allowing expanded output.",
+      currentValue: current.readContentPreview ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "readCollapsedLines",
+      label: "Read preview lines",
+      description: "Maximum read result lines shown before collapsing.",
+      currentValue: String(current.readCollapsedLines),
+      values: ["10", "20", "40", "80"],
+    },
+    {
+      id: "writeCollapsedLines",
+      label: "Write preview lines",
+      description: "Maximum write content lines shown before collapsing.",
+      currentValue: String(current.writeCollapsedLines),
+      values: ["10", "20", "40", "80"],
+    },
+    {
+      id: "editCollapsedLines",
+      label: "Edit diff preview lines",
+      description:
+        "Maximum edit diff lines shown before collapsing. `all` matches pi's built-in edit diff behavior.",
+      currentValue: String(current.editCollapsedLines),
+      values: ["all", "60", "100", "160", "240"],
+    },
+    {
+      id: "grepResultPreview",
+      label: "Grep result preview",
+      description:
+        "Show grep matches in tool results. Turn off to hide collapsed output while still allowing expanded output.",
+      currentValue: current.grepResultPreview ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "grepCollapsedLines",
+      label: "Grep preview lines",
+      description: "Maximum grep result lines shown before collapsing.",
+      currentValue: String(current.grepCollapsedLines),
+      values: ["10", "15", "25", "40", "80"],
+    },
+    {
+      id: "findResultPreview",
+      label: "Find result preview",
+      description:
+        "Show find paths in tool results. Turn off to hide collapsed output while still allowing expanded output.",
+      currentValue: current.findResultPreview ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "lsResultPreview",
+      label: "Ls result preview",
+      description:
+        "Show ls entries in tool results. Turn off to hide collapsed output while still allowing expanded output.",
+      currentValue: current.lsResultPreview ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "pathListCollapsedLines",
+      label: "Find/ls preview lines",
+      description: "Maximum find and ls result lines shown before collapsing.",
+      currentValue: String(current.pathListCollapsedLines),
+      values: ["10", "20", "40", "80", "120"],
+    },
+    {
+      id: "readLineNumbers",
+      label: "Read line numbers",
+      description: "Show line numbers in read previews.",
+      currentValue: current.readLineNumbers ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "pathIcons",
+      label: "Find/ls path icons",
+      description:
+        "Choose icons for find and ls path-list previews. Nerd mode requires a Nerd Font.",
+      currentValue: current.pathIcons,
+      values: ["unicode", "nerd", "off"],
+    },
+    {
+      id: "bashResultPreview",
+      label: "Bash result preview",
+      description:
+        "Show successful bash output. Turn off to hide collapsed output while still allowing expanded output, running state, and errors.",
+      currentValue: current.bashResultPreview ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "bashWarnings",
+      label: "Bash visual warnings",
+      description: "Show preview-only warnings for potentially destructive shell commands.",
+      currentValue: current.bashWarnings ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "syntaxHighlighting",
+      label: "Syntax highlighting",
+      description:
+        "Use Shiki token colors in code previews. Turn off for plainer, lower-noise previews.",
+      currentValue: current.syntaxHighlighting ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "secretWarnings",
+      label: "Secret value warnings",
+      description:
+        "Show preview-only warnings when read, write, or bash output looks like it may contain secrets.",
+      currentValue: current.secretWarnings ? "on" : "off",
+      values: ["on", "off"],
+    },
+    {
+      id: "settingsFile",
+      label: "Settings file",
+      description: "Settings are stored globally in this file.",
+      currentValue: getSettingsPath(),
+    },
+    {
+      id: "resetToDefaults",
+      label: "Restore defaults",
+      description: "Restore the default code preview settings.",
+      currentValue: "keep current",
+      values: ["keep current", "reset now"],
+    },
+  ];
+}
+
+class ToolPreviewSettingsSubmenu extends Container {
+  private readonly selectedTools: Set<CodePreviewToolName>;
+  private readonly settingsList: SettingsList;
+
+  constructor(currentValue: string, done: (selectedValue?: string) => void) {
+    super();
+    this.selectedTools = parseCodePreviewTools(currentValue) ?? new Set(ALL_CODE_PREVIEW_TOOLS);
+    this.settingsList = new SettingsList(
+      createToolToggleItems(this.selectedTools, getCodePreviewToolStatuses()),
+      ALL_CODE_PREVIEW_TOOLS.length + 2,
+      getSettingsListTheme(),
+      (id, value) => {
+        const tool = parseToolToggleId(id);
+        if (!tool) return;
+        if (value === "on") this.selectedTools.add(tool);
+        else this.selectedTools.delete(tool);
+      },
+      () => done(this.formatSelectedTools()),
+    );
+
+    this.addChild(new Text("Preview tools", 0, 0));
+    this.addChild(
+      new Text("Toggle tool previews individually. Changes take effect after /reload.", 0, 0),
+    );
+    this.addChild(new Spacer(1));
+    this.addChild(this.settingsList);
+  }
+
+  handleInput(data: string): void {
+    this.settingsList.handleInput(data);
+  }
+
+  private formatSelectedTools(): string {
+    return ALL_CODE_PREVIEW_TOOLS.filter((tool) => this.selectedTools.has(tool)).join(",");
+  }
+}
+
+function createToolToggleItems(
+  enabledTools: Set<CodePreviewToolName>,
+  statuses: Map<CodePreviewToolName, CodePreviewToolStatus>,
+): SettingItem[] {
+  return ALL_CODE_PREVIEW_TOOLS.map((tool) => {
+    const status = statuses.get(tool);
+    if (status?.state === "skipped-conflict") {
+      const owner = formatToolOwner(status.owner);
+      return {
+        id: `tool:${tool}`,
+        label: `${tool} preview`,
+        description: `${tool} preview is disabled because ${owner} owns the ${tool} tool. Disable that extension or change package order to let pi-code-previews own it.`,
+        currentValue: `disabled (${owner})`,
+      };
+    }
+
+    const statusText =
+      status?.state === "active" ? "currently active" : "takes effect after /reload";
+    return {
+      id: `tool:${tool}`,
+      label: `${tool} preview`,
+      description: `${tool} preview registration (${statusText}). Tools already owned by another extension are disabled automatically.`,
+      currentValue: enabledTools.has(tool) ? "on" : "off",
+      values: ["on", "off"],
+    };
+  });
+}
+
+function parseToolToggleId(id: string): CodePreviewToolName | undefined {
+  const tool = id.startsWith("tool:") ? id.slice("tool:".length) : "";
+  return ALL_CODE_PREVIEW_TOOLS.find((candidate) => candidate === tool);
+}
+
+class ThemeSelectSubmenu extends Container {
+  private readonly selectList: SelectList;
+
+  constructor(currentTheme: string, done: (selectedValue?: string) => void) {
+    super();
+
+    const themes: SelectItem[] = Object.keys(bundledThemes)
+      .sort()
+      .map((theme) => ({ value: theme, label: theme }));
+
+    this.selectList = new SelectList(themes, 12, getSelectListTheme(), {
+      minPrimaryColumnWidth: 16,
+      maxPrimaryColumnWidth: 48,
+    });
+
+    const currentIndex = themes.findIndex((theme) => theme.value === currentTheme);
+    if (currentIndex >= 0) this.selectList.setSelectedIndex(currentIndex);
+
+    this.selectList.onSelect = (item) => done(item.value);
+    this.selectList.onCancel = () => done(undefined);
+
+    this.addChild(new Text("Syntax theme", 0, 0));
+    this.addChild(new Text("Select a Shiki theme for code previews.", 0, 0));
+    this.addChild(new Spacer(1));
+    this.addChild(this.selectList);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text("Enter to select · Esc to go back", 0, 0));
+  }
+
+  handleInput(data: string): void {
+    this.selectList.handleInput(data);
+  }
+}

--- a/extensions/pi-code-previews/src/settings.ts
+++ b/extensions/pi-code-previews/src/settings.ts
@@ -1,0 +1,297 @@
+import { bundledThemes } from "shiki";
+import { getObjectValue } from "./data.ts";
+import {
+  ALL_CODE_PREVIEW_TOOLS,
+  isCodePreviewToolName,
+  parseCodePreviewTools,
+  type CodePreviewToolName,
+} from "./tool-names.ts";
+
+export type DiffBackgroundIntensity = "off" | "subtle" | "medium";
+export type DiffWordEmphasis = "off" | "smart" | "all";
+export type PathIconMode = "off" | "unicode" | "nerd";
+
+export interface CodePreviewSettings {
+  shikiTheme: string;
+  diffIntensity: DiffBackgroundIntensity;
+  wordEmphasis: DiffWordEmphasis;
+  readCollapsedLines: number;
+  readContentPreview: boolean;
+  writeCollapsedLines: number;
+  editCollapsedLines: number | "all";
+  grepCollapsedLines: number;
+  grepResultPreview: boolean;
+  findResultPreview: boolean;
+  lsResultPreview: boolean;
+  pathListCollapsedLines: number;
+  readLineNumbers: boolean;
+  bashResultPreview: boolean;
+  bashWarnings: boolean;
+  syntaxHighlighting: boolean;
+  secretWarnings: boolean;
+  pathIcons: PathIconMode;
+  tools: CodePreviewToolName[];
+}
+
+export const defaultCodePreviewSettings: CodePreviewSettings = {
+  shikiTheme: envTheme("CODE_PREVIEW_THEME", "dark-plus"),
+  diffIntensity: envDiffIntensity("CODE_PREVIEW_DIFF_INTENSITY", "subtle"),
+  wordEmphasis: envDiffWordEmphasis("CODE_PREVIEW_WORD_EMPHASIS", "all"),
+  readCollapsedLines: envNumber("CODE_PREVIEW_READ_LINES", 10),
+  readContentPreview: envBoolean("CODE_PREVIEW_READ_CONTENT", true),
+  writeCollapsedLines: envNumber("CODE_PREVIEW_WRITE_LINES", 10),
+  editCollapsedLines: envEditLines("CODE_PREVIEW_EDIT_LINES", 160),
+  grepCollapsedLines: envNumber("CODE_PREVIEW_GREP_LINES", 15),
+  grepResultPreview: envBoolean("CODE_PREVIEW_GREP_RESULTS", true),
+  findResultPreview: envBoolean("CODE_PREVIEW_FIND_RESULTS", true),
+  lsResultPreview: envBoolean("CODE_PREVIEW_LS_RESULTS", true),
+  pathListCollapsedLines: envNumber("CODE_PREVIEW_PATH_LIST_LINES", 20),
+  readLineNumbers: envBoolean("CODE_PREVIEW_READ_LINE_NUMBERS", true),
+  bashResultPreview: envBoolean("CODE_PREVIEW_BASH_RESULTS", true),
+  bashWarnings: envBoolean("CODE_PREVIEW_BASH_WARNINGS", true),
+  syntaxHighlighting: envBoolean("CODE_PREVIEW_SYNTAX", true),
+  secretWarnings: envBoolean("CODE_PREVIEW_SECRET_WARNINGS", true),
+  pathIcons: envPathIconMode("CODE_PREVIEW_PATH_ICONS", "unicode"),
+  tools: [...ALL_CODE_PREVIEW_TOOLS],
+};
+
+export const codePreviewSettings: CodePreviewSettings = cloneCodePreviewSettings(
+  defaultCodePreviewSettings,
+);
+
+export function setCodePreviewSettings(next: CodePreviewSettings) {
+  Object.assign(codePreviewSettings, cloneCodePreviewSettings(next));
+}
+
+function cloneCodePreviewSettings(settings: CodePreviewSettings): CodePreviewSettings {
+  return { ...settings, tools: [...settings.tools] };
+}
+
+export function normalizeSettings(
+  data: unknown,
+  fallback: CodePreviewSettings = codePreviewSettings,
+): CodePreviewSettings {
+  const shikiTheme = getObjectValue(data, "shikiTheme");
+  const diffIntensity = getObjectValue(data, "diffIntensity");
+  const wordEmphasis = getObjectValue(data, "wordEmphasis");
+  const readContentPreview = getObjectValue(data, "readContentPreview");
+  const grepResultPreview = getObjectValue(data, "grepResultPreview");
+  const findResultPreview = getObjectValue(data, "findResultPreview");
+  const lsResultPreview = getObjectValue(data, "lsResultPreview");
+  const readLineNumbers = getObjectValue(data, "readLineNumbers");
+  const bashResultPreview = getObjectValue(data, "bashResultPreview");
+  const bashWarnings = getObjectValue(data, "bashWarnings");
+  const syntaxHighlighting = getObjectValue(data, "syntaxHighlighting");
+  const secretWarnings = getObjectValue(data, "secretWarnings");
+  const pathIcons = getObjectValue(data, "pathIcons");
+  return withRequiredToolRenderers({
+    shikiTheme: isBundledThemeName(shikiTheme) ? shikiTheme : fallback.shikiTheme,
+    diffIntensity: isDiffBackgroundIntensity(diffIntensity)
+      ? diffIntensity
+      : fallback.diffIntensity,
+    wordEmphasis: isDiffWordEmphasis(wordEmphasis) ? wordEmphasis : fallback.wordEmphasis,
+    readCollapsedLines: coerceNumber(
+      getObjectValue(data, "readCollapsedLines"),
+      fallback.readCollapsedLines,
+    ),
+    readContentPreview:
+      typeof readContentPreview === "boolean" ? readContentPreview : fallback.readContentPreview,
+    writeCollapsedLines: coerceNumber(
+      getObjectValue(data, "writeCollapsedLines"),
+      fallback.writeCollapsedLines,
+    ),
+    editCollapsedLines: coerceEditPreviewLines(
+      getObjectValue(data, "editCollapsedLines"),
+      fallback.editCollapsedLines,
+    ),
+    grepCollapsedLines: coerceNumber(
+      getObjectValue(data, "grepCollapsedLines"),
+      fallback.grepCollapsedLines,
+    ),
+    grepResultPreview:
+      typeof grepResultPreview === "boolean" ? grepResultPreview : fallback.grepResultPreview,
+    findResultPreview:
+      typeof findResultPreview === "boolean" ? findResultPreview : fallback.findResultPreview,
+    lsResultPreview:
+      typeof lsResultPreview === "boolean" ? lsResultPreview : fallback.lsResultPreview,
+    pathListCollapsedLines: coerceNumber(
+      getObjectValue(data, "pathListCollapsedLines"),
+      fallback.pathListCollapsedLines,
+    ),
+    readLineNumbers:
+      typeof readLineNumbers === "boolean" ? readLineNumbers : fallback.readLineNumbers,
+    bashResultPreview:
+      typeof bashResultPreview === "boolean" ? bashResultPreview : fallback.bashResultPreview,
+    bashWarnings: typeof bashWarnings === "boolean" ? bashWarnings : fallback.bashWarnings,
+    syntaxHighlighting:
+      typeof syntaxHighlighting === "boolean" ? syntaxHighlighting : fallback.syntaxHighlighting,
+    secretWarnings: typeof secretWarnings === "boolean" ? secretWarnings : fallback.secretWarnings,
+    pathIcons: isPathIconMode(pathIcons) ? pathIcons : fallback.pathIcons,
+    tools: coerceTools(getObjectValue(data, "tools"), fallback.tools),
+  });
+}
+
+export function updateSetting(
+  current: CodePreviewSettings,
+  id: string,
+  value: string,
+): CodePreviewSettings {
+  const next = { ...current };
+  if (id === "shikiTheme" && isBundledThemeName(value)) next.shikiTheme = value;
+  else if (id === "diffIntensity" && isDiffBackgroundIntensity(value)) next.diffIntensity = value;
+  else if (id === "wordEmphasis" && isDiffWordEmphasis(value)) next.wordEmphasis = value;
+  else if (id === "readCollapsedLines")
+    next.readCollapsedLines = coerceStringNumber(value, current.readCollapsedLines);
+  else if (id === "readContentPreview") next.readContentPreview = value === "on";
+  else if (id === "writeCollapsedLines")
+    next.writeCollapsedLines = coerceStringNumber(value, current.writeCollapsedLines);
+  else if (id === "editCollapsedLines")
+    next.editCollapsedLines =
+      value === "all"
+        ? "all"
+        : coerceStringNumber(
+            value,
+            typeof current.editCollapsedLines === "number" ? current.editCollapsedLines : 100,
+          );
+  else if (id === "grepCollapsedLines")
+    next.grepCollapsedLines = coerceStringNumber(value, current.grepCollapsedLines);
+  else if (id === "grepResultPreview") next.grepResultPreview = value === "on";
+  else if (id === "findResultPreview") next.findResultPreview = value === "on";
+  else if (id === "lsResultPreview") next.lsResultPreview = value === "on";
+  else if (id === "pathListCollapsedLines")
+    next.pathListCollapsedLines = coerceStringNumber(value, current.pathListCollapsedLines);
+  else if (id === "readLineNumbers") next.readLineNumbers = value === "on";
+  else if (id === "bashResultPreview") next.bashResultPreview = value === "on";
+  else if (id === "bashWarnings") next.bashWarnings = value === "on";
+  else if (id === "syntaxHighlighting") next.syntaxHighlighting = value === "on";
+  else if (id === "secretWarnings") next.secretWarnings = value === "on";
+  else if (id === "pathIcons" && isPathIconMode(value)) next.pathIcons = value;
+  else if (id === "tools") next.tools = coerceTools(value, current.tools);
+  else if (id.startsWith("tool:")) next.tools = updateToolToggle(current.tools, id, value);
+  else if (id === "resetToDefaults" && value === "reset now")
+    return { ...defaultCodePreviewSettings };
+  return withRequiredToolRenderers(next);
+}
+
+function envTheme(name: string, fallback: string): string {
+  const value = process.env[name];
+  return isBundledThemeName(value) ? value : fallback;
+}
+
+function envNumber(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function envBoolean(name: string, fallback: boolean): boolean {
+  const value = process.env[name]?.toLowerCase();
+  if (value === undefined) return fallback;
+  return value === "1" || value === "true" || value === "on" || value === "yes";
+}
+
+function envEditLines(name: string, fallback: number | "all"): number | "all" {
+  const value = process.env[name];
+  if (value === "all") return "all";
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : fallback;
+}
+
+function envDiffIntensity(
+  name: string,
+  fallback: DiffBackgroundIntensity,
+): DiffBackgroundIntensity {
+  const value = process.env[name];
+  return isDiffBackgroundIntensity(value) ? value : fallback;
+}
+
+function envDiffWordEmphasis(name: string, fallback: DiffWordEmphasis): DiffWordEmphasis {
+  const value = process.env[name]?.toLowerCase();
+  return isDiffWordEmphasis(value) ? value : fallback;
+}
+
+function envPathIconMode(name: string, fallback: PathIconMode): PathIconMode {
+  const value = process.env[name]?.toLowerCase();
+  return isPathIconMode(value) ? value : fallback;
+}
+
+function coerceNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+function coerceStringNumber(value: string, fallback: number): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : fallback;
+}
+
+function coerceEditPreviewLines(value: unknown, fallback: number | "all"): number | "all" {
+  if (value === "all") return "all";
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) return Math.floor(value);
+  return fallback;
+}
+
+function coerceTools(value: unknown, fallback: CodePreviewToolName[]): CodePreviewToolName[] {
+  if (typeof value === "string") return [...(parseCodePreviewTools(value) ?? fallback)];
+  if (!Array.isArray(value)) return fallback;
+  const tools = value.filter(
+    (tool): tool is CodePreviewToolName => typeof tool === "string" && isCodePreviewToolName(tool),
+  );
+  return [...new Set(tools)];
+}
+
+export function getRequiredCodePreviewTools(
+  settings: CodePreviewSettings = codePreviewSettings,
+): Set<CodePreviewToolName> {
+  const tools = new Set<CodePreviewToolName>();
+  if (!settings.readContentPreview) tools.add("read");
+  if (!settings.grepResultPreview) tools.add("grep");
+  if (!settings.findResultPreview) tools.add("find");
+  if (!settings.lsResultPreview) tools.add("ls");
+  if (
+    !settings.bashResultPreview ||
+    !settings.grepResultPreview ||
+    !settings.findResultPreview ||
+    !settings.lsResultPreview
+  )
+    tools.add("bash");
+  return tools;
+}
+
+function withRequiredToolRenderers(settings: CodePreviewSettings): CodePreviewSettings {
+  const tools = new Set(settings.tools);
+  for (const tool of getRequiredCodePreviewTools(settings)) tools.add(tool);
+  return {
+    ...settings,
+    tools: ALL_CODE_PREVIEW_TOOLS.filter((tool) => tools.has(tool)),
+  };
+}
+
+function updateToolToggle(
+  currentTools: CodePreviewToolName[],
+  id: string,
+  value: string,
+): CodePreviewToolName[] {
+  const tool = id.slice("tool:".length);
+  if (!isCodePreviewToolName(tool)) return currentTools;
+  const enabled = new Set(currentTools);
+  if (value === "on") enabled.add(tool);
+  else if (value === "off") enabled.delete(tool);
+  return ALL_CODE_PREVIEW_TOOLS.filter((candidate) => enabled.has(candidate));
+}
+
+function isDiffBackgroundIntensity(value: unknown): value is DiffBackgroundIntensity {
+  return value === "off" || value === "subtle" || value === "medium";
+}
+
+function isDiffWordEmphasis(value: unknown): value is DiffWordEmphasis {
+  return value === "off" || value === "smart" || value === "all";
+}
+
+function isPathIconMode(value: unknown): value is PathIconMode {
+  return value === "off" || value === "unicode" || value === "nerd";
+}
+
+function isBundledThemeName(value: unknown): value is string {
+  return typeof value === "string" && value in bundledThemes;
+}

--- a/extensions/pi-code-previews/src/shiki.ts
+++ b/extensions/pi-code-previews/src/shiki.ts
@@ -1,0 +1,303 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { bundledThemesInfo, createHighlighter } from "shiki";
+import { hashString } from "./hash.ts";
+import { setCodePreviewSettings, codePreviewSettings } from "./settings.ts";
+import { escapeControlChars } from "./terminal-text.ts";
+
+export { escapeControlChars } from "./terminal-text.ts";
+
+let shikiHighlighter: Awaited<ReturnType<typeof createHighlighter>> | undefined;
+let shikiInitVersion = 0;
+let shikiHighlighterGeneration = 0;
+let shikiInitializingTheme: string | undefined;
+let renderCacheChars = 0;
+const loadedShikiLanguages = new Set<string>();
+const pendingShikiLanguages = new Set<string>();
+const renderCache = new Map<string, string[]>();
+const renderCacheSizes = new Map<string, number>();
+const languageLoadCallbacks = new Map<string, Set<() => void>>();
+const highlighterReadyCallbacks = new Set<() => void>();
+const shikiThemeTypes = new Map(bundledThemesInfo.map((theme) => [theme.id, theme.type]));
+
+const MAX_HIGHLIGHT_CHARS = envPositiveInteger("CODE_PREVIEW_MAX_HIGHLIGHT_CHARS", 80000);
+const CACHE_LIMIT = envPositiveInteger("CODE_PREVIEW_CACHE_LIMIT", 192);
+const CACHE_CHAR_LIMIT = envPositiveInteger("CODE_PREVIEW_CACHE_CHAR_LIMIT", 4_000_000);
+
+const PRELOADED_SHIKI_LANGUAGES = [
+  "bash",
+  "typescript",
+  "tsx",
+  "javascript",
+  "jsx",
+  "json",
+  "markdown",
+  "diff",
+  "yaml",
+] as const;
+
+export async function initializeShiki(theme: string) {
+  if (!codePreviewSettings.syntaxHighlighting) return;
+  const initVersion = ++shikiInitVersion;
+  shikiInitializingTheme = theme;
+  try {
+    const nextHighlighter = await createHighlighter({
+      themes: [theme],
+      langs: [...PRELOADED_SHIKI_LANGUAGES],
+    });
+    if (initVersion !== shikiInitVersion) {
+      nextHighlighter.dispose();
+      return;
+    }
+
+    const previousHighlighter = shikiHighlighter;
+    shikiHighlighter = nextHighlighter;
+    shikiInitializingTheme = undefined;
+    shikiHighlighterGeneration++;
+    previousHighlighter?.dispose();
+
+    clearRenderCache();
+    loadedShikiLanguages.clear();
+    pendingShikiLanguages.clear();
+    languageLoadCallbacks.clear();
+    setCodePreviewSettings({ ...codePreviewSettings, shikiTheme: theme });
+    for (const lang of PRELOADED_SHIKI_LANGUAGES) loadedShikiLanguages.add(lang);
+    notifyHighlighterReady();
+  } catch (error) {
+    if (initVersion !== shikiInitVersion) return;
+    shikiInitializingTheme = undefined;
+    console.warn(
+      "[pi-code-previews] Shiki failed to initialize; previews will be plain text.",
+      error,
+    );
+    shikiHighlighter?.dispose();
+    shikiHighlighter = undefined;
+    shikiHighlighterGeneration++;
+    clearRenderCache();
+    loadedShikiLanguages.clear();
+    pendingShikiLanguages.clear();
+    languageLoadCallbacks.clear();
+    highlighterReadyCallbacks.clear();
+  }
+}
+
+export function renderHighlightedText(
+  text: string,
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+): string[] {
+  const normalized = text.replace(/\t/g, "   ");
+  const plain = () =>
+    normalized.split("\n").map((line) => theme.fg("toolOutput", escapeControlChars(line)));
+  if (!codePreviewSettings.syntaxHighlighting || !lang || shouldSkipHighlight(normalized))
+    return plain();
+  return renderWithShiki(normalized, lang, invalidate) ?? plain();
+}
+
+export function renderWithShiki(
+  code: string,
+  lang: string | undefined,
+  invalidate?: () => void,
+): string[] | undefined {
+  if (!codePreviewSettings.syntaxHighlighting || !lang || shouldSkipHighlight(code))
+    return undefined;
+  if (!shikiHighlighter) {
+    requestHighlighterInit(codePreviewSettings.shikiTheme, invalidate);
+    return undefined;
+  }
+  const shikiLang = normalizeShikiLanguage(lang);
+  const cacheKey = `${codePreviewSettings.shikiTheme}\0${shikiLang}\0${code.length}\0${hashString(code)}`;
+  const cached = renderCache.get(cacheKey);
+  if (cached) {
+    renderCache.delete(cacheKey);
+    renderCache.set(cacheKey, cached);
+    return cached;
+  }
+  try {
+    if (!loadedShikiLanguages.has(shikiLang)) requestLanguageLoad(shikiLang, invalidate);
+    const tokens = shikiHighlighter.codeToTokensBase(code, {
+      lang: shikiLang as never,
+      theme: codePreviewSettings.shikiTheme as never,
+    });
+    const rendered = tokens.map((line) =>
+      normalizeShikiContrast(line.map((token) => ansiFromToken(token)).join("")),
+    );
+    cacheRendered(cacheKey, rendered);
+    return rendered;
+  } catch {
+    return undefined;
+  }
+}
+
+export function shouldSkipHighlight(text: string): boolean {
+  return (
+    Number.isFinite(MAX_HIGHLIGHT_CHARS) &&
+    MAX_HIGHLIGHT_CHARS > 0 &&
+    text.length > MAX_HIGHLIGHT_CHARS
+  );
+}
+
+export function getShikiStatus(): {
+  initialized: boolean;
+  cacheSize: number;
+  cacheLimit: number;
+  maxHighlightChars: number;
+  loadedLanguages: number;
+  pendingLanguages: number;
+} {
+  return {
+    initialized: Boolean(shikiHighlighter),
+    cacheSize: renderCache.size,
+    cacheLimit: CACHE_LIMIT,
+    maxHighlightChars: MAX_HIGHLIGHT_CHARS,
+    loadedLanguages: loadedShikiLanguages.size,
+    pendingLanguages: pendingShikiLanguages.size,
+  };
+}
+
+function cacheRendered(key: string, value: string[]): void {
+  const previousSize = renderCacheSizes.get(key) ?? 0;
+  if (previousSize > 0) renderCacheChars -= previousSize;
+  const size = renderedCharSize(value);
+  renderCache.set(key, value);
+  renderCacheSizes.set(key, size);
+  renderCacheChars += size;
+  while (renderCache.size > CACHE_LIMIT || renderCacheChars > CACHE_CHAR_LIMIT) {
+    const first = renderCache.keys().next().value;
+    if (typeof first !== "string") break;
+    deleteCachedRender(first);
+  }
+}
+
+function deleteCachedRender(key: string): void {
+  renderCache.delete(key);
+  renderCacheChars -= renderCacheSizes.get(key) ?? 0;
+  renderCacheSizes.delete(key);
+}
+
+function clearRenderCache(): void {
+  renderCache.clear();
+  renderCacheSizes.clear();
+  renderCacheChars = 0;
+}
+
+function renderedCharSize(value: string[]): number {
+  let total = 0;
+  for (const line of value) total += line.length;
+  return total;
+}
+
+function requestHighlighterInit(theme: string, invalidate: (() => void) | undefined): void {
+  if (invalidate) highlighterReadyCallbacks.add(invalidate);
+  if (shikiInitializingTheme === theme) return;
+  void initializeShiki(theme);
+}
+
+function notifyHighlighterReady(): void {
+  const callbacks = [...highlighterReadyCallbacks];
+  highlighterReadyCallbacks.clear();
+  callbacks.forEach((callback) => callback());
+}
+
+function requestLanguageLoad(shikiLang: string, invalidate: (() => void) | undefined): void {
+  if (invalidate) {
+    const callbacks = languageLoadCallbacks.get(shikiLang) ?? new Set<() => void>();
+    callbacks.add(invalidate);
+    languageLoadCallbacks.set(shikiLang, callbacks);
+  }
+  if (pendingShikiLanguages.has(shikiLang)) return;
+  const highlighter = shikiHighlighter;
+  if (!highlighter) return;
+  const generation = shikiHighlighterGeneration;
+  pendingShikiLanguages.add(shikiLang);
+  void highlighter
+    .loadLanguage(shikiLang as never)
+    .then(() => {
+      if (generation !== shikiHighlighterGeneration) return;
+      loadedShikiLanguages.add(shikiLang);
+      const callbacks = languageLoadCallbacks.get(shikiLang);
+      languageLoadCallbacks.delete(shikiLang);
+      callbacks?.forEach((callback) => callback());
+    })
+    .catch(() => {
+      if (generation === shikiHighlighterGeneration) languageLoadCallbacks.delete(shikiLang);
+    })
+    .finally(() => {
+      if (generation === shikiHighlighterGeneration) pendingShikiLanguages.delete(shikiLang);
+    });
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function normalizeShikiLanguage(lang: string): string {
+  const normalized = lang.toLowerCase();
+  if (normalized === "sh" || normalized === "shell" || normalized === "zsh") return "bash";
+  if (
+    normalized === "shell-session" ||
+    normalized === "shellsession" ||
+    normalized === "terminal" ||
+    normalized === "console"
+  )
+    return "shellscript";
+  if (normalized === "ts") return "typescript";
+  if (normalized === "js") return "javascript";
+  if (normalized === "md") return "markdown";
+  if (normalized === "yml") return "yaml";
+  return normalized;
+}
+
+function normalizeShikiContrast(ansi: string): string {
+  if (shikiThemeTypes.get(codePreviewSettings.shikiTheme) === "light") return ansi;
+  return ansi.replace(/\x1b\[([0-9;]*)m/g, (seq, params: string) =>
+    isLowContrastFg(params) ? "\x1b[38;2;139;148;158m" : seq,
+  );
+}
+
+function isLowContrastFg(params: string): boolean {
+  if (params === "30" || params === "90" || params === "38;5;0" || params === "38;5;8") return true;
+  if (!params.startsWith("38;2;")) return false;
+  const [, , r, g, b] = params.split(";").map(Number);
+  if (![r, g, b].every(Number.isFinite)) return false;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance < 72;
+}
+
+function ansiFromToken(
+  token: { content: string; color?: string; fontStyle?: number },
+  forceUnderline = false,
+): string {
+  let open = token.color ? ansiFg(token.color) : "";
+  let close = token.color ? "\x1b[39m" : "";
+  // TextMate fontStyle bit flags: italic=1, bold=2, underline=4.
+  const fontStyle = token.fontStyle ?? 0;
+  if (fontStyle & 2) {
+    open += "\x1b[1m";
+    close = "\x1b[22m" + close;
+  }
+  if (fontStyle & 1) {
+    open += "\x1b[3m";
+    close = "\x1b[23m" + close;
+  }
+  if (fontStyle & 4 || forceUnderline) {
+    open += "\x1b[4m";
+    close = "\x1b[24m" + close;
+  }
+  return open + escapeControlChars(token.content) + close;
+}
+
+const ansiFgCache = new Map<string, string>();
+
+function ansiFg(hex: string): string {
+  const cached = ansiFgCache.get(hex);
+  if (cached !== undefined) return cached;
+  const clean = hex.replace(/^#/, "").slice(0, 6);
+  const n = Number.parseInt(clean, 16);
+  const ansi = Number.isFinite(n)
+    ? `\x1b[38;2;${(n >> 16) & 255};${(n >> 8) & 255};${n & 255}m`
+    : "";
+  ansiFgCache.set(hex, ansi);
+  return ansi;
+}

--- a/extensions/pi-code-previews/src/terminal-text.ts
+++ b/extensions/pi-code-previews/src/terminal-text.ts
@@ -1,0 +1,114 @@
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+
+export function escapeControlChars(text: string): string {
+  return text
+    .replace(/\x1b/g, "␛")
+    .replace(/\r/g, "␍")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "�");
+}
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+export function visibleLength(text: string): number {
+  return visibleWidth(text);
+}
+
+export function wrapAnsiToWidth(
+  text: string,
+  width: number,
+  maxRows = 3,
+  continuationPrefix = "",
+): string[] {
+  if (width <= 0) return [""];
+  const rows: string[] = [];
+  let row = "";
+  let rowWidth = 0;
+  let index = 0;
+  let state = "";
+  const continuationWidth = visibleWidth(continuationPrefix);
+
+  function pushRow(): boolean {
+    rows.push(truncateToWidth(row, width, ""));
+    if (rows.length >= maxRows) {
+      truncateLastRow(rows, width);
+      return false;
+    }
+    row = continuationPrefix ? state + continuationPrefix : state;
+    rowWidth = continuationWidth;
+    return true;
+  }
+
+  while (index < text.length) {
+    const ansi = extractSgr(text, index);
+    if (ansi) {
+      row += ansi.sequence;
+      state = updateAnsiState(state, ansi.sequence);
+      index += ansi.sequence.length;
+      continue;
+    }
+
+    const nextAnsi = text.indexOf("\x1b", index);
+    const plainEnd = nextAnsi >= 0 ? nextAnsi : text.length;
+    const plain = text.slice(index, plainEnd);
+    for (const { segment } of segmenter.segment(plain)) {
+      const segmentWidth = visibleWidth(segment);
+      if (rowWidth > 0 && rowWidth + segmentWidth > width && !pushRow()) return rows;
+      if (segmentWidth > width && rowWidth === 0) {
+        const clipped = truncateToWidth(segment, width, "");
+        if (clipped) {
+          row += clipped;
+          rowWidth += visibleWidth(clipped);
+        }
+        if (!pushRow()) return rows;
+        continue;
+      }
+      row += segment;
+      rowWidth += segmentWidth;
+    }
+    index = plainEnd;
+  }
+
+  rows.push(truncateToWidth(row, width, ""));
+  if (rows.length > maxRows) return truncateLastRow(rows.slice(0, maxRows), width);
+  return rows;
+}
+
+function truncateLastRow(rows: string[], width: number): string[] {
+  const last = rows.at(-1) ?? "";
+  if (visibleWidth(last) >= width && width > 1)
+    rows[rows.length - 1] = truncateToWidth(last, width - 1, "") + "›";
+  return rows;
+}
+
+function extractSgr(text: string, index: number): { sequence: string } | undefined {
+  if (text[index] !== "\x1b" || text[index + 1] !== "[") return undefined;
+  let end = index + 2;
+  while (end < text.length && text[end] !== "m") end++;
+  if (end >= text.length) return undefined;
+  return { sequence: text.slice(index, end + 1) };
+}
+
+function updateAnsiState(current: string, sequence: string): string {
+  if (sequence === "\x1b[0m") return "";
+  if (/^\x1b\[3(?:8;[^m]+|9)m$/.test(sequence))
+    return replaceAnsi(current, /\x1b\[3(?:8;[^m]+|9)m/g, sequence === "\x1b[39m" ? "" : sequence);
+  if (/^\x1b\[4(?:8;[^m]+|9)m$/.test(sequence))
+    return replaceAnsi(current, /\x1b\[4(?:8;[^m]+|9)m/g, sequence === "\x1b[49m" ? "" : sequence);
+  if (sequence === "\x1b[22m") return current.replace(/\x1b\[(?:1|2)m/g, "");
+  if (sequence === "\x1b[1m") return replaceAnsi(current, /\x1b\[1m/g, sequence);
+  if (sequence === "\x1b[2m") return replaceAnsi(current, /\x1b\[2m/g, sequence);
+  if (sequence === "\x1b[3m" || sequence === "\x1b[23m")
+    return replaceAnsi(current, /\x1b\[(?:3|23)m/g, sequence === "\x1b[23m" ? "" : sequence);
+  if (sequence === "\x1b[4m" || sequence === "\x1b[24m")
+    return replaceAnsi(current, /\x1b\[(?:4|24)m/g, sequence === "\x1b[24m" ? "" : sequence);
+  return current + sequence;
+}
+
+function replaceAnsi(current: string, pattern: RegExp, replacement: string): string {
+  return current.replace(pattern, "") + replacement;
+}

--- a/extensions/pi-code-previews/src/tool-names.ts
+++ b/extensions/pi-code-previews/src/tool-names.ts
@@ -1,0 +1,30 @@
+export const ALL_CODE_PREVIEW_TOOLS = [
+  "bash",
+  "read",
+  "write",
+  "edit",
+  "grep",
+  "find",
+  "ls",
+] as const;
+
+export type CodePreviewToolName = (typeof ALL_CODE_PREVIEW_TOOLS)[number];
+
+export function isCodePreviewToolName(value: string): value is CodePreviewToolName {
+  return (ALL_CODE_PREVIEW_TOOLS as readonly string[]).includes(value);
+}
+
+export function parseCodePreviewTools(
+  raw: string | undefined,
+): Set<CodePreviewToolName> | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.toLowerCase() === "all") return new Set(ALL_CODE_PREVIEW_TOOLS);
+  if (trimmed.toLowerCase() === "none") return new Set();
+  const enabled = new Set<CodePreviewToolName>();
+  for (const part of trimmed.split(/[\s,]+/)) {
+    const tool = part.trim();
+    if (isCodePreviewToolName(tool)) enabled.add(tool);
+  }
+  return enabled;
+}

--- a/extensions/pi-code-previews/src/tool-renderers/bash.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/bash.ts
@@ -1,0 +1,140 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createBashToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getBashWarnings } from "../bash-warnings.ts";
+import { getObjectValue, getTextContent, isTruncated } from "../data.ts";
+import {
+  countLabel,
+  hiddenPreviewExpandHint,
+  previewFooter,
+  previewLines,
+  showingFooter,
+  trimSingleTrailingNewline,
+} from "../format.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { renderHighlightedText } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { withSecretWarning } from "./common.ts";
+
+export function registerBash(pi: ExtensionAPI, cwd: string) {
+  const originalBash = createBashToolDefinition(cwd);
+
+  pi.registerTool({
+    ...originalBash,
+
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalBash.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+
+    renderCall(args, theme, context) {
+      const command = typeof args.command === "string" ? args.command : "";
+      const timeout =
+        typeof args.timeout === "number" ? theme.fg("muted", ` (timeout ${args.timeout}s)`) : "";
+      const highlighted = renderHighlightedText(
+        command || "...",
+        "bash",
+        theme,
+        context.invalidate,
+      ).join("\n");
+      const warnings = codePreviewSettings.bashWarnings ? getBashWarnings(command) : [];
+      const warningText = warnings.length
+        ? `${theme.fg("warning", `⚠ Preview ${countLabel(warnings.length, "warning")}: ${warnings.join(", ")}`)}\n`
+        : "";
+      return new Text(
+        `${warningText}${theme.fg("toolTitle", theme.bold("$"))} ${highlighted}${timeout}`,
+        0,
+        0,
+      );
+    },
+
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Running…"), 0, 0);
+      if (!expanded && !context.isError && shouldHideBashResult(context.args))
+        return new Text(hiddenPreviewExpandHint(theme), 0, 0);
+      const output = trimSingleTrailingNewline(getTextContent(result.content));
+      const lines = output
+        ? output
+            .split("\n")
+            .map((line) =>
+              theme.fg(context.isError ? "error" : "toolOutput", escapeControlChars(line)),
+            )
+        : [];
+      const limit = expanded ? lines.length : 8;
+      const preview = previewLines(lines, limit, theme);
+      let text = preview.lines.length
+        ? withSecretWarning(output, theme, preview.lines.join("\n"))
+        : theme.fg("muted", "No output");
+      if (preview.hidden > 0)
+        text += showingFooter(theme, preview.shown, lines.length, "output lines");
+      if (isTruncated(result.details)) text += previewFooter(theme, "Output truncated by bash");
+      const fullOutputPath = getObjectValue(result.details, "fullOutputPath");
+      if (typeof fullOutputPath === "string")
+        text += previewFooter(theme, `Full output: ${escapeControlChars(fullOutputPath)}`);
+      return new Text(text, 0, 0);
+    },
+  });
+}
+
+function shouldHideBashResult(args: unknown): boolean {
+  if (!codePreviewSettings.bashResultPreview) return true;
+  const command = getObjectValue(args, "command");
+  if (typeof command !== "string") return false;
+  const shellCommand = getFirstShellCommandName(command);
+  if (
+    (shellCommand === "grep" || shellCommand === "egrep" || shellCommand === "fgrep") &&
+    !codePreviewSettings.grepResultPreview
+  )
+    return true;
+  if (shellCommand === "find" && !codePreviewSettings.findResultPreview) return true;
+  if (shellCommand === "ls" && !codePreviewSettings.lsResultPreview) return true;
+  return false;
+}
+
+function getFirstShellCommandName(command: string): string | undefined {
+  const words = getLeadingShellWords(command);
+  const commandWord = words.find((word) => !isShellAssignment(word));
+  return commandWord?.split("/").pop();
+}
+
+function getLeadingShellWords(command: string): string[] {
+  const words: string[] = [];
+  let index = 0;
+  while (index < command.length) {
+    while (index < command.length && /\s/.test(command[index]!)) index++;
+    if (index >= command.length || isShellOperator(command[index]!)) break;
+
+    let word = "";
+    while (index < command.length) {
+      const char = command[index]!;
+      if (/\s/.test(char) || isShellOperator(char)) break;
+      if (char === "'" || char === '"') {
+        const quote = char;
+        index++;
+        while (index < command.length && command[index] !== quote) {
+          if (quote === '"' && command[index] === "\\") index++;
+          if (index < command.length) word += command[index++]!;
+        }
+        if (index < command.length) index++;
+        continue;
+      }
+      if (char === "\\") {
+        index++;
+        if (index < command.length) word += command[index++]!;
+        continue;
+      }
+      word += char;
+      index++;
+    }
+    if (word) words.push(word);
+    if (words.length >= 8) break;
+  }
+  return words;
+}
+
+function isShellAssignment(word: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word);
+}
+
+function isShellOperator(char: string): boolean {
+  return "|&;()<>{}".includes(char);
+}

--- a/extensions/pi-code-previews/src/tool-renderers/common.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/common.ts
@@ -1,0 +1,194 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import {
+  countLabel,
+  hiddenLinesMarker,
+  selectPreviewLines,
+  selectPreviewTextLines,
+} from "../format.ts";
+import { hashString } from "../hash.ts";
+import { getSecretWarnings } from "../secret-warnings.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { renderHighlightedText } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+
+const SECRET_SCAN_CHARS = positiveEnvInteger("CODE_PREVIEW_SECRET_SCAN_CHARS", 200_000);
+
+export function withSecretWarning(source: string, theme: Theme, preview: string): string {
+  if (!codePreviewSettings.secretWarnings) return preview;
+  const warnings = getSecretWarnings(secretScanSample(source));
+  if (warnings.length === 0) return preview;
+  return `${theme.fg("warning", `⚠ Preview ${countLabel(warnings.length, "warning")}: possible ${warnings.join(", ")}`)}\n${preview}`;
+}
+
+export function countFileLines(content: string): number {
+  if (!content) return 0;
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const withoutFinalTerminator = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
+  return withoutFinalTerminator.split("\n").length;
+}
+
+export function renderHighlightedPreviewLines(
+  rawLines: string[],
+  limit: number,
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+  lineNumbers?: { firstLine: number; lineNumberWidth?: number },
+): { lines: string[]; shown: number; hidden: number } {
+  return renderHighlightedPreviewEntries(
+    selectPreviewLines(rawLines, limit),
+    lang,
+    theme,
+    invalidate,
+    lineNumbers,
+  );
+}
+
+export function renderHighlightedPreviewText(
+  text: string,
+  limit: number,
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+  lineNumbers?: { firstLine: number; lineNumberWidth?: number },
+): { lines: string[]; shown: number; hidden: number; total: number } {
+  const preview = selectPreviewTextLines(text, limit);
+  const numbered = lineNumbers
+    ? {
+        ...lineNumbers,
+        lineNumberWidth:
+          lineNumbers.lineNumberWidth ??
+          String(lineNumbers.firstLine + Math.max(0, preview.total - 1)).length,
+      }
+    : undefined;
+  return {
+    ...renderHighlightedPreviewEntries(preview, lang, theme, invalidate, numbered),
+    total: preview.total,
+  };
+}
+
+function renderHighlightedPreviewEntries(
+  preview: {
+    entries: ReturnType<typeof selectPreviewLines<string>>["entries"];
+    shown: number;
+    hidden: number;
+  },
+  lang: string | undefined,
+  theme: Theme,
+  invalidate?: () => void,
+  lineNumbers?: { firstLine: number; lineNumberWidth?: number },
+): { lines: string[]; shown: number; hidden: number } {
+  const lines: string[] = [];
+  let chunk: Array<{ line: string; index: number }> = [];
+
+  function flushChunk(): void {
+    if (chunk.length === 0) return;
+    const normalizedChunk = chunk.map((entry) => entry.line.replace(/\t/g, "   "));
+    const highlighted = renderHighlightedText(normalizedChunk.join("\n"), lang, theme, invalidate);
+    for (let index = 0; index < chunk.length; index++) {
+      const rendered =
+        highlighted[index] ??
+        theme.fg("toolOutput", escapeControlChars(normalizedChunk[index] ?? ""));
+      if (!lineNumbers || !codePreviewSettings.readLineNumbers) {
+        lines.push(rendered);
+        continue;
+      }
+      const width =
+        lineNumbers.lineNumberWidth ?? String(lineNumbers.firstLine + chunk[index]!.index).length;
+      const lineNumber = String(lineNumbers.firstLine + chunk[index]!.index).padStart(width, " ");
+      lines.push(`${theme.fg("dim", `${lineNumber} │ `)}${rendered}`);
+    }
+    chunk = [];
+  }
+
+  for (const entry of preview.entries) {
+    if (entry.kind === "hidden") {
+      flushChunk();
+      lines.push(hiddenLinesMarker(theme, entry.hidden));
+    } else {
+      chunk.push({ line: entry.line, index: entry.index });
+    }
+  }
+  flushChunk();
+  return { lines, shown: preview.shown, hidden: preview.hidden };
+}
+
+export function renderSelectedOutputLines(
+  rawLines: string[],
+  limit: number,
+  theme: Theme,
+  renderChunk: (chunk: string[]) => string[],
+): { lines: string[]; shown: number; hidden: number } {
+  const preview = selectPreviewLines(rawLines, limit);
+  const lines: string[] = [];
+  let chunk: string[] = [];
+
+  function flushChunk(): void {
+    if (chunk.length === 0) return;
+    lines.push(...renderChunk(chunk));
+    chunk = [];
+  }
+
+  for (const entry of preview.entries) {
+    if (entry.kind === "hidden") {
+      flushChunk();
+      lines.push(hiddenLinesMarker(theme, entry.hidden));
+    } else {
+      chunk.push(entry.line);
+    }
+  }
+  flushChunk();
+  return { lines, shown: preview.shown, hidden: preview.hidden };
+}
+
+export function cachedPreview(
+  state: Record<string, unknown>,
+  keyName: string,
+  componentName: string,
+  key: string,
+  create: () => Component,
+): Component {
+  const cached = state[componentName];
+  if (state[keyName] !== key || !cached || typeof (cached as Component).render !== "function") {
+    state[keyName] = key;
+    state[componentName] = create();
+  }
+  return state[componentName] as Component;
+}
+
+export function previewCacheKey(
+  kind: string,
+  source: string,
+  path: string,
+  expanded: boolean,
+  theme: Theme,
+): string {
+  return [
+    kind,
+    path,
+    expanded ? "expanded" : "collapsed",
+    codePreviewSettings.shikiTheme,
+    codePreviewSettings.syntaxHighlighting ? "syntax" : "plain",
+    codePreviewSettings.diffIntensity,
+    String(codePreviewSettings.editCollapsedLines),
+    (theme as Theme & { name?: string }).name ?? "",
+    source.length,
+    hashString(source),
+  ].join("\0");
+}
+
+export function previewArgsKey(kind: string, source: string, path: string): string {
+  return [kind, path, source.length, hashString(source)].join("\0");
+}
+
+function secretScanSample(source: string): string {
+  if (source.length <= SECRET_SCAN_CHARS) return source;
+  const half = Math.floor(SECRET_SCAN_CHARS / 2);
+  return `${source.slice(0, half)}\n${source.slice(-half)}`;
+}
+
+function positiveEnvInteger(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/extensions/pi-code-previews/src/tool-renderers/edit.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/edit.ts
@@ -1,0 +1,298 @@
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
+import { createEditToolDefinition, getLanguageFromPath } from "@mariozechner/pi-coding-agent";
+import { Container, Text, type Component } from "@mariozechner/pi-tui";
+import { AsyncPreview, shouldRenderAsync } from "../async-preview.ts";
+import { getEditDiff, getObjectValue, getPathArg, getTextContent } from "../data.ts";
+import {
+  createProgressiveSyntaxHighlightedDiffText,
+  FullWidthDiffText,
+  renderPlainDiff,
+  renderSyntaxHighlightedDiff,
+  summarizeDiff,
+} from "../diff.ts";
+import { countLabel, previewFooter, showingFooter, themedKeyHint } from "../format.ts";
+import { resolvePreviewLanguage } from "../language.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { shouldSkipHighlight } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { createSimpleDiff } from "../write-diff.ts";
+import { cachedPreview, previewArgsKey, previewCacheKey } from "./common.ts";
+
+export function registerEdit(pi: ExtensionAPI, cwd: string) {
+  const originalEdit = createEditToolDefinition(cwd);
+
+  pi.registerTool({
+    ...originalEdit,
+    // The built-in edit tool uses renderShell: "self". Override that so pi
+    // wraps our highlighted diff in the standard colored tool background.
+    renderShell: "default",
+
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalEdit.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+
+    renderCall(args, theme, context) {
+      const path = getPathArg(args);
+      const operations = getEditPreviewOperations(args);
+      const operationsSource = editOperationsSource(operations);
+      const argsKey = previewArgsKey("edit-args", operationsSource, path);
+      if (context.state.editArgsKey !== argsKey) {
+        context.state.editArgsKey = argsKey;
+        context.state.editSummaryText = undefined;
+        context.state.editCallPreviewKey = undefined;
+        context.state.editCallPreviewComponent = undefined;
+      }
+
+      const text =
+        context.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+      context.state.editHeaderText = text;
+      text.setText(formatEditHeader(path, cwd, theme, context.state.editSummaryText));
+
+      if (!context.argsComplete || operations.length === 0 || context.executionStarted) return text;
+
+      const previewKey = previewCacheKey(
+        "edit-call",
+        operationsSource,
+        path,
+        context.expanded,
+        theme,
+      );
+      if (context.state.editCallPreviewKey !== previewKey) {
+        context.state.editCallPreviewKey = previewKey;
+        const render = () =>
+          renderEditCallPreview(operations, path, context.expanded, theme, context.invalidate);
+        context.state.editCallPreviewComponent = shouldRenderAsync(operationsSource)
+          ? new AsyncPreview("Rendering proposed edit diff…", theme, render, context.invalidate)
+          : render();
+      }
+      return new HeaderAndBody(text, context.state.editCallPreviewComponent as Component);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Editing…"), 0, 0);
+
+      const firstText = getTextContent(result.content);
+      if (context.isError) {
+        context.state.editSummaryText = undefined;
+        updateEditHeader(context, cwd, theme);
+        return new Text(
+          theme.fg("error", escapeControlChars(firstText.split("\n")[0] || "Edit failed")),
+          0,
+          0,
+        );
+      }
+
+      const diff = getEditDiff(result.details);
+      if (!diff) {
+        context.state.editSummaryText = `${theme.fg("success", "✓ Edit applied")}${theme.fg("muted", " · no diff")}`;
+        updateEditHeader(context, cwd, theme);
+        return new Container();
+      }
+
+      const filePath = getPathArg(context.args);
+      const lang = resolvePreviewLanguage({
+        path: filePath,
+        piLanguage: getLanguageFromPath(filePath),
+      });
+      const summary = summarizeDiff(diff);
+      const limit =
+        expanded || codePreviewSettings.editCollapsedLines === "all"
+          ? summary.totalLines
+          : codePreviewSettings.editCollapsedLines;
+      context.state.editSummaryText = formatEditSummary(summary, limit, theme);
+      if (!expanded && summary.totalLines > limit)
+        context.state.editSummaryText += ` (${themedKeyHint(theme, "app.tools.expand", "expand")})`;
+      updateEditHeader(context, cwd, theme);
+      const render = () =>
+        renderEditDiffPreview(diff, lang, limit, summary.totalLines, theme, context.invalidate);
+      const previewKey = previewCacheKey("edit-result", diff, filePath, expanded, theme);
+      return cachedPreview(
+        context.state,
+        "editResultPreviewKey",
+        "editResultPreviewComponent",
+        previewKey,
+        () =>
+          shouldRenderAsync(diff)
+            ? new AsyncPreview("Rendering edit diff…", theme, render, context.invalidate)
+            : render(),
+      );
+    },
+  });
+}
+
+function renderEditDiffPreview(
+  diff: string,
+  lang: string | undefined,
+  limit: number,
+  totalLines: number,
+  theme: Theme,
+  invalidate?: () => void,
+): FullWidthDiffText {
+  const skipSyntaxHighlight = shouldSkipHighlight(diff);
+  const footer = (body: string) => {
+    let text = body;
+    if (totalLines > limit) text += showingFooter(theme, limit, totalLines, "diff lines");
+    if (skipSyntaxHighlight)
+      text += previewFooter(theme, "Syntax highlighting skipped for large diff");
+    return text;
+  };
+  return skipSyntaxHighlight
+    ? new FullWidthDiffText(footer(renderPlainDiff(diff, theme, limit)), theme)
+    : createProgressiveSyntaxHighlightedDiffText(diff, lang, theme, limit, {
+        decorate: footer,
+        invalidate,
+      });
+}
+
+function getEditPreviewOperations(args: unknown): Array<{ oldText: string; newText: string }> {
+  const edits = getObjectValue(args, "edits");
+  if (Array.isArray(edits)) {
+    return edits.flatMap((edit) => {
+      const oldText = getObjectValue(edit, "oldText") ?? getObjectValue(edit, "old_text");
+      const newText = getObjectValue(edit, "newText") ?? getObjectValue(edit, "new_text");
+      return typeof oldText === "string" && typeof newText === "string" && oldText !== newText
+        ? [{ oldText, newText }]
+        : [];
+    });
+  }
+  const oldText = getObjectValue(args, "oldText") ?? getObjectValue(args, "old_text");
+  const newText = getObjectValue(args, "newText") ?? getObjectValue(args, "new_text");
+  return typeof oldText === "string" && typeof newText === "string" && oldText !== newText
+    ? [{ oldText, newText }]
+    : [];
+}
+
+function editOperationsSource(operations: Array<{ oldText: string; newText: string }>): string {
+  return operations.map((operation) => `${operation.oldText}\0${operation.newText}`).join("\0\0");
+}
+
+function renderEditCallPreview(
+  operations: Array<{ oldText: string; newText: string }>,
+  path: string,
+  expanded: boolean,
+  theme: Theme,
+  invalidate?: () => void,
+): FullWidthDiffText {
+  const lang = resolvePreviewLanguage({ path, piLanguage: getLanguageFromPath(path) });
+  const maxOperations = Math.min(operations.length, 3);
+  const perOperationLimit =
+    operations.length > 1
+      ? Math.max(
+          8,
+          Math.floor(
+            (typeof codePreviewSettings.editCollapsedLines === "number"
+              ? codePreviewSettings.editCollapsedLines
+              : 160) / maxOperations,
+          ),
+        )
+      : undefined;
+  const sections: string[] = [];
+  const diffs = operations.map((operation) =>
+    createSimpleDiff(operation.oldText, operation.newText),
+  );
+  const summaries = diffs.map((diff) => summarizeDiff(diff));
+  const totalAdditions = summaries.reduce((total, summary) => total + summary.additions, 0);
+  const totalRemovals = summaries.reduce((total, summary) => total + summary.removals, 0);
+  const totalLines = summaries.reduce((total, summary) => total + summary.totalLines, 0);
+
+  for (let index = 0; index < maxOperations; index++) {
+    const diff = diffs[index]!;
+    const summary = summaries[index]!;
+    const limit =
+      expanded || codePreviewSettings.editCollapsedLines === "all"
+        ? summary.totalLines
+        : (perOperationLimit ?? codePreviewSettings.editCollapsedLines);
+    const skipSyntaxHighlight = shouldSkipHighlight(diff);
+    let rendered = skipSyntaxHighlight
+      ? renderPlainDiff(diff, theme, limit)
+      : renderSyntaxHighlightedDiff(diff, lang, theme, limit, invalidate);
+    if (summary.totalLines > limit)
+      rendered += showingFooter(theme, limit, summary.totalLines, "proposed diff lines");
+    if (skipSyntaxHighlight)
+      rendered += previewFooter(theme, "Syntax highlighting skipped for large proposed diff");
+    if (operations.length > 1)
+      sections.push(theme.fg("muted", `Proposed edit ${index + 1}/${operations.length}`));
+    sections.push(rendered);
+  }
+
+  const remainder = operations.length - maxOperations;
+  const header = `${theme.fg("muted", "proposed edit")} ${theme.fg("success", `+${totalAdditions}`)} ${theme.fg("error", `-${totalRemovals}`)}${operations.length > 1 ? theme.fg("muted", ` · ${operations.length} edit blocks`) : ""}`;
+  let text = `${header}\n${sections.join("\n")}`;
+  if (remainder > 0) text += showingFooter(theme, maxOperations, operations.length, "edit blocks");
+  else if (
+    !expanded &&
+    operations.length === 1 &&
+    totalLines >
+      (typeof codePreviewSettings.editCollapsedLines === "number"
+        ? codePreviewSettings.editCollapsedLines
+        : totalLines)
+  ) {
+    text += ` (${themedKeyHint(theme, "app.tools.expand", "expand")})`;
+  }
+  return new FullWidthDiffText(text, theme);
+}
+
+class HeaderAndBody implements Component {
+  constructor(
+    private readonly header: Component,
+    private readonly body: Component,
+  ) {}
+
+  render(width: number): string[] {
+    return [...this.header.render(width), ...this.body.render(width)];
+  }
+
+  invalidate(): void {
+    this.header.invalidate();
+    this.body.invalidate();
+  }
+}
+
+function formatEditHeader(path: string, cwd: string, theme: Theme, summaryText: unknown): string {
+  const base = `${theme.fg("toolTitle", theme.bold("edit"))} ${renderDisplayPath(path, cwd, theme)}`;
+  return typeof summaryText === "string" && summaryText
+    ? `${base}${editSummarySeparator(theme)}${summaryText}`
+    : base;
+}
+
+function updateEditHeader(
+  context: { args: unknown; state: Record<string, unknown> },
+  cwd: string,
+  theme: Theme,
+): void {
+  const text = context.state.editHeaderText;
+  if (text instanceof Text)
+    text.setText(
+      formatEditHeader(getPathArg(context.args), cwd, theme, context.state.editSummaryText),
+    );
+}
+
+function formatEditSummary(
+  summary: ReturnType<typeof summarizeDiff>,
+  limit: number,
+  theme: Theme,
+): string {
+  let text = theme.fg("muted", describeEditShape(summary));
+  text += editSummarySeparator(theme) + theme.fg("muted", countLabel(summary.hunks, "hunk"));
+  text +=
+    editSummarySeparator(theme) +
+    `${theme.fg("success", `+${summary.additions}`)} ${theme.fg("error", `-${summary.removals}`)}`;
+  if (summary.totalLines > limit)
+    text +=
+      editSummarySeparator(theme) +
+      theme.fg("muted", `showing ${limit}/${summary.totalLines} diff lines`);
+  return text;
+}
+
+function editSummarySeparator(theme: Theme): string {
+  return theme.fg("muted", " · ");
+}
+
+function describeEditShape(summary: ReturnType<typeof summarizeDiff>): string {
+  const parts: string[] = [];
+  if (summary.replacements > 0) parts.push(countLabel(summary.replacements, "replacement"));
+  if (summary.insertions > 0) parts.push(countLabel(summary.insertions, "insertion"));
+  if (summary.deletions > 0) parts.push(countLabel(summary.deletions, "deletion"));
+  return parts.length ? parts.join(", ") : "changes";
+}

--- a/extensions/pi-code-previews/src/tool-renderers/find.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/find.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createFindToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getTextContent } from "../data.ts";
+import { hiddenPreviewExpandHint, showingFooter, trimSingleTrailingNewline } from "../format.ts";
+import { renderPathListLines } from "../path-list-rendering.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { renderSelectedOutputLines } from "./common.ts";
+
+export function registerFind(pi: ExtensionAPI, cwd: string) {
+  const originalFind = createFindToolDefinition(cwd);
+  pi.registerTool({
+    ...originalFind,
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalFind.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+    renderCall(args, theme) {
+      const pattern = typeof args.pattern === "string" ? args.pattern : "";
+      const path = typeof args.path === "string" && args.path ? args.path : ".";
+      return new Text(
+        `${theme.fg("toolTitle", theme.bold("find"))} ${theme.fg("accent", escapeControlChars(pattern || "*"))} ${theme.fg("muted", "in")} ${renderDisplayPath(path, cwd, theme)}`,
+        0,
+        0,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Finding…"), 0, 0);
+      const output = trimSingleTrailingNewline(getTextContent(result.content));
+      if (context.isError)
+        return new Text(
+          theme.fg("error", escapeControlChars(output.split("\n")[0] || "Find failed")),
+          0,
+          0,
+        );
+      if (!expanded && !codePreviewSettings.findResultPreview)
+        return new Text(hiddenPreviewExpandHint(theme), 0, 0);
+      if (!output || output === "No files found matching pattern")
+        return new Text(theme.fg("muted", output || "No files found"), 0, 0);
+      if (expanded && !codePreviewSettings.findResultPreview)
+        return new Text(
+          output
+            .split("\n")
+            .map((line) => theme.fg("toolOutput", escapeControlChars(line)))
+            .join("\n"),
+          0,
+          0,
+        );
+      const rawLines = output.split("\n");
+      const limit = expanded ? rawLines.length : codePreviewSettings.pathListCollapsedLines;
+      const preview = renderSelectedOutputLines(rawLines, limit, theme, (chunk) =>
+        renderPathListLines(chunk.join("\n"), cwd, theme),
+      );
+      let text = preview.lines.join("\n");
+      if (preview.hidden > 0) text += showingFooter(theme, preview.shown, rawLines.length, "paths");
+      return new Text(text, 0, 0);
+    },
+  });
+}

--- a/extensions/pi-code-previews/src/tool-renderers/grep.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/grep.ts
@@ -1,0 +1,82 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createGrepToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getTextContent } from "../data.ts";
+import {
+  hiddenPreviewExpandHint,
+  metadata,
+  previewFooter,
+  showingFooter,
+  trimSingleTrailingNewline,
+} from "../format.ts";
+import { renderGrepOutputLines } from "../grep-rendering.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { shouldSkipHighlight } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { renderSelectedOutputLines } from "./common.ts";
+
+export function registerGrep(pi: ExtensionAPI, cwd: string) {
+  const originalGrep = createGrepToolDefinition(cwd);
+
+  pi.registerTool({
+    ...originalGrep,
+
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalGrep.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+
+    renderCall(args, theme) {
+      const pattern = typeof args.pattern === "string" ? args.pattern : "";
+      const path = typeof args.path === "string" && args.path ? args.path : ".";
+      const glob = typeof args.glob === "string" && args.glob ? args.glob : undefined;
+      const limit = typeof args.limit === "number" ? args.limit : undefined;
+      let text = `${theme.fg("toolTitle", theme.bold("grep"))} ${theme.fg("accent", `/${escapeControlChars(pattern)}/`)} ${theme.fg("muted", "in")} ${renderDisplayPath(path, cwd, theme)}`;
+      text += metadata(theme, [
+        glob ? escapeControlChars(glob) : undefined,
+        limit ? `limit ${limit}` : undefined,
+      ]);
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Searching…"), 0, 0);
+      const output = trimSingleTrailingNewline(getTextContent(result.content));
+      if (context.isError) {
+        return new Text(
+          theme.fg("error", escapeControlChars(output.split("\n")[0] || "Grep failed")),
+          0,
+          0,
+        );
+      }
+      if (!expanded && !codePreviewSettings.grepResultPreview)
+        return new Text(hiddenPreviewExpandHint(theme), 0, 0);
+      if (!output || output === "No matches found")
+        return new Text(theme.fg("muted", output || "No matches found"), 0, 0);
+
+      const pattern = typeof context.args?.pattern === "string" ? context.args.pattern : "";
+      const rawLines = output.split("\n");
+      const limit = expanded ? rawLines.length : codePreviewSettings.grepCollapsedLines;
+      const skipHighlight = shouldSkipHighlight(output);
+      const preview = renderSelectedOutputLines(rawLines, limit, theme, (chunk) =>
+        renderGrepOutputLines(
+          chunk.join("\n"),
+          theme,
+          {
+            pattern,
+            literal: context.args?.literal === true,
+            ignoreCase: context.args?.ignoreCase === true,
+          },
+          context.invalidate,
+          { syntaxHighlight: !skipHighlight },
+        ),
+      );
+      let text = preview.lines.join("\n");
+      if (preview.hidden > 0)
+        text += showingFooter(theme, preview.shown, rawLines.length, "grep output lines");
+      if (skipHighlight)
+        text += previewFooter(theme, "Syntax highlighting skipped for large grep output");
+      return new Text(text, 0, 0);
+    },
+  });
+}

--- a/extensions/pi-code-previews/src/tool-renderers/ls.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/ls.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createLsToolDefinition } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getTextContent } from "../data.ts";
+import { hiddenPreviewExpandHint, showingFooter, trimSingleTrailingNewline } from "../format.ts";
+import { renderPathListLines } from "../path-list-rendering.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { renderSelectedOutputLines } from "./common.ts";
+
+export function registerLs(pi: ExtensionAPI, cwd: string) {
+  const originalLs = createLsToolDefinition(cwd);
+  pi.registerTool({
+    ...originalLs,
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalLs.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+    renderCall(args, theme) {
+      const path = typeof args.path === "string" && args.path ? args.path : ".";
+      return new Text(
+        `${theme.fg("toolTitle", theme.bold("ls"))} ${renderDisplayPath(path, cwd, theme)}`,
+        0,
+        0,
+      );
+    },
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Listing…"), 0, 0);
+      const output = trimSingleTrailingNewline(getTextContent(result.content));
+      if (context.isError)
+        return new Text(
+          theme.fg("error", escapeControlChars(output.split("\n")[0] || "List failed")),
+          0,
+          0,
+        );
+      if (!expanded && !codePreviewSettings.lsResultPreview)
+        return new Text(hiddenPreviewExpandHint(theme), 0, 0);
+      if (!output || output === "(empty directory)")
+        return new Text(theme.fg("muted", "Empty directory"), 0, 0);
+      if (expanded && !codePreviewSettings.lsResultPreview)
+        return new Text(
+          output
+            .split("\n")
+            .map((line) => theme.fg("toolOutput", escapeControlChars(line)))
+            .join("\n"),
+          0,
+          0,
+        );
+      const rawLines = output.split("\n");
+      const limit = expanded ? rawLines.length : codePreviewSettings.pathListCollapsedLines;
+      const preview = renderSelectedOutputLines(rawLines, limit, theme, (chunk) =>
+        renderPathListLines(chunk.join("\n"), cwd, theme),
+      );
+      let text = preview.lines.join("\n");
+      if (preview.hidden > 0)
+        text += showingFooter(theme, preview.shown, rawLines.length, "entries");
+      return new Text(text, 0, 0);
+    },
+  });
+}

--- a/extensions/pi-code-previews/src/tool-renderers/read.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/read.ts
@@ -1,0 +1,89 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createReadToolDefinition, getLanguageFromPath } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getPathArg, getReadStartLine, getTextContent, isTruncated } from "../data.ts";
+import { hiddenPreviewExpandHint, metadata, previewFooter, showingFooter } from "../format.ts";
+import { resolvePreviewLanguage } from "../language.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { normalizeShikiLanguage, shouldSkipHighlight } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import { renderHighlightedPreviewText, withSecretWarning } from "./common.ts";
+
+export function registerRead(pi: ExtensionAPI, cwd: string) {
+  const originalRead = createReadToolDefinition(cwd);
+
+  pi.registerTool({
+    ...originalRead,
+
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      return originalRead.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+
+    renderCall(args, theme, _context) {
+      const path = getPathArg(args);
+      const lang = resolvePreviewLanguage({ path, piLanguage: getLanguageFromPath(path) });
+      let text = `${theme.fg("toolTitle", theme.bold("read"))} ${renderDisplayPath(path, cwd, theme)}`;
+      if (typeof args.offset === "number" || typeof args.limit === "number") {
+        const start = typeof args.offset === "number" ? args.offset : 1;
+        const end = typeof args.limit === "number" ? start + args.limit - 1 : undefined;
+        text += theme.fg("warning", `:${start}${end ? `-${end}` : ""}`);
+      }
+      text += metadata(theme, [lang ? normalizeShikiLanguage(lang) : undefined]);
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return new Text(theme.fg("warning", "Reading…"), 0, 0);
+      const firstText = getTextContent(result.content);
+      if (context.isError) {
+        return new Text(
+          theme.fg("error", escapeControlChars(firstText.split("\n")[0] || "Read failed")),
+          0,
+          0,
+        );
+      }
+
+      const path = getPathArg(context.args);
+
+      // Pi already renders image content parts natively. Avoid emitting terminal image
+      // escape sequences here; show only a compact note beside Pi's image renderer.
+      if (result.content?.some((part) => part.type === "image")) {
+        return new Text(
+          theme.fg("dim", escapeControlChars(firstText.replace(/^Read image file/i, "image"))),
+          0,
+          0,
+        );
+      }
+
+      if (!expanded && !codePreviewSettings.readContentPreview)
+        return new Text(hiddenPreviewExpandHint(theme), 0, 0);
+
+      const lang = resolvePreviewLanguage({
+        path,
+        content: firstText,
+        piLanguage: getLanguageFromPath(path),
+      });
+      const firstLine = getReadStartLine(context.args);
+      const limit = expanded ? 0 : codePreviewSettings.readCollapsedLines;
+      const skipHighlight = shouldSkipHighlight(firstText);
+      const preview = renderHighlightedPreviewText(
+        firstText,
+        limit,
+        skipHighlight ? undefined : lang,
+        theme,
+        context.invalidate,
+        { firstLine },
+      );
+
+      let text = preview.lines.length
+        ? withSecretWarning(firstText, theme, preview.lines.join("\n"))
+        : theme.fg("muted", "Empty file");
+      if (preview.hidden > 0) text += showingFooter(theme, preview.shown, preview.total, "lines");
+
+      if (skipHighlight) text += previewFooter(theme, "Syntax highlighting skipped for large file");
+      if (isTruncated(result.details)) text += previewFooter(theme, "Output truncated by read");
+      return new Text(text, 0, 0);
+    },
+  });
+}

--- a/extensions/pi-code-previews/src/tool-renderers/write.ts
+++ b/extensions/pi-code-previews/src/tool-renderers/write.ts
@@ -1,0 +1,179 @@
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
+import { createWriteToolDefinition, getLanguageFromPath } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { AsyncPreview, shouldRenderAsync } from "../async-preview.ts";
+import { getObjectValue, getPathArg, getTextContent } from "../data.ts";
+import {
+  createProgressiveSyntaxHighlightedDiffText,
+  FullWidthDiffText,
+  renderPlainDiff,
+  summarizeDiff,
+} from "../diff.ts";
+import { countLabel, formatBytes, metadata, previewFooter, showingFooter } from "../format.ts";
+import { resolvePreviewLanguage } from "../language.ts";
+import { renderDisplayPath } from "../paths.ts";
+import { codePreviewSettings } from "../settings.ts";
+import { normalizeShikiLanguage, shouldSkipHighlight } from "../shiki.ts";
+import { escapeControlChars } from "../terminal-text.ts";
+import {
+  createSimpleDiff,
+  getWriteDiffSkipReason,
+  readExistingFileForPreview,
+  shouldSkipWriteDiffBytes,
+} from "../write-diff.ts";
+import {
+  cachedPreview,
+  countFileLines,
+  previewCacheKey,
+  renderHighlightedPreviewText,
+  withSecretWarning,
+} from "./common.ts";
+
+export function registerWrite(pi: ExtensionAPI, cwd: string) {
+  const originalWrite = createWriteToolDefinition(cwd);
+
+  pi.registerTool({
+    ...originalWrite,
+
+    async execute(toolCallId, params, signal, onUpdate, ctx) {
+      const path = getPathArg(params);
+      const content = typeof params.content === "string" ? params.content : "";
+      const before = path ? await readExistingFileForPreview(path, cwd, content) : undefined;
+      const result = await originalWrite.execute(toolCallId, params, signal, onUpdate, ctx);
+      const details = result.details && typeof result.details === "object" ? result.details : {};
+      return { ...result, details: { ...details, codePreviewBeforeWrite: before } };
+    },
+
+    renderCall(args, theme, context) {
+      const path = getPathArg(args);
+      const content = typeof args.content === "string" ? args.content : "";
+      const lang = resolvePreviewLanguage({ path, content, piLanguage: getLanguageFromPath(path) });
+      const limit = context.expanded ? 0 : codePreviewSettings.writeCollapsedLines;
+      const skipHighlight = shouldSkipHighlight(content);
+      const preview = renderHighlightedPreviewText(
+        content,
+        limit,
+        skipHighlight ? undefined : lang,
+        theme,
+        context.invalidate,
+      );
+
+      let text = `${theme.fg("toolTitle", theme.bold("write"))} ${renderDisplayPath(path, cwd, theme)}`;
+      text += metadata(theme, [
+        formatBytes(Buffer.byteLength(content, "utf8")),
+        countLabel(preview.total, "line"),
+        lang ? normalizeShikiLanguage(lang) : undefined,
+      ]);
+      const contentPreview = preview.lines.length
+        ? withSecretWarning(content, theme, preview.lines.join("\n"))
+        : theme.fg("muted", "Empty content");
+      text += `\n${contentPreview}`;
+      if (preview.hidden > 0) text += showingFooter(theme, preview.shown, preview.total, "lines");
+      if (skipHighlight)
+        text += previewFooter(theme, "Syntax highlighting skipped for large content");
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, { expanded }, theme, context) {
+      const firstText = getTextContent(result.content);
+      if (context.isError)
+        return new Text(theme.fg("error", escapeControlChars(firstText || "Write failed")), 0, 0);
+
+      const path = getPathArg(context.args);
+      const content = typeof context.args?.content === "string" ? context.args.content : "";
+      const before = getObjectValue(result.details, "codePreviewBeforeWrite");
+      const beforeContent = getObjectValue(before, "content");
+      const skipReason = getWriteDiffSkipReason(before, content);
+      if (skipReason)
+        return new Text(
+          theme.fg("success", "✓ Write applied") +
+            theme.fg("muted", ` · diff skipped: ${skipReason}`),
+          0,
+          0,
+        );
+      if (typeof beforeContent === "string" && beforeContent !== content) {
+        if (shouldSkipWriteDiffBytes(beforeContent, content)) {
+          return new Text(
+            theme.fg("success", "✓ Write applied") +
+              theme.fg("muted", " · diff skipped for large content"),
+            0,
+            0,
+          );
+        }
+        const render = () =>
+          renderWriteDiffPreview(beforeContent, content, path, expanded, theme, context.invalidate);
+        const source = `${beforeContent}\0${content}`;
+        const previewKey = previewCacheKey("write-result", source, path, expanded, theme);
+        return cachedPreview(
+          context.state,
+          "writeResultPreviewKey",
+          "writeResultPreviewComponent",
+          previewKey,
+          () =>
+            shouldRenderAsync(source)
+              ? new AsyncPreview("Rendering write diff…", theme, render, context.invalidate)
+              : render(),
+        );
+      }
+      if (typeof beforeContent === "string")
+        return new Text(theme.fg("muted", "✓ Write applied · no changes"), 0, 0);
+      return new Text(
+        theme.fg("success", `✓ New file (${countLabel(countFileLines(content), "line")})`),
+        0,
+        0,
+      );
+    },
+  });
+}
+
+function renderWriteDiffPreview(
+  before: string,
+  content: string,
+  path: string,
+  expanded: boolean,
+  theme: Theme,
+  invalidate?: () => void,
+): FullWidthDiffText {
+  if (shouldSkipWriteDiffBytes(before, content)) {
+    return new FullWidthDiffText(
+      theme.fg("success", "✓ Write applied") +
+        theme.fg("muted", " · diff skipped for large content"),
+      theme,
+    );
+  }
+  const diff = createSimpleDiff(before, content);
+  const lang = resolvePreviewLanguage({ path, content, piLanguage: getLanguageFromPath(path) });
+  const summary = summarizeDiff(diff);
+  const limit =
+    expanded || codePreviewSettings.editCollapsedLines === "all"
+      ? summary.totalLines
+      : codePreviewSettings.editCollapsedLines;
+  const header = `${theme.fg("success", "✓ Write applied")} ${theme.fg("muted", describeEditShape(summary))}${editSummarySeparator(theme)}${theme.fg("success", `+${summary.additions}`)} ${theme.fg("error", `-${summary.removals}`)}\n`;
+  const skipSyntaxHighlight = shouldSkipHighlight(diff);
+  const decorate = (body: string) => {
+    let text = header + body;
+    if (summary.totalLines > limit)
+      text += showingFooter(theme, limit, summary.totalLines, "diff lines");
+    if (skipSyntaxHighlight)
+      text += previewFooter(theme, "Syntax highlighting skipped for large diff");
+    return text;
+  };
+  return skipSyntaxHighlight
+    ? new FullWidthDiffText(decorate(renderPlainDiff(diff, theme, limit)), theme)
+    : createProgressiveSyntaxHighlightedDiffText(diff, lang, theme, limit, {
+        decorate,
+        invalidate,
+      });
+}
+
+function editSummarySeparator(theme: Theme): string {
+  return theme.fg("muted", " · ");
+}
+
+function describeEditShape(summary: ReturnType<typeof summarizeDiff>): string {
+  const parts: string[] = [];
+  if (summary.replacements > 0) parts.push(countLabel(summary.replacements, "replacement"));
+  if (summary.insertions > 0) parts.push(countLabel(summary.insertions, "insertion"));
+  if (summary.deletions > 0) parts.push(countLabel(summary.deletions, "deletion"));
+  return parts.length ? parts.join(", ") : "changes";
+}

--- a/extensions/pi-code-previews/src/tool-selection.ts
+++ b/extensions/pi-code-previews/src/tool-selection.ts
@@ -1,0 +1,27 @@
+import { codePreviewSettings, getRequiredCodePreviewTools } from "./settings.ts";
+import {
+  ALL_CODE_PREVIEW_TOOLS,
+  isCodePreviewToolName,
+  parseCodePreviewTools,
+  type CodePreviewToolName,
+} from "./tool-names.ts";
+
+export { ALL_CODE_PREVIEW_TOOLS, isCodePreviewToolName, type CodePreviewToolName };
+
+export function getEnabledCodePreviewTools(): Set<CodePreviewToolName> {
+  const enabled =
+    parseCodePreviewTools(process.env.CODE_PREVIEW_TOOLS) ?? new Set(codePreviewSettings.tools);
+  for (const tool of getRequiredCodePreviewTools()) enabled.add(tool);
+  return enabled;
+}
+
+export function isCodePreviewToolEnabled(
+  name: CodePreviewToolName,
+  enabled = getEnabledCodePreviewTools(),
+): boolean {
+  return enabled.has(name);
+}
+
+export function formatEnabledCodePreviewTools(enabled = getEnabledCodePreviewTools()): string {
+  return ALL_CODE_PREVIEW_TOOLS.filter((tool) => enabled.has(tool)).join(", ") || "none";
+}

--- a/extensions/pi-code-previews/src/tool-status.ts
+++ b/extensions/pi-code-previews/src/tool-status.ts
@@ -1,0 +1,72 @@
+import type { SourceInfo } from "@mariozechner/pi-coding-agent";
+import { ALL_CODE_PREVIEW_TOOLS, type CodePreviewToolName } from "./tool-names.ts";
+
+export type CodePreviewToolStatus =
+  | { state: "pending" }
+  | { state: "active" }
+  | { state: "disabled-by-config" }
+  | { state: "skipped-conflict"; owner: SourceInfo };
+
+const toolStatuses = new Map<CodePreviewToolName, CodePreviewToolStatus>();
+
+resetCodePreviewToolStatuses(new Set());
+
+export function resetCodePreviewToolStatuses(configuredTools: Set<CodePreviewToolName>): void {
+  for (const tool of ALL_CODE_PREVIEW_TOOLS) {
+    toolStatuses.set(
+      tool,
+      configuredTools.has(tool) ? { state: "pending" } : { state: "disabled-by-config" },
+    );
+  }
+}
+
+export function setCodePreviewToolStatus(
+  tool: CodePreviewToolName,
+  status: CodePreviewToolStatus,
+): void {
+  toolStatuses.set(tool, status);
+}
+
+export function getCodePreviewToolStatuses(): Map<CodePreviewToolName, CodePreviewToolStatus> {
+  return new Map(toolStatuses);
+}
+
+export function formatActiveCodePreviewTools(statuses = getCodePreviewToolStatuses()): string {
+  return formatToolsWithState(statuses, "active");
+}
+
+export function formatDisabledCodePreviewTools(statuses = getCodePreviewToolStatuses()): string {
+  return formatToolsWithState(statuses, "disabled-by-config");
+}
+
+export function formatPendingCodePreviewTools(statuses = getCodePreviewToolStatuses()): string {
+  return formatToolsWithState(statuses, "pending");
+}
+
+export function formatSkippedCodePreviewToolLines(
+  statuses = getCodePreviewToolStatuses(),
+): string[] {
+  return ALL_CODE_PREVIEW_TOOLS.flatMap((tool) => {
+    const status = statuses.get(tool);
+    if (status?.state !== "skipped-conflict") return [];
+    return `  ${tool} — owned by ${formatToolOwner(status.owner)}`;
+  });
+}
+
+export function formatToolOwner(sourceInfo: SourceInfo): string {
+  if (sourceInfo.source === "builtin") return "builtin";
+  if (sourceInfo.origin === "package") return sourceInfo.source || sourceInfo.path || "unknown";
+  const scope = sourceInfo.scope && sourceInfo.scope !== "temporary" ? ` ${sourceInfo.scope}` : "";
+  const source = `${sourceInfo.source || "unknown"}${scope}`;
+  return sourceInfo.path ? `${source} (${sourceInfo.path})` : source;
+}
+
+function formatToolsWithState(
+  statuses: Map<CodePreviewToolName, CodePreviewToolStatus>,
+  state: CodePreviewToolStatus["state"],
+): string {
+  return (
+    ALL_CODE_PREVIEW_TOOLS.filter((tool) => statuses.get(tool)?.state === state).join(", ") ||
+    "none"
+  );
+}

--- a/extensions/pi-code-previews/src/write-diff.ts
+++ b/extensions/pi-code-previews/src/write-diff.ts
@@ -1,0 +1,226 @@
+import { readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+import { diffLines } from "diff";
+import { formatBytes } from "./format.ts";
+
+export type StructuredDiffLine = {
+  kind: "context" | "add" | "remove" | "separator";
+  oldLine?: number;
+  newLine?: number;
+  content: string;
+};
+export interface StructuredDiffHunk {
+  header: string;
+  lines: StructuredDiffLine[];
+}
+
+export type ExistingFilePreview =
+  | { kind: "content"; content: string }
+  | { kind: "skipped"; reason: string; byteLength?: number; maxBytes: number };
+
+const MAX_WRITE_DIFF_BYTES = envPositiveInteger("CODE_PREVIEW_MAX_WRITE_DIFF_BYTES", 200000);
+
+export async function readExistingFileForPreview(
+  path: string,
+  cwd: string,
+  nextContent = "",
+): Promise<ExistingFilePreview | undefined> {
+  if (!path) return undefined;
+  const resolved = resolvePreviewPath(path, cwd);
+  let fileStat: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStat = await stat(resolved);
+  } catch (error) {
+    return isFileNotFound(error)
+      ? undefined
+      : skippedExistingFile("previous content unavailable", undefined);
+  }
+
+  if (!fileStat.isFile())
+    return skippedExistingFile("previous path is not a regular file", fileStat.size);
+  if (fileStat.size > MAX_WRITE_DIFF_BYTES)
+    return skippedExistingFile("previous file too large", fileStat.size);
+
+  const nextBytes = Buffer.byteLength(nextContent, "utf8");
+  if (nextBytes > MAX_WRITE_DIFF_BYTES)
+    return skippedExistingFile("new content too large", nextBytes);
+
+  try {
+    const content = await readFile(resolved, "utf8");
+    const bytes = Buffer.byteLength(content, "utf8");
+    if (bytes > MAX_WRITE_DIFF_BYTES) return skippedExistingFile("previous file too large", bytes);
+    return { kind: "content", content };
+  } catch {
+    return skippedExistingFile("previous content unavailable", fileStat.size);
+  }
+}
+
+export function getWriteDiffSkipReason(before: unknown, nextContent: string): string | undefined {
+  if (!before || typeof before !== "object") return undefined;
+  if (shouldSkipWriteDiffText(nextContent))
+    return formatSkipReason("new content too large", Buffer.byteLength(nextContent, "utf8"));
+  const record = before as Record<string, unknown>;
+  if (record.kind !== "skipped") return undefined;
+  const reason = typeof record.reason === "string" ? record.reason : "preview unavailable";
+  const byteLength = typeof record.byteLength === "number" ? record.byteLength : undefined;
+  const maxBytes = typeof record.maxBytes === "number" ? record.maxBytes : MAX_WRITE_DIFF_BYTES;
+  return formatSkipReason(reason, byteLength, maxBytes);
+}
+
+export function shouldSkipWriteDiffText(text: string): boolean {
+  return Buffer.byteLength(text, "utf8") > MAX_WRITE_DIFF_BYTES;
+}
+
+export function shouldSkipWriteDiffBytes(...texts: string[]): boolean {
+  let total = 0;
+  for (const text of texts) {
+    total += Buffer.byteLength(text, "utf8");
+    if (total > MAX_WRITE_DIFF_BYTES) return true;
+  }
+  return false;
+}
+
+export function getMaxWriteDiffBytes(): number {
+  return MAX_WRITE_DIFF_BYTES;
+}
+
+export function resolvePreviewPath(path: string, cwd: string): string {
+  let expanded = path.replace(/[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g, " ");
+  if (expanded === "~") expanded = homedir();
+  else if (expanded.startsWith("~/")) expanded = `${homedir()}${expanded.slice(1)}`;
+  return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
+}
+
+export function createSimpleDiff(before: string, after: string): string {
+  return formatStructuredDiff(createStructuredDiff(before, after));
+}
+
+export function createStructuredDiff(before: string, after: string): StructuredDiffHunk[] {
+  const changes = diffLines(before, after);
+  const hasChangeAfter = changes.map(() => false);
+  let futureChangeSeen = false;
+  for (let index = changes.length - 1; index >= 0; index--) {
+    hasChangeAfter[index] = futureChangeSeen;
+    const change = changes[index]!;
+    if (change.added || change.removed) futureChangeSeen = true;
+  }
+
+  const lines: StructuredDiffLine[] = [];
+  let oldLine = 1;
+  let newLine = 1;
+  const context = 3;
+  let emittedChange = false;
+  let firstChangeLine = 1;
+
+  for (let index = 0; index < changes.length; index++) {
+    const change = changes[index]!;
+    const chunkLines = splitDiffLines(change.value);
+
+    if (!change.added && !change.removed) {
+      const hasFutureChange = hasChangeAfter[index] ?? false;
+      if (!emittedChange && hasFutureChange) {
+        const start = Math.max(0, chunkLines.length - context);
+        for (let offset = start; offset < chunkLines.length; offset++)
+          lines.push({
+            kind: "context",
+            oldLine: oldLine + offset,
+            newLine: newLine + offset,
+            content: chunkLines[offset] ?? "",
+          });
+      } else if (emittedChange) {
+        lines.push(
+          ...(hasFutureChange
+            ? compactContextLines(chunkLines, oldLine, newLine, context)
+            : chunkLines.slice(0, context).map((line, offset) => ({
+                kind: "context" as const,
+                oldLine: oldLine + offset,
+                newLine: newLine + offset,
+                content: line,
+              }))),
+        );
+      }
+      oldLine += chunkLines.length;
+      newLine += chunkLines.length;
+      continue;
+    }
+
+    if (!emittedChange) firstChangeLine = newLine;
+    emittedChange = true;
+    for (const line of chunkLines) {
+      if (change.removed) lines.push({ kind: "remove", oldLine: oldLine++, content: line });
+      else if (change.added) lines.push({ kind: "add", newLine: newLine++, content: line });
+    }
+  }
+
+  return lines.length ? [{ header: `@@ ${firstChangeLine} @@`, lines }] : [];
+}
+
+function skippedExistingFile(reason: string, byteLength: number | undefined): ExistingFilePreview {
+  return { kind: "skipped", reason, byteLength, maxBytes: MAX_WRITE_DIFF_BYTES };
+}
+
+function formatSkipReason(
+  reason: string,
+  byteLength: number | undefined,
+  maxBytes = MAX_WRITE_DIFF_BYTES,
+): string {
+  if (byteLength === undefined) return reason;
+  return `${reason} (${formatBytes(byteLength)} > ${formatBytes(maxBytes)})`;
+}
+
+function formatStructuredDiff(hunks: StructuredDiffHunk[]): string {
+  return hunks.flatMap((hunk) => [hunk.header, ...hunk.lines.map(formatStructuredLine)]).join("\n");
+}
+
+function formatStructuredLine(line: StructuredDiffLine): string {
+  if (line.kind === "separator") return "...";
+  if (line.kind === "add") return `+${line.newLine ?? ""} ${line.content}`;
+  if (line.kind === "remove") return `-${line.oldLine ?? ""} ${line.content}`;
+  return ` ${line.newLine ?? line.oldLine ?? ""} ${line.content}`;
+}
+
+function splitDiffLines(value: string): string[] {
+  const lines = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  return lines;
+}
+
+function compactContextLines(
+  lines: string[],
+  oldFirstLine: number,
+  newFirstLine: number,
+  context: number,
+): StructuredDiffLine[] {
+  if (lines.length <= context * 2)
+    return lines.map((line, offset) => ({
+      kind: "context",
+      oldLine: oldFirstLine + offset,
+      newLine: newFirstLine + offset,
+      content: line,
+    }));
+  return [
+    ...lines.slice(0, context).map((line, offset) => ({
+      kind: "context" as const,
+      oldLine: oldFirstLine + offset,
+      newLine: newFirstLine + offset,
+      content: line,
+    })),
+    { kind: "separator", content: "..." } satisfies StructuredDiffLine,
+    ...lines.slice(-context).map((line, offset) => ({
+      kind: "context" as const,
+      oldLine: oldFirstLine + lines.length - context + offset,
+      newLine: newFirstLine + lines.length - context + offset,
+      content: line,
+    })),
+  ];
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/extensions/pi-code-previews/tsconfig.json
+++ b/extensions/pi-code-previews/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts", "bench/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@code-yeongyu/pi-nested-agents-md": "github:code-yeongyu/pi-nested-agents-md",
         "@ff-labs/fff-node": "^0.6.4",
         "@sinclair/typebox": "^0.34.49",
-        "pi-lsp-client": "github:code-yeongyu/pi-lsp-client"
+        "diff": "^8.0.4",
+        "pi-lsp-client": "github:code-yeongyu/pi-lsp-client",
+        "shiki": "^4.0.2"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -27,9 +29,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -48,9 +50,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -59,9 +61,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -259,30 +261,30 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1040.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1040.0.tgz",
-      "integrity": "sha512-tFCqtci1gVGIRwgK3tmv2DV2EawXjBIQgwM/7KaeL4wHUMhNMUA+POUw6vGowtQb51ZaSDjK3KzI3MaQskOyuw==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+      "integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/credential-provider-node": "^3.972.38",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
         "@aws-sdk/eventstream-handler-node": "^3.972.14",
         "@aws-sdk/middleware-eventstream": "^3.972.10",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/middleware-websocket": "^3.972.16",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/token-providers": "3.1040.0",
+        "@aws-sdk/token-providers": "3.1045.0",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -319,9 +321,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.7.tgz",
-      "integrity": "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -346,14 +348,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz",
-      "integrity": "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -364,14 +366,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz",
-      "integrity": "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.6.1",
@@ -387,21 +389,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz",
-      "integrity": "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/credential-provider-env": "^3.972.33",
-        "@aws-sdk/credential-provider-http": "^3.972.35",
-        "@aws-sdk/credential-provider-login": "^3.972.37",
-        "@aws-sdk/credential-provider-process": "^3.972.33",
-        "@aws-sdk/credential-provider-sso": "^3.972.37",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
-        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -414,15 +416,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz",
-      "integrity": "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -435,19 +437,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz",
-      "integrity": "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.33",
-        "@aws-sdk/credential-provider-http": "^3.972.35",
-        "@aws-sdk/credential-provider-ini": "^3.972.37",
-        "@aws-sdk/credential-provider-process": "^3.972.33",
-        "@aws-sdk/credential-provider-sso": "^3.972.37",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -460,14 +462,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz",
-      "integrity": "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -479,16 +481,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz",
-      "integrity": "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/token-providers": "3.1039.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -500,15 +502,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
-      "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -520,15 +522,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz",
-      "integrity": "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -625,14 +627,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.36.tgz",
-      "integrity": "sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.17",
@@ -652,14 +654,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.37.tgz",
-      "integrity": "sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@smithy/core": "^3.23.17",
@@ -698,26 +700,26 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz",
-      "integrity": "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.7",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.24",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.23",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -768,14 +770,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
-      "integrity": "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.36",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -787,15 +789,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1040.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1040.0.tgz",
-      "integrity": "sha512-0KTpz2KqASQwzLOywV1bS2TX6Su0bARkATgpSu236BDM/D/6cMQ2EPiFwoRYwwvXsWSDn8KkKp9NV2ZWWA53Xw==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+      "integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -899,14 +901,14 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.23.tgz",
-      "integrity": "sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.37",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -1057,6 +1059,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,6 +1074,9 @@
       "integrity": "sha512-t9K3NzYkBxK2UYp6Xy7Lac/RAL+cWa+78HcRNI693k0U9c6G65J2/cVn5SVOiJ1EcnEnC3MCuPsCEmj/9d3Pqw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1083,6 +1091,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,6 +1106,9 @@
       "integrity": "sha512-GHJhJ3P7cGth4F0VTyoe3maFQT0cW+RbMm7R5XKkNZZW2rNtR+4jo+neAU4gchYH6jv7ajCB5HQdNBcou8zxKA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1160,9 +1174,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.51.0.tgz",
-      "integrity": "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "hasInstallScript": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -1268,6 +1282,9 @@
         "arm64"
       ],
       "inBundle": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1286,6 +1303,9 @@
         "arm64"
       ],
       "inBundle": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1304,6 +1324,9 @@
         "riscv64"
       ],
       "inBundle": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,6 +1345,9 @@
         "x64"
       ],
       "inBundle": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,6 +1366,9 @@
         "x64"
       ],
       "inBundle": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,30 +1415,16 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.72.1.tgz",
-      "integrity": "sha512-Z5XH9mUDsBymh7Prtk5Eun4Cs+s9C3uzynug+oWAjzQESjjnCuy7KU6Ek8E9Eg+b9yroCwVw2ItLDxp2E3vYjA==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+      "integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+      "deprecated": "please use @earendil-works/pi-agent-core instead going forward",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.72.1",
+        "@mariozechner/pi-ai": "^0.73.1",
         "typebox": "^1.1.24"
       },
       "engines": {
@@ -1417,9 +1432,10 @@
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.72.1.tgz",
-      "integrity": "sha512-mOq71Pjnu72xxzwrh52VIiNwt+/a+Wpa11k5segi01/zTZJt8eMDc5Q2z6GhczYMr5+6EpZ8T+BaeHqq0jk5ag==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+      "integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+      "deprecated": "please use @earendil-works/pi-ai instead going forward",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -1444,17 +1460,17 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.72.1.tgz",
-      "integrity": "sha512-gKApiLfAYpvPnWThvwXrLjZIhsziSSUKBph7DHCy/1IomuIGN1MTxS/9ZtcuFqPy3/+VfEUOKegGlY6m+CRNlA==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.1.tgz",
+      "integrity": "sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==",
+      "deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.72.1",
-        "@mariozechner/pi-ai": "^0.72.1",
-        "@mariozechner/pi-tui": "^0.72.1",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-tui": "^0.73.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
@@ -1464,6 +1480,7 @@
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
         "marked": "^15.0.12",
         "minimatch": "^10.2.3",
         "proper-lockfile": "^4.1.2",
@@ -1483,27 +1500,11 @@
         "@mariozechner/clipboard": "^0.3.5"
       }
     },
-    "node_modules/@mariozechner/pi-coding-agent/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.72.1.tgz",
-      "integrity": "sha512-KjeqzMQp4vafomfkvI8HKv5/52PqRP5BmlowGC8WKyOaB+u0UkkTdfM5U1Ui3ty2gA7FOfglVRiyvcitiWwvMQ==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+      "integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+      "deprecated": "please use @earendil-works/pi-tui instead going forward",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -2381,6 +2382,106 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
@@ -3081,9 +3182,9 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
-      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -3195,6 +3296,24 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -3204,9 +3323,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -3229,6 +3348,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3241,10 +3366,16 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@yuuang/ffi-rs-android-arm64": {
+    "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-android-arm64/-/ffi-rs-android-arm64-1.3.1.tgz",
-      "integrity": "sha512-V4nmlXdOYZEa7GOxSExVG95SLp8FE0iTq2yKeN54UlfNMr3Sik+1Ff57LcCv7qYcn4TBqnBAt5rT3FAM6T6caQ==",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
+    },
+    "node_modules/@yuuang/ffi-rs-android-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-android-arm64/-/ffi-rs-android-arm64-1.3.2.tgz",
+      "integrity": "sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==",
       "cpu": [
         "arm64"
       ],
@@ -3258,9 +3389,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-darwin-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.3.1.tgz",
-      "integrity": "sha512-YlnTMIyzfW3mAULC5ZA774nzQfFlYXM0rrfq/8ZzWt+IMbYk55a++jrI+6JeKV+1EqlDS3TFBEFtjdBNG94KzQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-kRdgPaOM6TfuC5wHUwstlatk4HNie2lwSLJWQL2LiAUIJ7+96CoiWUNVhwBcFrhdfxhnWenYS6F668CV0vit8Q==",
       "cpu": [
         "arm64"
       ],
@@ -3274,9 +3405,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-darwin-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.3.1.tgz",
-      "integrity": "sha512-sI3LpQQ34SX4nyOHc5yxA7FSqs9qPEUMqW/y/wWo9cuyPpaHMFsi/BeOVYsnC0syp3FrY7gzn6RnD6PlXCktXg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-O3AlVgre8FQcZRJe44Xs7A6iDLumoPXqbw40+eJCa2gyXaXyLPdHoWrS1W9rBCa1QZRRnG7zRulPVFw8C5uo8g==",
       "cpu": [
         "x64"
       ],
@@ -3290,9 +3421,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-arm-gnueabihf": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm-gnueabihf/-/ffi-rs-linux-arm-gnueabihf-1.3.1.tgz",
-      "integrity": "sha512-1WkcGkJTlwh4ZA59htKI+RXhiL3oKiYwLv7PO8LUf6FuADK73s5GcXp67iakKu243uYu+qGYr4RHco4ySddYhQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm-gnueabihf/-/ffi-rs-linux-arm-gnueabihf-1.3.2.tgz",
+      "integrity": "sha512-IXiNdTbIcTCPny5eeElijFWYeKSJjQWSjt9ZyJNdLHYiB1Np+XD6K7wNZS6EOMgMelhW1kQE62T654skGkVDIA==",
       "cpu": [
         "arm"
       ],
@@ -3306,11 +3437,14 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-arm64-gnu": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.3.1.tgz",
-      "integrity": "sha512-J2PwqviycZxaEVA0Bwv38LqGDGSB9A1DPN4iYginYJZSvTvKW8kh7Tis0HbZrX1YDKnY8hi3lt0N0tCTNPDH5Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.3.2.tgz",
+      "integrity": "sha512-gWFO6xufUK9lPYUqDvKa6IR243dPqdetgl9Q7HrZWaDu7wLo06QQrosw8QTzndafQnOcBKm6LoLujmGCfTgJOA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3322,11 +3456,14 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-arm64-musl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.3.1.tgz",
-      "integrity": "sha512-Hn1W1hBPssTaqikU1Bqp1XUdDdOgbnYVIOtR++LVx66hhrtjf/xrIUQOhTm+NmOFDG16JUKXe1skfM4gpaqYwg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.3.2.tgz",
+      "integrity": "sha512-lejvOSqypPziQH5rzfkDlJ6e92qhWbDutE9ttOO6z5I2k83zoh9iZhZWhaXSU5VqgQpcshRkrbtXb9gy1ft5dA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3338,11 +3475,14 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-x64-gnu": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.3.1.tgz",
-      "integrity": "sha512-kW6e+oCYZPvpH2ppPsffA18e1aLowtmWTRjVlyHtY04g/nQDepQvDUkkcvInh9fW5jLna7PjHvktW1tVgYIj2A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.3.2.tgz",
+      "integrity": "sha512-s8VCFazaJKmgY2hgMTpWk4TtBY/zy5ovbaGgwyY0FvBD0YvyhcET4IrMsDJpHhFVTPCYfKZ1dN45clD/YiFp6g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3354,11 +3494,14 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-linux-x64-musl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.3.1.tgz",
-      "integrity": "sha512-HTwblAzruUS16nQPrez3ozvEHm1Xxh8J8w7rZYrpmAcNl1hzyOT8z/hY70M9Rt9fOqQ4Ovgor9qVy/U3ZJo0ZA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.3.2.tgz",
+      "integrity": "sha512-Ahr5chfKZKWUik20bEZRug+be57LZ2yYrtolyjSRoo7A4ZniBUHBZUNWm6TD6i0CJayqyxWeVk/XiaABD8bY0w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3370,9 +3513,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-arm64-msvc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.3.1.tgz",
-      "integrity": "sha512-WeZkGl2BP1U4tRhEQH+FXLQS52N8obp74smK5AAGOfzPAT1pHkq6+dVkC1QCSIt7dHJs7SPtlnQw+5DkdZYlWA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.3.2.tgz",
+      "integrity": "sha512-yhpLcj0qel5VNlpzxPZfNmi7+rEX8444QHjUP6WWLxdRfqPllROu/Cp3OpkBpw3BLdxfcDhWkjWMD5QsJN0Pvg==",
       "cpu": [
         "arm64"
       ],
@@ -3386,9 +3529,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-ia32-msvc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.3.1.tgz",
-      "integrity": "sha512-rNGgMeCH5mdeHiMiJgt7wWXovZ+FHEfXhU9p4zZBH4n8M1/QnEsRUwlapISPLpILSGpoYS6iBuq9/fUlZY8Mhg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.3.2.tgz",
+      "integrity": "sha512-BFVSbdtg/7mJBw5kQFOPKFiA+SF7z3240HpzHN81Umm4Bp4dWkyx0msYn8+Q7/BBJiLQ4F6bi3Nftk58YA9r9w==",
       "cpu": [
         "x64",
         "ia32"
@@ -3403,9 +3546,9 @@
       }
     },
     "node_modules/@yuuang/ffi-rs-win32-x64-msvc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.3.1.tgz",
-      "integrity": "sha512-dr2LcLD2CXo2a7BktlOpV68QhayqiI112KxIJC9tBgQO/Dkdg4CPsdqmvzzLhFo64iC5RLl2BT7M5lJImrfUWw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.3.2.tgz",
+      "integrity": "sha512-ZL5MJ76n2rjwGo26kCWW7wK6QT/cee00Rx8pfW79pz6vM6jqfhoE7zTnwFiw4aOQUes9+HUc5DeeJ3z+Vb9oLg==",
       "cpu": [
         "x64"
       ],
@@ -3472,13 +3615,16 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "inBundle": true,
       "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -3532,7 +3678,6 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -3609,7 +3754,6 @@
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3659,6 +3803,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3680,6 +3834,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/clean-stack": {
@@ -3714,22 +3888,6 @@
         "npm": ">=5.0.0"
       }
     },
-    "node_modules/cli-highlight/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cli-highlight/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3745,65 +3903,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cli-table3": {
@@ -3823,59 +3922,38 @@
       }
     },
     "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.2.2"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -3897,6 +3975,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -4139,13 +4227,34 @@
         "node": ">= 14"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
       "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4585,9 +4694,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "funding": [
         {
           "type": "github",
@@ -4661,22 +4770,22 @@
       }
     },
     "node_modules/ffi-rs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.3.1.tgz",
-      "integrity": "sha512-ZyNXL9fnclnZV+waQmWB9JrfbIEyxQa1OWtMrHOrAgcC04PgP5hBMG5TdhVN8N4uT/eul8zCFMVnJUukAFFlXA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.3.2.tgz",
+      "integrity": "sha512-4s8dX9VbBw/jd5NOuE3EJRqXaIVdjMyiumeeDzrOhtjQRwp6Bz2za7iksWXTnvTQKV/tTdm1s1w7mObe92zPjQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "@yuuang/ffi-rs-android-arm64": "1.3.1",
-        "@yuuang/ffi-rs-darwin-arm64": "1.3.1",
-        "@yuuang/ffi-rs-darwin-x64": "1.3.1",
-        "@yuuang/ffi-rs-linux-arm-gnueabihf": "1.3.1",
-        "@yuuang/ffi-rs-linux-arm64-gnu": "1.3.1",
-        "@yuuang/ffi-rs-linux-arm64-musl": "1.3.1",
-        "@yuuang/ffi-rs-linux-x64-gnu": "1.3.1",
-        "@yuuang/ffi-rs-linux-x64-musl": "1.3.1",
-        "@yuuang/ffi-rs-win32-arm64-msvc": "1.3.1",
-        "@yuuang/ffi-rs-win32-ia32-msvc": "1.3.1",
-        "@yuuang/ffi-rs-win32-x64-msvc": "1.3.1"
+        "@yuuang/ffi-rs-android-arm64": "1.3.2",
+        "@yuuang/ffi-rs-darwin-arm64": "1.3.2",
+        "@yuuang/ffi-rs-darwin-x64": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm-gnueabihf": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.3.2",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.3.2",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.3.2",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.3.2",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.3.2",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.3.2"
       }
     },
     "node_modules/figures": {
@@ -4797,9 +4906,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4940,7 +5049,6 @@
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -5022,6 +5130,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -5046,9 +5190,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5056,6 +5200,16 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -5337,9 +5491,9 @@
       "license": "ISC"
     },
     "node_modules/issue-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-      "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+      "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5361,6 +5515,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -5431,9 +5596,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5469,9 +5634,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
-      "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
@@ -5590,9 +5755,9 @@
       "peer": true
     },
     "node_modules/lru-cache": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-      "integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5665,6 +5830,27 @@
         "marked": ">=1 <16"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -5683,6 +5869,95 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -5760,7 +6035,6 @@
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -5787,7 +6061,6 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5923,9 +6196,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.0.tgz",
+      "integrity": "sha512-6jfZzqK8EfWGnTeZQe+bgMx4IgiEZn7k1eM4GE8SE81B3iYch52dVSMO1hC2OnNbFLIwzvwUkUxsOOcUPG2XIw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -6004,8 +6277,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -6026,24 +6299,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
+        "libnpmpack": "^9.1.7",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -6062,7 +6335,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -6134,7 +6407,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6182,7 +6455,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6385,7 +6658,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6527,7 +6800,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6596,7 +6869,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -6652,7 +6925,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6819,7 +7092,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6828,12 +7101,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -6901,12 +7174,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6920,13 +7193,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6943,12 +7216,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.21",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.5.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6968,12 +7241,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -7043,7 +7316,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7075,12 +7348,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7128,34 +7401,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -7236,7 +7491,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7244,12 +7499,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -7622,12 +7877,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7696,7 +7951,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.13",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7724,13 +7979,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7757,7 +8012,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7789,6 +8044,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -7886,6 +8150,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/openai": {
@@ -8209,7 +8490,6 @@
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -8346,6 +8626,16 @@
       "peer": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/proto-list": {
@@ -8534,6 +8824,37 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
@@ -8579,11 +8900,26 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -8655,6 +8991,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/semantic-release/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/semantic-release/node_modules/clean-stack": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
@@ -8670,6 +9019,28 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/semantic-release/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/semantic-release/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semantic-release/node_modules/execa": {
       "version": "9.6.1",
@@ -8807,6 +9178,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/semantic-release/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semantic-release/node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -8831,6 +9220,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/semver": {
@@ -8880,6 +9315,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/signal-exit": {
@@ -9063,6 +9517,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -9116,14 +9580,6 @@
         "through2": "~2.0.0"
       }
     },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -9145,6 +9601,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -9160,7 +9623,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -9173,14 +9646,34 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "inBundle": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -9214,9 +9707,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -9412,14 +9905,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9505,6 +9998,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -9532,9 +10035,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -9548,9 +10051,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.36",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.36.tgz",
-      "integrity": "sha512-aGbdGqjFiCYy7XAe4+KUz53N2fB2ngumD1nImL2n6Hv0Tf8+bqx8k1DP+dOu3mLg3hOHbdl9K+2i7jomfYDk9A==",
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
       "inBundle": true,
       "license": "MIT",
       "peer": true
@@ -9584,9 +10087,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9638,6 +10141,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universal-user-agent": {
@@ -9700,6 +10271,34 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
@@ -9752,62 +10351,44 @@
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.2.2"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -9862,9 +10443,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -9879,72 +10460,32 @@
       }
     },
     "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "dev": true,
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^9.0.1",
+        "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
+        "yargs-parser": "^20.2.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=10"
       }
     },
     "node_modules/yauzl": {
@@ -9963,7 +10504,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "inBundle": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9973,9 +10514,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
-      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -9992,6 +10533,16 @@
       "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
       "extensions/workspace-memory/index.ts",
       "node_modules/@code-yeongyu/pi-nested-agents-md/src/index.ts",
       "node_modules/pi-lsp-client/src/index.ts",
-      "node_modules/pi-code-previews/index.ts"
+      "extensions/pi-code-previews/index.ts"
     ]
   },
   "dependencies": {
     "@code-yeongyu/pi-nested-agents-md": "github:code-yeongyu/pi-nested-agents-md",
     "@ff-labs/fff-node": "^0.6.4",
     "@sinclair/typebox": "^0.34.49",
-    "pi-code-previews": "github:mattleong/pi-code-previews",
-    "pi-lsp-client": "github:code-yeongyu/pi-lsp-client"
+    "diff": "^8.0.4",
+    "pi-lsp-client": "github:code-yeongyu/pi-lsp-client",
+    "shiki": "^4.0.2"
   },
   "bundledDependencies": [
     "@code-yeongyu/pi-nested-agents-md",
-    "pi-code-previews",
     "pi-lsp-client"
   ],
   "devDependencies": {


### PR DESCRIPTION
Convert pi-code-previews from external npm dependency to vendored internal extension under `extensions/pi-code-previews/`.

**Changes:**
- Copies pi-code-previews source from node_modules to extensions/
- Updates `pi.extensions` path to point to local extension
- Adds `diff` and `shiki` as direct root dependencies
- Removes pi-code-previews from dependencies and bundledDependencies
- Regenerates package-lock.json to fix `npm ci` missing deps issue

**Motivation:**
Previously added in #40 as an external GitHub dependency, but this meant users needed the external package installed separately. Vendoring it makes pi-code-previews install automatically with roach-pi.

Fixes CI `npm ci` failure caused by missing transitive deps (unist-util-visit-parents, vfile-message, unist-util-stringify-position) in the lock file.