### PR TITLE
fix: respect shellPath setting in sandboxed bash operations

### DIFF
--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -15,6 +15,7 @@ import { emptyUsage, isResultError, isResultSuccess, getResultSummaryText, type 
 import { renderCall, renderResult } from "./render.js";
 import { parsePlan } from "./plan-parser.js";
 import { buildValidatorPrompt } from "./validator-template.js";
+import { readFileSync } from "fs";
 import { readFile, writeFile, mkdir } from "fs/promises";
 import { microcompactMessages, getCompactionPrompt, formatCompactSummary } from "./compaction.js";
 import { convertToLlm, serializeConversation } from "@mariozechner/pi-coding-agent";
@@ -273,14 +274,25 @@ export default function (pi: ExtensionAPI) {
 
     const shouldRegisterSandboxedBash = process.platform !== "darwin" || process.env.PI_AGENTIC_SANDBOX_BASH === "1";
     if (shouldRegisterSandboxedBash) {
-      const sandboxedBashOperations = createSandboxedBashOperations(createRootSandbox());
+      // Respect shellPath from settings.json so that the sandboxed bash uses the
+      // user's configured shell (e.g. Git Bash) instead of default PATH resolution.
+      let shellPath: string | undefined;
+      try {
+        const settingsPath = join(homedir(), ".pi", "agent", "settings.json");
+        const settingsRaw = readFileSync(settingsPath, "utf-8");
+        const settings = JSON.parse(settingsRaw);
+        shellPath = settings.shellPath;
+      } catch {
+        // Fall through — getShellConfig will use default resolution
+      }
+      const sandboxedBashOperations = createSandboxedBashOperations(createRootSandbox(), shellPath);
       const localBash = createBashTool(process.cwd(), { operations: sandboxedBashOperations });
       pi.registerTool({
         ...localBash,
         label: "bash (sandboxed)",
       });
       pi.on("user_bash", (_event, ctx) => ({
-        operations: createSandboxedBashOperations(createRootSandbox(ctx as any, true)),
+        operations: createSandboxedBashOperations(createRootSandbox(ctx as any, true), shellPath),
       }));
     }
   }

--- a/extensions/agentic-harness/sandbox/bash-operations.ts
+++ b/extensions/agentic-harness/sandbox/bash-operations.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
+import { getShellConfig } from "@mariozechner/pi-coding-agent";
 import { resolveSandboxLaunch } from "./executor.js";
 import type { SandboxRuntimeOptions } from "./types.js";
 import { getDefaultApprovalStore } from "./approval-store.js";
@@ -13,11 +14,17 @@ function killProcessTree(pid: number): void {
   }
 }
 
-export function createSandboxedBashOperations(sandbox: Omit<SandboxRuntimeOptions, "approvalStore">): BashOperations {
+export function createSandboxedBashOperations(
+  sandbox: Omit<SandboxRuntimeOptions, "approvalStore">,
+  shellPath?: string,
+): BashOperations {
   return {
     async exec(command, cwd, options) {
+      // Resolve the user-configured shell (e.g. Git Bash), but keep the
+      // sandbox login-shell convention (-lc) for args.
+      const { shell: resolvedShell } = getShellConfig(shellPath);
       const resolvedSandbox = await resolveSandboxLaunch({
-        command: "bash",
+        command: resolvedShell,
         args: ["-lc", command],
         cwd,
         env: options.env || process.env,


### PR DESCRIPTION
The sandboxed bash operations hardcoded command: "bash", which on Windows resolves to C:\Windows\System32\bash.exe (the WSL launcher) first on PATH, bypassing the user's configured shellPath (e.g. Git Bash).

This fix reads shellPath from ~/.pi/agent/settings.json and passes it to getShellConfig() so the sandboxed bash spawns the user's preferred shell while preserving the login-shell convention (-lc).