### PR TITLE
feat(harness): add todoread/todowrite facade and fix dual-lock race c…

### DIFF
--- a/docs/engineering-discipline/plans/2026-05-18-todowrite-todoread-surface.md
+++ b/docs/engineering-discipline/plans/2026-05-18-todowrite-todoread-surface.md
@@ -1,0 +1,673 @@
+# Todowrite/Todoread Surface Implementation Plan
+
+> **Worker note:** Execute this plan task-by-task using the run-plan skill or subagents. Checkbox syntax is rendered task formatting only; canonical progress for this plan should be updated through `todowrite` after Task 3 lands.
+
+**Goal:** Replace normal agent-facing progress updates with `todowrite` and `todoread` while keeping roach-pi's structured harness state as the canonical backend.
+
+**Architecture:** Add a thin facade layer over the existing `HarnessState` reducer, snapshot, and replay-event system. Existing `harness_milestone`, `harness_plan`, and `harness_todo` remain as compatibility/internal tools, but prompt guidance and default active tools should steer agents to `todowrite` and `todoread`.
+
+**Tech Stack:** TypeScript, pi extension API, `@sinclair/typebox`, Vitest, existing `HarnessState` reducer/storage/replay modules.
+
+**Work Scope:**
+- **In scope:** Add `todowrite` and `todoread` tools; support `M1`/`M2` milestone IDs and `M1.T1`/`M2.T3` plan-task IDs; infer active run state from session replay or explicit params; update docs/skills/tests to train agents toward the new surface.
+- **Out of scope:** Replacing `HarnessState`; creating a separate todo database; removing legacy harness tools in this release; redesigning team-mode run state.
+
+**Verification Strategy:**
+- **Level:** test-suite
+- **Command:** `npm --prefix extensions/agentic-harness test && npm --prefix extensions/agentic-harness run build`
+- **What it validates:** Agentic harness unit/integration tests, tool registration contracts, structured harness state behavior, session replay behavior, and TypeScript correctness.
+
+---
+
+## File Structure Mapping
+
+- Create `extensions/agentic-harness/harness-state-service.ts`
+  - Shared load/apply/persist/event helpers currently private to `harness-tools.ts`.
+- Create `extensions/agentic-harness/todo-facade.ts`
+  - Pure mapping between `HarnessState` and `todowrite`/`todoread` item shapes.
+- Modify `extensions/agentic-harness/harness-tools.ts`
+  - Reuse shared service helpers and register `todowrite`/`todoread`.
+  - De-emphasize `harness_plan` and `harness_todo` guidance.
+- Modify `extensions/agentic-harness/index.ts`
+  - Keep registering compatibility tools.
+  - On session start, prefer active tools that include `todowrite`/`todoread` and exclude `harness_plan`/`harness_todo` when `setActiveTools` is available.
+- Modify skill docs:
+  - `extensions/agentic-harness/skills/agentic-run-plan/SKILL.md`
+  - `extensions/agentic-harness/skills/agentic-long-run/SKILL.md`
+  - `extensions/agentic-harness/skills/agentic-plan-crafting/SKILL.md`
+  - `extensions/agentic-harness/skills/agentic-review-work/SKILL.md`
+  - `extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md`
+- Modify tests:
+  - `extensions/agentic-harness/tests/harness-tools.test.ts`
+  - `extensions/agentic-harness/tests/extension.test.ts`
+  - `extensions/agentic-harness/tests/skill-docs.test.ts`
+- Create `extensions/agentic-harness/tests/todo-facade.test.ts`
+  - Focused pure mapper tests.
+
+## Project Capability Discovery
+
+No project-specific agents or skills are required for this implementation. Existing validation is handled by the `extensions/agentic-harness` Vitest suite and TypeScript build.
+
+---
+
+### Task 1: Extract Harness State Service Helpers
+
+**Dependencies:** None
+**Files:**
+- Create: `extensions/agentic-harness/harness-state-service.ts`
+- Modify: `extensions/agentic-harness/harness-tools.ts`
+- Test: `extensions/agentic-harness/tests/harness-tools.test.ts`
+
+- [ ] **Step 1: Create shared service module**
+
+Create `extensions/agentic-harness/harness-state-service.ts` with the helper functions currently private in `harness-tools.ts`: `loadHarnessState`, `persistHarnessState`, `applyAndPersist`, `applyAndPersistFromLoadedState`, and `emitHarnessEvent`.
+
+The exported signatures must be:
+
+```ts
+export async function loadHarnessState(
+  runId: string,
+  rootDir?: string,
+  now?: string,
+): Promise<HarnessState>;
+
+export async function persistHarnessState(
+  state: HarnessState,
+  rootDir?: string,
+  now?: string,
+): Promise<void>;
+
+export function emitHarnessEvent(
+  ctx: { sessionManager?: any },
+  state: HarnessState,
+  command: HarnessCommand,
+  now?: string,
+  rootDir?: string,
+): void;
+
+export async function applyAndPersistFromLoadedState(
+  runId: string,
+  rootDir: string | undefined,
+  buildCommand: (state: HarnessState) => HarnessCommand,
+  ctx: { sessionManager?: any },
+): Promise<{
+  state: HarnessState;
+  event: import("./harness-state.js").HarnessStateEvent;
+}>;
+
+export async function applyAndPersist(
+  runId: string,
+  rootDir: string | undefined,
+  command: HarnessCommand,
+  ctx: { sessionManager?: any },
+): Promise<{
+  state: HarnessState;
+  event: import("./harness-state.js").HarnessStateEvent;
+}>;
+```
+
+Preserve the existing in-process mutation lock key behavior:
+
+```ts
+const key = `${rootDir ?? defaultHarnessStateRoot()}\0${runId}`;
+```
+
+- [ ] **Step 2: Replace local helper definitions in `harness-tools.ts`**
+
+Remove the private helper implementations from `harness-tools.ts` and import them:
+
+```ts
+import {
+  applyAndPersist,
+  applyAndPersistFromLoadedState,
+  loadHarnessState,
+} from "./harness-state-service.js";
+```
+
+Keep existing tool behavior unchanged in this task.
+
+- [ ] **Step 3: Run focused harness tool tests**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test -- tests/harness-tools.test.ts
+```
+
+Expected: PASS. Existing harness tool registration and execution behavior remains unchanged.
+
+### Task 2: Add Pure Todowrite/Todoread Mapping
+
+**Dependencies:** Task 1
+**Files:**
+- Create: `extensions/agentic-harness/todo-facade.ts`
+- Create: `extensions/agentic-harness/tests/todo-facade.test.ts`
+
+- [ ] **Step 1: Define facade types and ID parsing**
+
+Create `todo-facade.ts` with these public types:
+
+```ts
+export type TodoFacadeStatus = "pending" | "in_progress" | "completed" | "failed" | "cancelled";
+export type TodoFacadePriority = "high" | "medium" | "low";
+
+export interface TodoFacadeItem {
+  id: string;
+  content: string;
+  status: TodoFacadeStatus;
+  priority?: TodoFacadePriority;
+}
+
+export interface TodoReadResult {
+  runId: string;
+  rootDir?: string;
+  todos: TodoFacadeItem[];
+}
+```
+
+Add ID parsing helpers:
+
+```ts
+export function parseTodoFacadeId(id: string):
+  | { kind: "milestone"; milestoneId: string }
+  | { kind: "plan_task"; milestoneId: string; taskId: number }
+  | { kind: "unknown"; id: string } {
+  const milestone = /^M\d+$/.exec(id);
+  if (milestone) return { kind: "milestone", milestoneId: id };
+
+  const task = /^(M\d+)\.T(\d+)$/.exec(id);
+  if (task) return { kind: "plan_task", milestoneId: task[1], taskId: Number(task[2]) };
+
+  return { kind: "unknown", id };
+}
+```
+
+- [ ] **Step 2: Map harness statuses to facade statuses**
+
+Implement these exact mappings:
+
+```ts
+export function milestoneStatusToTodoStatus(status: HarnessMilestoneStatus): TodoFacadeStatus {
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "skipped") return "cancelled";
+  if (status === "planning" || status === "executing" || status === "validating") return "in_progress";
+  return "pending";
+}
+
+export function planTaskStatusToTodoStatus(status: HarnessPlanTaskStatus): TodoFacadeStatus {
+  if (status === "running") return "in_progress";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "skipped") return "cancelled";
+  return "pending";
+}
+```
+
+Implement reverse mappings:
+
+```ts
+export function todoStatusToMilestoneStatus(status: TodoFacadeStatus): HarnessMilestoneStatus {
+  if (status === "in_progress") return "executing";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "skipped";
+  return "pending";
+}
+
+export function todoStatusToPlanTaskStatus(status: TodoFacadeStatus): HarnessPlanTaskStatus {
+  if (status === "in_progress") return "running";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "skipped";
+  return "pending";
+}
+```
+
+- [ ] **Step 3: Build `readTodosFromHarnessState`**
+
+Add:
+
+```ts
+export function readTodosFromHarnessState(
+  state: HarnessState,
+  options: { rootDir?: string } = {},
+): TodoReadResult {
+  const todos: TodoFacadeItem[] = [];
+
+  for (const milestone of state.milestones) {
+    todos.push({
+      id: milestone.id,
+      content: milestone.name,
+      status: milestoneStatusToTodoStatus(milestone.status),
+      priority: milestone.status === "executing" || milestone.status === "validating" ? "high" : "medium",
+    });
+
+    const plan = selectPlanForMilestone(state, milestone);
+    if (!plan) continue;
+    for (const task of plan.tasks) {
+      todos.push({
+        id: `${milestone.id}.T${task.id}`,
+        content: task.name,
+        status: planTaskStatusToTodoStatus(task.status),
+        priority: task.status === "running" || task.status === "failed" ? "high" : "medium",
+      });
+    }
+  }
+
+  return { runId: state.runId, rootDir: options.rootDir, todos };
+}
+```
+
+- [ ] **Step 4: Add pure mapper tests**
+
+Create `todo-facade.test.ts` with tests covering:
+
+```ts
+expect(parseTodoFacadeId("M1")).toEqual({ kind: "milestone", milestoneId: "M1" });
+expect(parseTodoFacadeId("M2.T3")).toEqual({ kind: "plan_task", milestoneId: "M2", taskId: 3 });
+expect(parseTodoFacadeId("misc")).toEqual({ kind: "unknown", id: "misc" });
+expect(todoStatusToMilestoneStatus("in_progress")).toBe("executing");
+expect(todoStatusToPlanTaskStatus("in_progress")).toBe("running");
+expect(milestoneStatusToTodoStatus("validating")).toBe("in_progress");
+expect(planTaskStatusToTodoStatus("skipped")).toBe("cancelled");
+```
+
+Also build a `HarnessState` with milestones `M1`, `M2` and a plan under `M2`, then assert that `readTodosFromHarnessState` returns IDs `M1`, `M2`, `M2.T1`, and `M2.T2`.
+
+- [ ] **Step 5: Run focused mapper tests**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test -- tests/todo-facade.test.ts
+```
+
+Expected: PASS.
+
+### Task 3: Register Todoread/Todowrite Tools
+
+**Dependencies:** Tasks 1 and 2
+**Files:**
+- Modify: `extensions/agentic-harness/harness-tools.ts`
+- Modify: `extensions/agentic-harness/tests/harness-tools.test.ts`
+- Modify: `extensions/agentic-harness/tests/extension.test.ts`
+
+- [ ] **Step 1: Add tool schemas**
+
+In `harness-tools.ts`, add a `TodoFacadeStatusEnum`, `TodoFacadePriorityEnum`, `TodoWriteItem`, `TodoWriteParams`, and `TodoReadParams` near the existing tool schema definitions:
+
+```ts
+const TodoFacadeStatusEnum = stringEnum(
+  ["pending", "in_progress", "completed", "failed", "cancelled"],
+  { description: "Todo status" },
+);
+
+const TodoFacadePriorityEnum = stringEnum(
+  ["high", "medium", "low"],
+  { description: "Todo priority" },
+);
+
+const TodoWriteItem = Type.Object({
+  id: Type.String({ description: "Milestone id like M1 or plan task id like M2.T3" }),
+  content: Type.String({ description: "Human-readable task or milestone label" }),
+  status: TodoFacadeStatusEnum,
+  priority: Type.Optional(TodoFacadePriorityEnum),
+});
+
+const TodoWriteParams = Type.Object({
+  runId: Type.Optional(Type.String({ description: "Harness run id. Optional when a current run can be inferred from session replay." })),
+  rootDir: Type.Optional(Type.String({ description: "Harness state root directory override" })),
+  todos: Type.Array(TodoWriteItem, { description: "Complete updated milestone/task todo list" }),
+});
+
+const TodoReadParams = Type.Object({
+  runId: Type.Optional(Type.String({ description: "Harness run id. Optional when a current run can be inferred from session replay." })),
+  rootDir: Type.Optional(Type.String({ description: "Harness state root directory override" })),
+});
+```
+
+- [ ] **Step 2: Infer active run from session replay**
+
+Add a local helper in `harness-tools.ts`:
+
+```ts
+function resolveRunIdentityFromParamsOrSession(
+  params: { runId?: string; rootDir?: string },
+  ctx: { cwd?: string; sessionManager?: any },
+): { runId: string; rootDir?: string } {
+  if (params.runId) return { runId: params.runId, rootDir: params.rootDir };
+
+  const branch = ctx.sessionManager?.getBranch?.() ?? [];
+  const events = extractHarnessReplayEventsFromSessionEntries(branch);
+  const latest = events.at(-1);
+  if (latest?.runId) {
+    return {
+      runId: latest.runId,
+      rootDir: params.rootDir ?? latest.rootDir,
+    };
+  }
+
+  throw new Error("runId is required because no active harness run could be inferred from this session");
+}
+```
+
+Import `extractHarnessReplayEventsFromSessionEntries` from `harness-events.js`.
+
+- [ ] **Step 3: Register `todoread`**
+
+Inside `registerHarnessTools(pi)`, register `todoread` before the compatibility harness tools:
+
+```ts
+pi.registerTool({
+  name: "todoread",
+  label: "TodoRead",
+  description: "Read current milestone and plan-task progress from roach-pi structured harness state.",
+  promptSnippet: "Read current milestone/task todo progress",
+  promptGuidelines: [
+    "Use todoread before updating or reporting plan/milestone progress.",
+    "IDs like M1 and M2 refer to milestones. IDs like M2.T1 refer to plan tasks inside that milestone.",
+    "Use todowrite to persist progress updates. Do not edit markdown checkboxes as progress state.",
+  ],
+  parameters: TodoReadParams,
+  execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+    try {
+      const identity = resolveRunIdentityFromParamsOrSession(params, ctx);
+      const state = await loadHarnessState(identity.runId, identity.rootDir);
+      const result = readTodosFromHarnessState(state, { rootDir: identity.rootDir });
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        details: result,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+    }
+  },
+});
+```
+
+- [ ] **Step 4: Register `todowrite`**
+
+Add `todowrite` after `todoread`. It must apply only recognized IDs and must reject unknown IDs instead of silently ignoring them.
+
+Implementation rules:
+- For `M1`: use `set_milestone_status`.
+- For `M2.T3`: find the plan attached to milestone `M2`, then use `set_plan_task_status`.
+- If a milestone ID does not exist, return `isError: true`.
+- If a task ID does not exist in the milestone's active plan, return `isError: true`.
+- Ignore `priority` for persistence in this release, but keep it accepted in the schema.
+
+Core execute loop:
+
+```ts
+const result = await applyAndPersistFromLoadedState(
+  identity.runId,
+  identity.rootDir,
+  (current) => {
+    const item = params.todos[index];
+    const parsed = parseTodoFacadeId(item.id);
+    if (parsed.kind === "milestone") {
+      if (!current.milestones.some((m) => m.id === parsed.milestoneId)) {
+        throw new Error(`Milestone ${parsed.milestoneId} not found`);
+      }
+      return {
+        type: "set_milestone_status",
+        id: parsed.milestoneId,
+        status: todoStatusToMilestoneStatus(item.status),
+      };
+    }
+    if (parsed.kind === "plan_task") {
+      const milestone = current.milestones.find((m) => m.id === parsed.milestoneId);
+      if (!milestone) throw new Error(`Milestone ${parsed.milestoneId} not found`);
+      const plan = selectPlanForMilestone(current, milestone);
+      if (!plan) throw new Error(`No active plan found for milestone ${parsed.milestoneId}`);
+      if (!plan.tasks.some((task) => task.id === parsed.taskId)) {
+        throw new Error(`Task ${item.id} not found`);
+      }
+      const status = todoStatusToPlanTaskStatus(item.status);
+      const at = new Date().toISOString();
+      return {
+        type: "set_plan_task_status",
+        planId: plan.id,
+        taskId: parsed.taskId,
+        status,
+        startedAt: status === "running" ? at : undefined,
+        completedAt: status === "completed" || status === "failed" || status === "skipped" ? at : undefined,
+      };
+    }
+    throw new Error(`Unsupported todo id ${item.id}; expected M1 or M1.T1`);
+  },
+  ctx,
+);
+```
+
+Because `applyAndPersistFromLoadedState` applies one command per call, implement the actual `todowrite` body as a sequential loop over `params.todos`, reloading state through the helper each time. After the loop, load final state and return `readTodosFromHarnessState(finalState)`.
+
+- [ ] **Step 5: Add registration and execute tests**
+
+In `harness-tools.test.ts` and `extension.test.ts`, assert:
+
+```ts
+expect(tools.get("todoread")).toBeDefined();
+expect(tools.get("todowrite")).toBeDefined();
+```
+
+Add execution tests in `harness-tools.test.ts`:
+- Create milestone `M1`, attach plan `m1-plan`, define task `1`.
+- Call `todoread` with explicit `runId`; expect IDs `M1` and `M1.T1`.
+- Call `todowrite` with `M1` as `in_progress`; expect snapshot milestone status `executing`.
+- Call `todowrite` with `M1.T1` as `completed`; expect snapshot plan task status `completed`.
+- Call `todowrite` with `M9`; expect `isError: true`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test -- tests/todo-facade.test.ts tests/harness-tools.test.ts tests/extension.test.ts
+```
+
+Expected: PASS.
+
+### Task 4: De-Emphasize Legacy Harness Plan/Todo Surface
+
+**Dependencies:** Task 3
+**Files:**
+- Modify: `extensions/agentic-harness/harness-tools.ts`
+- Modify: `extensions/agentic-harness/index.ts`
+- Modify: `extensions/agentic-harness/tests/extension.test.ts`
+- Modify: `extensions/agentic-harness/tests/harness-tools.test.ts`
+
+- [ ] **Step 1: Remove prompt training from `harness_plan` and `harness_todo`**
+
+Keep the `harness_plan` and `harness_todo` registrations for compatibility, but remove their `promptSnippet` and `promptGuidelines` fields. Update their descriptions to say:
+
+```ts
+description:
+  "Compatibility tool for structured harness plan state. Prefer todoread/todowrite for normal agent-facing progress updates.",
+```
+
+and:
+
+```ts
+description:
+  "Compatibility tool for structured harness todo state. Prefer todoread/todowrite for normal agent-facing progress updates.",
+```
+
+Leave `harness_milestone` public in this release because it still owns milestone creation metadata, dependencies, attempts, plan files, and review files.
+
+- [ ] **Step 2: Prefer active tools at session start when supported**
+
+In `index.ts`, add a `session_start` handler after tool registration or inside the existing session start flow:
+
+```ts
+function preferTodoSurfaceTools(pi: any): void {
+  if (typeof pi.getActiveTools !== "function" || typeof pi.setActiveTools !== "function") {
+    return;
+  }
+  const active = pi.getActiveTools();
+  if (!Array.isArray(active)) return;
+  pi.setActiveTools(active.filter((name: string) => name !== "harness_plan" && name !== "harness_todo"));
+}
+```
+
+Call `preferTodoSurfaceTools(pi)` once during extension setup and again on `session_start`. This preserves compatibility for manual re-enable while making the default agent surface `todoread`/`todowrite`.
+
+- [ ] **Step 3: Update tests for de-emphasized legacy tools**
+
+Update harness tool registration tests:
+- Keep asserting `harness_plan` and `harness_todo` are registered.
+- Stop asserting they have `promptSnippet` or non-empty `promptGuidelines`.
+- Add assertions that `todoread` and `todowrite` have non-empty `promptGuidelines`.
+
+Add an `extension.test.ts` case with mock `getActiveTools`/`setActiveTools`:
+
+```ts
+const activeTools = ["todoread", "todowrite", "harness_plan", "harness_todo", "harness_milestone"];
+mockPi.getActiveTools = vi.fn(() => activeTools);
+mockPi.setActiveTools = vi.fn();
+extension(mockPi);
+expect(mockPi.setActiveTools).toHaveBeenCalledWith(["todoread", "todowrite", "harness_milestone"]);
+```
+
+- [ ] **Step 4: Run focused registration tests**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test -- tests/harness-tools.test.ts tests/extension.test.ts
+```
+
+Expected: PASS.
+
+### Task 5: Update Skill Guidance To Use Todowrite/Todoread
+
+**Dependencies:** Task 4
+**Files:**
+- Modify: `extensions/agentic-harness/skills/agentic-run-plan/SKILL.md`
+- Modify: `extensions/agentic-harness/skills/agentic-long-run/SKILL.md`
+- Modify: `extensions/agentic-harness/skills/agentic-plan-crafting/SKILL.md`
+- Modify: `extensions/agentic-harness/skills/agentic-review-work/SKILL.md`
+- Modify: `extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md`
+- Modify: `extensions/agentic-harness/tests/skill-docs.test.ts`
+
+- [ ] **Step 1: Update run-plan task status language**
+
+In `agentic-run-plan/SKILL.md`, replace the mandatory `harness_plan set_task_status` instruction with:
+
+````md
+After the validator passes, you **MUST** update structured progress via `todowrite`. First call `todoread`, then write back the complete list with the relevant `M#.T#` item marked `completed`.
+
+Example:
+```json
+{
+  "todos": [
+    { "id": "M1", "content": "Foundation", "status": "in_progress" },
+    { "id": "M1.T1", "content": "Create shared service", "status": "completed" },
+    { "id": "M1.T2", "content": "Register todowrite", "status": "pending" }
+  ]
+}
+```
+````
+
+Keep the statement that markdown checkboxes are rendered output only.
+
+- [ ] **Step 2: Update long-run state language**
+
+In `agentic-long-run/SKILL.md`, preserve `harness_milestone` instructions for milestone creation and milestone metadata. Replace plan-task progress instructions with `todoread`/`todowrite`.
+
+Required wording:
+
+```md
+Use `harness_milestone` for milestone creation, dependency metadata, attempts, plan files, review files, and milestone lifecycle. Use `todoread` and `todowrite` for normal milestone/task progress updates visible to the agent.
+```
+
+For recovery instructions, say:
+
+```md
+For executing milestones, call `todoread` and continue from the first item whose status is not `completed` or `cancelled`. Do not infer task status from markdown checkboxes.
+```
+
+- [ ] **Step 3: Update plan-crafting guidance**
+
+In `agentic-plan-crafting/SKILL.md`, change worker notes so generated plans tell workers to use `todowrite` after the facade lands:
+
+```md
+> **Worker note:** Execute this plan task-by-task using the agentic-run-plan skill or subagents. Checkbox syntax is rendered task formatting only; canonical progress is read with `todoread` and updated with `todowrite`.
+```
+
+Keep plan registration details only where the plan is attached to a milestone. Do not tell normal workers to call `harness_plan set_task_status`.
+
+- [ ] **Step 4: Update review and milestone-planning guidance**
+
+In `agentic-review-work/SKILL.md`, keep `harness_milestone` for review-result milestone status when needed, but add:
+
+```md
+If review completion corresponds to a plan task, update that task through `todowrite` rather than `harness_plan`.
+```
+
+In `agentic-milestone-planning/SKILL.md`, keep `harness_milestone` initialization. If task progress examples exist, convert them to `todowrite`.
+
+- [ ] **Step 5: Update skill-doc tests**
+
+Update `skill-docs.test.ts` expectations:
+- `agentic-run-plan` contains `todowrite` and `todoread`.
+- `agentic-run-plan` does not contain `harness_plan set_task_status`.
+- `agentic-long-run` contains `harness_milestone`, `todowrite`, and `todoread`.
+- `agentic-plan-crafting` contains `canonical progress is read with \`todoread\` and updated with \`todowrite\``.
+
+- [ ] **Step 6: Run skill doc tests**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test -- tests/skill-docs.test.ts
+```
+
+Expected: PASS.
+
+### Task 6: Final Verification
+
+**Dependencies:** Tasks 1-5
+**Files:** None (read-only verification)
+
+- [ ] **Step 1: Run full agentic harness test suite and build**
+
+Run:
+
+```bash
+npm --prefix extensions/agentic-harness test && npm --prefix extensions/agentic-harness run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Verify user-facing success criteria**
+
+Manually inspect the final code and tests:
+- [ ] `todoread` is registered and returns current `M#` and `M#.T#` progress from `HarnessState`.
+- [ ] `todowrite` is registered and can update milestone and plan-task statuses.
+- [ ] `harness_plan` and `harness_todo` remain registered for compatibility but are no longer promoted in prompt guidance.
+- [ ] `harness_milestone` remains available for milestone metadata and lifecycle operations.
+- [ ] Skill docs train agents to use `todoread`/`todowrite` for normal progress.
+- [ ] No separate todo state store was introduced.
+
+- [ ] **Step 3: Inspect local diff**
+
+Run:
+
+```bash
+git diff -- extensions/agentic-harness/harness-state-service.ts extensions/agentic-harness/todo-facade.ts extensions/agentic-harness/harness-tools.ts extensions/agentic-harness/index.ts extensions/agentic-harness/skills extensions/agentic-harness/tests
+```
+
+Expected: Diff only contains facade, tool registration, skill guidance, and tests described in this plan.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** The plan covers `todowrite`/`todoread` as the surface API, `M1`/`M2` milestone IDs, `M1.T1` task IDs, compatibility retention, prompt migration, tests, and final verification.
+- **Placeholder scan:** No unresolved implementation placeholders are left. All new files, functions, mappings, and commands are named explicitly.
+- **Type consistency:** `TodoFacadeStatus`, `TodoFacadeItem`, `TodoReadResult`, and `HarnessState` mappings are used consistently across tasks.
+- **Dependency verification:** Tasks 1-5 are sequential because they touch overlapping files or depend on exported APIs from earlier tasks. Task 6 depends on all implementation tasks.
+- **Verification coverage:** Final verification runs the highest discovered test-suite command and includes manual checks for the user-facing contract.

--- a/extensions/agentic-harness/harness-state-service.ts
+++ b/extensions/agentic-harness/harness-state-service.ts
@@ -1,0 +1,117 @@
+import { resolve as resolvePath } from "node:path";
+import {
+  applyHarnessCommand,
+  createHarnessState,
+  type HarnessCommand,
+  type HarnessState,
+} from "./harness-state.js";
+import {
+  createHarnessReplayEvent,
+  HARNESS_STATE_EVENT_CUSTOM_TYPE,
+} from "./harness-events.js";
+import {
+  createHarnessStateSnapshot,
+  defaultHarnessStateRoot,
+  harnessStateSnapshotPath,
+  readHarnessStateSnapshot,
+  writeHarnessStateSnapshot,
+} from "./harness-storage.js";
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+const harnessStateMutationLocks = new Map<string, Promise<unknown>>();
+
+export async function withHarnessStateMutationLock<T>(
+  runId: string,
+  rootDir: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `${resolvePath(rootDir ?? defaultHarnessStateRoot())}\0${runId}`;
+  const previous = harnessStateMutationLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.catch(() => undefined).then(() => current);
+  harnessStateMutationLocks.set(key, queued);
+
+  await previous.catch(() => undefined);
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (harnessStateMutationLocks.get(key) === queued) {
+      harnessStateMutationLocks.delete(key);
+    }
+  }
+}
+
+export async function loadHarnessState(
+  runId: string,
+  rootDir?: string,
+  now?: string,
+): Promise<HarnessState> {
+  const dir = rootDir ?? defaultHarnessStateRoot();
+  const path = harnessStateSnapshotPath(dir, runId);
+  const snapshot = await readHarnessStateSnapshot(path);
+  if (snapshot) {
+    return snapshot.state;
+  }
+  return createHarnessState({ runId, title: runId, now: now || isoNow() });
+}
+
+export async function persistHarnessState(
+  state: HarnessState,
+  rootDir?: string,
+  now?: string,
+): Promise<void> {
+  const dir = rootDir ?? defaultHarnessStateRoot();
+  const path = harnessStateSnapshotPath(dir, state.runId);
+  const snapshot = createHarnessStateSnapshot(state, { now: now || isoNow() });
+  await writeHarnessStateSnapshot(path, snapshot);
+}
+
+export function emitHarnessEvent(
+  ctx: { sessionManager?: any },
+  state: HarnessState,
+  command: HarnessCommand,
+  now?: string,
+  rootDir?: string,
+): void {
+  const event = createHarnessReplayEvent(state, command, { now: now || isoNow(), rootDir });
+  ctx.sessionManager?.appendCustomEntry?.(HARNESS_STATE_EVENT_CUSTOM_TYPE, event);
+}
+
+export async function applyAndPersistFromLoadedState(
+  runId: string,
+  rootDir: string | undefined,
+  buildCommand: (state: HarnessState) => HarnessCommand,
+  ctx: { sessionManager?: any },
+): Promise<{
+  state: HarnessState;
+  event: import("./harness-state.js").HarnessStateEvent;
+}> {
+  return withHarnessStateMutationLock(runId, rootDir, async () => {
+    const state = await loadHarnessState(runId, rootDir);
+    const command = buildCommand(state);
+    const replayEvent = createHarnessReplayEvent(state, command, { rootDir });
+    const result = applyHarnessCommand(state, command);
+    await persistHarnessState(result.state, rootDir);
+    ctx.sessionManager?.appendCustomEntry?.(HARNESS_STATE_EVENT_CUSTOM_TYPE, replayEvent);
+    return result;
+  });
+}
+
+export async function applyAndPersist(
+  runId: string,
+  rootDir: string | undefined,
+  command: HarnessCommand,
+  ctx: { sessionManager?: any },
+): Promise<{
+  state: HarnessState;
+  event: import("./harness-state.js").HarnessStateEvent;
+}> {
+  return applyAndPersistFromLoadedState(runId, rootDir, () => command, ctx);
+}

--- a/extensions/agentic-harness/harness-tools.ts
+++ b/extensions/agentic-harness/harness-tools.ts
@@ -1,34 +1,32 @@
 import { Type, type TUnsafe } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
-  applyHarnessCommand,
-  createHarnessState,
+  selectPlanForMilestone,
   selectMilestoneSummary,
   selectPlanSummary,
   selectTodosForOwner,
-  type HarnessCommand,
   type HarnessMilestoneStatus,
   type HarnessPlanTaskStatus,
-  type HarnessState,
   type HarnessTodoOwnerType,
   type HarnessTodoStatus,
 } from "./harness-state.js";
 import {
-  createHarnessReplayEvent,
-  HARNESS_STATE_EVENT_CUSTOM_TYPE,
-} from "./harness-events.js";
-import {
-  createHarnessStateSnapshot,
-  defaultHarnessStateRoot,
-  harnessStateSnapshotPath,
-  readHarnessStateSnapshot,
-  writeHarnessStateSnapshot,
-} from "./harness-storage.js";
+  applyAndPersist,
+  applyAndPersistFromLoadedState,
+  loadHarnessState,
+} from "./harness-state-service.js";
 import {
   renderHarnessPlanMarkdown,
   renderHarnessStateMarkdown,
   renderHarnessTodoMarkdown,
 } from "./harness-render.js";
+import { extractHarnessReplayEventsFromSessionEntries } from "./harness-events.js";
+import {
+  parseTodoFacadeId,
+  readTodosFromHarnessState,
+  todoStatusToMilestoneStatus,
+  todoStatusToPlanTaskStatus,
+} from "./todo-facade.js";
 
 type StringEnumSchema<T extends string> = TUnsafe<T> & {
   type: "string";
@@ -44,107 +42,6 @@ function stringEnum<T extends string>(
     enum: [...values],
     ...options,
   }) as StringEnumSchema<T>;
-}
-
-function isoNow(): string {
-  return new Date().toISOString();
-}
-
-const harnessStateMutationLocks = new Map<string, Promise<unknown>>();
-
-async function withHarnessStateMutationLock<T>(
-  runId: string,
-  rootDir: string | undefined,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const key = `${rootDir ?? defaultHarnessStateRoot()}\0${runId}`;
-  const previous = harnessStateMutationLocks.get(key) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = previous.catch(() => undefined).then(() => current);
-  harnessStateMutationLocks.set(key, queued);
-
-  await previous.catch(() => undefined);
-  try {
-    return await fn();
-  } finally {
-    release();
-    if (harnessStateMutationLocks.get(key) === queued) {
-      harnessStateMutationLocks.delete(key);
-    }
-  }
-}
-
-// ---------- Shared helpers ----------
-
-async function loadHarnessState(
-  runId: string,
-  rootDir?: string,
-  now?: string,
-): Promise<HarnessState> {
-  const dir = rootDir ?? defaultHarnessStateRoot();
-  const path = harnessStateSnapshotPath(dir, runId);
-  const snapshot = await readHarnessStateSnapshot(path);
-  if (snapshot) {
-    return snapshot.state;
-  }
-  return createHarnessState({ runId, title: runId, now: now || isoNow() });
-}
-
-async function persistHarnessState(
-  state: HarnessState,
-  rootDir?: string,
-  now?: string,
-): Promise<void> {
-  const dir = rootDir ?? defaultHarnessStateRoot();
-  const path = harnessStateSnapshotPath(dir, state.runId);
-  const snapshot = createHarnessStateSnapshot(state, { now: now || isoNow() });
-  await writeHarnessStateSnapshot(path, snapshot);
-}
-
-function emitHarnessEvent(
-  ctx: { sessionManager?: any },
-  state: HarnessState,
-  command: HarnessCommand,
-  now?: string,
-  rootDir?: string,
-): void {
-  const event = createHarnessReplayEvent(state, command, { now: now || isoNow(), rootDir });
-  ctx.sessionManager?.appendCustomEntry?.(HARNESS_STATE_EVENT_CUSTOM_TYPE, event);
-}
-
-async function applyAndPersistFromLoadedState(
-  runId: string,
-  rootDir: string | undefined,
-  buildCommand: (state: HarnessState) => HarnessCommand,
-  ctx: { sessionManager?: any },
-): Promise<{
-  state: HarnessState;
-  event: import("./harness-state.js").HarnessStateEvent;
-}> {
-  return withHarnessStateMutationLock(runId, rootDir, async () => {
-    const state = await loadHarnessState(runId, rootDir);
-    const command = buildCommand(state);
-    const replayEvent = createHarnessReplayEvent(state, command, { rootDir });
-    const result = applyHarnessCommand(state, command);
-    await persistHarnessState(result.state, rootDir);
-    ctx.sessionManager?.appendCustomEntry?.(HARNESS_STATE_EVENT_CUSTOM_TYPE, replayEvent);
-    return result;
-  });
-}
-
-async function applyAndPersist(
-  runId: string,
-  rootDir: string | undefined,
-  command: HarnessCommand,
-  ctx: { sessionManager?: any },
-): Promise<{
-  state: HarnessState;
-  event: import("./harness-state.js").HarnessStateEvent;
-}> {
-  return applyAndPersistFromLoadedState(runId, rootDir, () => command, ctx);
 }
 
 // ---------- Tool: harness_milestone ----------
@@ -279,9 +176,163 @@ const HarnessTodoParams = Type.Object({
   status: Type.Optional(HarnessTodoStatusEnum),
 });
 
+// ---------- Tools: todoread / todowrite ----------
+
+const TodoFacadeStatusEnum = stringEnum(
+  ["pending", "in_progress", "completed", "failed", "cancelled"],
+  { description: "Todo status" },
+);
+
+const TodoFacadePriorityEnum = stringEnum(
+  ["high", "medium", "low"],
+  { description: "Todo priority" },
+);
+
+const TodoWriteItem = Type.Object({
+  id: Type.String({ description: "Milestone id like M1 or plan task id like M2.T3" }),
+  content: Type.String({ description: "Human-readable task or milestone label" }),
+  status: TodoFacadeStatusEnum,
+  priority: Type.Optional(TodoFacadePriorityEnum),
+});
+
+const TodoWriteParams = Type.Object({
+  runId: Type.Optional(Type.String({ description: "Harness run id. Optional when a current run can be inferred from session replay." })),
+  rootDir: Type.Optional(Type.String({ description: "Harness state root directory override" })),
+  todos: Type.Array(TodoWriteItem, { description: "Complete updated milestone/task todo list" }),
+});
+
+const TodoReadParams = Type.Object({
+  runId: Type.Optional(Type.String({ description: "Harness run id. Optional when a current run can be inferred from session replay." })),
+  rootDir: Type.Optional(Type.String({ description: "Harness state root directory override" })),
+});
+
+function resolveRunIdentityFromParamsOrSession(
+  params: { runId?: string; rootDir?: string },
+  ctx: { cwd?: string; sessionManager?: any },
+): { runId: string; rootDir?: string } {
+  if (params.runId) return { runId: params.runId, rootDir: params.rootDir };
+
+  const branch = ctx.sessionManager?.getBranch?.() ?? [];
+  const events = extractHarnessReplayEventsFromSessionEntries(branch);
+  const latest = events.at(-1);
+  if (latest?.runId) {
+    return {
+      runId: latest.runId,
+      rootDir: params.rootDir ?? latest.rootDir,
+    };
+  }
+
+  throw new Error("runId is required because no active harness run could be inferred from this session");
+}
+
 // ---------- Registration ----------
 
 export function registerHarnessTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "todoread",
+    label: "TodoRead",
+    description: "Read current milestone and plan-task progress from roach-pi structured harness state.",
+    promptSnippet: "Read current milestone/task todo progress",
+    promptGuidelines: [
+      "Use todoread before updating or reporting plan/milestone progress.",
+      "IDs like M1 and M2 refer to milestones. IDs like M2.T1 refer to plan tasks inside that milestone.",
+      "Use todowrite to persist progress updates. Do not edit markdown checkboxes as progress state.",
+    ],
+    parameters: TodoReadParams,
+    execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+      try {
+        const identity = resolveRunIdentityFromParamsOrSession(params, ctx);
+        const state = await loadHarnessState(identity.runId, identity.rootDir);
+        const result = readTodosFromHarnessState(state, { rootDir: identity.rootDir });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          details: undefined,
+          isError: true,
+        };
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "todowrite",
+    label: "TodoWrite",
+    description: "Persist milestone and plan-task progress into roach-pi structured harness state.",
+    promptSnippet: "Update current milestone/task todo progress",
+    promptGuidelines: [
+      "Call todoread first, then write back the complete updated milestone/task todo list.",
+      "Use milestone IDs like M1 and task IDs like M1.T1.",
+      "Priority is accepted for compatibility but structured progress persists only status.",
+    ],
+    parameters: TodoWriteParams,
+    execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
+      try {
+        const identity = resolveRunIdentityFromParamsOrSession(params, ctx);
+
+        for (let index = 0; index < params.todos.length; index += 1) {
+          await applyAndPersistFromLoadedState(
+            identity.runId,
+            identity.rootDir,
+            (current) => {
+              const item = params.todos[index];
+              const parsed = parseTodoFacadeId(item.id);
+              if (parsed.kind === "milestone") {
+                if (!current.milestones.some((m) => m.id === parsed.milestoneId)) {
+                  throw new Error(`Milestone ${parsed.milestoneId} not found`);
+                }
+                return {
+                  type: "set_milestone_status",
+                  id: parsed.milestoneId,
+                  status: todoStatusToMilestoneStatus(item.status),
+                };
+              }
+              if (parsed.kind === "plan_task") {
+                const milestone = current.milestones.find((m) => m.id === parsed.milestoneId);
+                if (!milestone) throw new Error(`Milestone ${parsed.milestoneId} not found`);
+                const plan = selectPlanForMilestone(current, milestone);
+                if (!plan) throw new Error(`No active plan found for milestone ${parsed.milestoneId}`);
+                if (!plan.tasks.some((task) => task.id === parsed.taskId)) {
+                  throw new Error(`Task ${item.id} not found`);
+                }
+                const status = todoStatusToPlanTaskStatus(item.status);
+                const at = new Date().toISOString();
+                return {
+                  type: "set_plan_task_status",
+                  planId: plan.id,
+                  taskId: parsed.taskId,
+                  status,
+                  startedAt: status === "running" ? at : undefined,
+                  completedAt: status === "completed" || status === "failed" || status === "skipped" ? at : undefined,
+                };
+              }
+              throw new Error(`Unsupported todo id ${item.id}; expected M1 or M1.T1`);
+            },
+            ctx,
+          );
+        }
+
+        const finalState = await loadHarnessState(identity.runId, identity.rootDir);
+        const result = readTodosFromHarnessState(finalState, { rootDir: identity.rootDir });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          details: undefined,
+          isError: true,
+        };
+      }
+    },
+  });
+
   pi.registerTool({
     name: "harness_milestone",
     label: "Harness Milestone",
@@ -412,15 +463,7 @@ export function registerHarnessTools(pi: ExtensionAPI): void {
     name: "harness_plan",
     label: "Harness Plan",
     description:
-      "Attach plans, define tasks, set task status, or load/render harness plans through structured state. Prefer this tool over hand-editing plan markdown files.",
-    promptSnippet: "Update harness plan state",
-    promptGuidelines: [
-      "Use harness_plan to attach plans to milestones, define tasks, or update task progress.",
-      "Always provide runId. Use attach to create or update a plan, define_tasks to set the task list.",
-      "Use set_task_status to mark tasks running, completed, failed, etc.",
-      "Use load to get structured JSON summary, render to get markdown output.",
-      "Prefer this tool over editing plan markdown files directly.",
-    ],
+      "Compatibility tool for structured harness plan state. Prefer todoread/todowrite for normal agent-facing progress updates.",
     parameters: HarnessPlanParams,
     execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
       const {
@@ -567,15 +610,7 @@ export function registerHarnessTools(pi: ExtensionAPI): void {
     name: "harness_todo",
     label: "Harness Todo",
     description:
-      "Set, update, clear, load, or render harness todos through structured state. Prefer this tool over hand-editing todo markdown files.",
-    promptSnippet: "Update harness todo state",
-    promptGuidelines: [
-      "Use harness_todo to manage todos for milestones, plans, or plan tasks.",
-      "Always provide runId. Use set to replace all todos for an owner, update_status to toggle a single todo.",
-      "Use clear to remove all todos for an owner.",
-      "Use load to get structured JSON, render to get markdown output.",
-      "Prefer this tool over editing todo.md files directly.",
-    ],
+      "Compatibility tool for structured harness todo state. Prefer todoread/todowrite for normal agent-facing progress updates.",
     parameters: HarnessTodoParams,
     execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
       const { runId, action, rootDir, ownerType, ownerId, todos, todoId, status } = params;

--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -64,6 +64,7 @@ import { renderWebfetchCall, renderWebfetchResult } from "./webfetch/render.js";
 import { registerHarnessTools } from "./harness-tools.js";
 import { HarnessProgressProvider } from "./harness-progress.js";
 import { applyStructuredPlanTaskStatusUpdates, selectStructuredPlanForPaths } from "./harness-runtime-progress.js";
+import { withHarnessStateMutationLock } from "./harness-state-service.js";
 import { getDefaultApprovalStore } from "./sandbox/approval-store.js";
 import { parseSandboxApprovalMode } from "./sandbox/approval-mode.js";
 import { createSandboxedBashOperations } from "./sandbox/bash-operations.js";
@@ -178,33 +179,12 @@ const planTaskIdsByToolCallId = new Map<string, number[]>();
 const sessionPlanPaths = new Set<string>();
 let workingVisibility: WorkingVisibilityController | null = null;
 let harnessProgress: HarnessProgressProvider | null = null;
-const structuredTaskStatusLocks = new Map<string, Promise<void>>();
-
 function extractExplicitPlanTaskIdsFromArgs(args: unknown): number[] {
   return [...new Set(subagentItemRecords(args)
     .filter((item) => item.agent === "plan-compliance" || item.agent === "plan-worker" || item.agent === "plan-validator")
     .map((item) => item.planTaskId)
     .filter((planTaskId): planTaskId is number => typeof planTaskId === "number" && Number.isInteger(planTaskId))
   )];
-}
-
-async function withStructuredTaskStatusLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  const previous = structuredTaskStatusLocks.get(key) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const chained = previous.then(() => current, () => current);
-  structuredTaskStatusLocks.set(key, chained);
-  await previous.catch(() => undefined);
-  try {
-    return await fn();
-  } finally {
-    release();
-    if (structuredTaskStatusLocks.get(key) === chained) {
-      structuredTaskStatusLocks.delete(key);
-    }
-  }
 }
 
 type StringEnumSchema<T extends string> = TUnsafe<T> & {
@@ -218,6 +198,20 @@ function stringEnum<T extends string>(values: readonly T[], options: { descripti
     enum: [...values],
     ...options,
   }) as StringEnumSchema<T>;
+}
+
+function preferTodoSurfaceTools(pi: any): void {
+  try {
+    if (typeof pi.getActiveTools !== "function" || typeof pi.setActiveTools !== "function") {
+      return;
+    }
+    const active = pi.getActiveTools();
+    if (!Array.isArray(active)) return;
+    pi.setActiveTools(active.filter((name: string) => name !== "harness_plan" && name !== "harness_todo"));
+  } catch {
+    // Ignore "Extension runtime not initialized" errors during early loading.
+    // Will be retried on session_start.
+  }
 }
 
 export default function (pi: ExtensionAPI) {
@@ -325,56 +319,56 @@ export default function (pi: ExtensionAPI) {
   // non-interactively and have no user at the other end.
   if (isRootSession) {
     pi.registerTool({
-      name: "ask_user_question",
-      label: "Ask User Question",
-      description:
-        "Ask the user a question when the agent needs clarification. The agent composes the question and optional choices dynamically. Returns the user's answer as text.",
-      promptSnippet:
-        "Ask the user a clarifying question with optional multiple-choice answers",
-      promptGuidelines: [
-        "Use ask_user_question whenever you encounter ambiguity, unclear scope, or need user preference.",
-        "Generate the question and choices yourself based on the current context — do not rely on predefined templates.",
-        "Offer concrete choices (A/B/C style) when the options are enumerable. Omit choices for open-ended questions.",
-        "Ask one focused question at a time. Do not bundle multiple questions.",
-        "After receiving an answer, decide whether further clarification is needed or proceed with the task.",
-      ],
-      parameters: AskUserQuestionParams,
-      execute: async (toolCallId, params, signal, onUpdate, ctx) => {
-        const { question, choices, placeholder, defaultValue } = params;
+        name: "ask_user_question",
+        label: "Ask User Question",
+        description:
+          "Ask the user a question when the agent needs clarification. The agent composes the question and optional choices dynamically. Returns the user's answer as text.",
+        promptSnippet:
+          "Ask the user a clarifying question with optional multiple-choice answers",
+        promptGuidelines: [
+          "Use ask_user_question whenever you encounter ambiguity, unclear scope, or need user preference.",
+          "Generate the question and choices yourself based on the current context — do not rely on predefined templates.",
+          "Offer concrete choices (A/B/C style) when the options are enumerable. Omit choices for open-ended questions.",
+          "Ask one focused question at a time. Do not bundle multiple questions.",
+          "After receiving an answer, decide whether further clarification is needed or proceed with the task.",
+        ],
+        parameters: AskUserQuestionParams,
+        execute: async (toolCallId, params, signal, onUpdate, ctx) => {
+          const { question, choices, placeholder, defaultValue } = params;
 
-        let answer: string | undefined;
+          let answer: string | undefined;
 
-        if (choices && choices.length > 0) {
-          const withDirect = choices.includes(DIRECT_INPUT_OPTION)
-            ? choices
-            : [...choices, DIRECT_INPUT_OPTION];
+          if (choices && choices.length > 0) {
+            const withDirect = choices.includes(DIRECT_INPUT_OPTION)
+              ? choices
+              : [...choices, DIRECT_INPUT_OPTION];
 
-          answer = await ctx.ui.select(question, withDirect, { signal });
+            answer = await ctx.ui.select(question, withDirect, { signal });
 
-          if (answer === DIRECT_INPUT_OPTION) {
+            if (answer === DIRECT_INPUT_OPTION) {
+              answer = await ctx.ui.input(question, placeholder || defaultValue, {
+                signal,
+              });
+            }
+          } else {
             answer = await ctx.ui.input(question, placeholder || defaultValue, {
               signal,
             });
           }
-        } else {
-          answer = await ctx.ui.input(question, placeholder || defaultValue, {
-            signal,
-          });
-        }
 
-        if (answer === undefined) {
+          if (answer === undefined) {
+            return {
+              content: [{ type: "text", text: "User cancelled the question." }],
+              details: undefined,
+            };
+          }
+
           return {
-            content: [{ type: "text", text: "User cancelled the question." }],
+            content: [{ type: "text", text: answer }],
             details: undefined,
           };
-        }
-
-        return {
-          content: [{ type: "text", text: answer }],
-          details: undefined,
-        };
-      },
-    });
+        },
+      });
   }
 
   const HEARTBEAT_MS = 1000;
@@ -544,19 +538,19 @@ export default function (pi: ExtensionAPI) {
 
   if (isRootSession && !isTeamWorker && isTeamModeEnabled) {
     pi.registerTool({
-      name: "team",
-      label: "Team",
-      description: "Run a lightweight native team over existing pi subagents with structured task synthesis.",
-      promptSnippet: "Coordinate a small team of bounded pi worker agents",
-      promptGuidelines: [
-        "Use team for coordinated multi-agent execution when a goal can be split into independent bounded tasks.",
-        "Prefer small worker counts for the MVP; max parallel tasks is 12 with 10 concurrent.",
-        "Workers must not recursively orchestrate or spawn subagents.",
-        "Use subagent directly for simple one-off parallel dispatch without team synthesis.",
-      ],
-      parameters: TeamParams,
-      renderCall: (args, theme) => renderCall(args, theme),
-      renderResult: (result, { expanded }, theme) => renderResult(result, expanded, theme),
+        name: "team",
+        label: "Team",
+        description: "Run a lightweight native team over existing pi subagents with structured task synthesis.",
+        promptSnippet: "Coordinate a small team of bounded pi worker agents",
+        promptGuidelines: [
+          "Use team for coordinated multi-agent execution when a goal can be split into independent bounded tasks.",
+          "Prefer small worker counts for the MVP; max parallel tasks is 12 with 10 concurrent.",
+          "Workers must not recursively orchestrate or spawn subagents.",
+          "Use subagent directly for simple one-off parallel dispatch without team synthesis.",
+        ],
+        parameters: TeamParams,
+        renderCall: (args, theme) => renderCall(args, theme),
+        renderResult: (result, { expanded }, theme) => renderResult(result, expanded, theme),
       execute: async (_toolCallId, params, signal, onUpdate, ctx) => {
         const { goal, workerCount, agent, agentScope, worktree, worktreePolicy, backend, maxOutput, runId, resumeRunId, resumeMode, staleTaskMs, commandTarget, commandMessage } = params as TeamToolParams;
         const defaultCwd = ctx.cwd;
@@ -1213,6 +1207,8 @@ export default function (pi: ExtensionAPI) {
   });
 
   registerHarnessTools(pi);
+  // Try now (may fail if runtime not initialized — caught and retried on session_start)
+  preferTodoSurfaceTools(pi);
 
   pi.on("session_shutdown", async (_event, _ctx) => {
     workingVisibility?.restore();
@@ -2049,7 +2045,7 @@ Do not start multi-step implementation without a clear understanding of what the
     const rootDir = latestEvent?.rootDir ?? harnessProgress?.getRunIdentity().rootDir ?? defaultHarnessStateRoot(ctx.cwd);
     if (!runId) return;
 
-    await withStructuredTaskStatusLock(`${rootDir}\u0000${runId}`, async () => {
+    await withHarnessStateMutationLock(runId, rootDir, async () => {
       const snapshotPath = harnessStateSnapshotPath(rootDir, runId);
       const snapshot = await readHarnessStateSnapshot(snapshotPath);
       if (!snapshot) return;
@@ -2180,6 +2176,7 @@ Do not start multi-step implementation without a clear understanding of what the
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    preferTodoSurfaceTools(pi);
     currentPhase = "idle";
     activeGoalDocument = null;
     clarificationDone = false;

--- a/extensions/agentic-harness/skills/agentic-long-run/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-long-run/SKILL.md
@@ -14,13 +14,13 @@ Long-running execution must be **resumable, auditable, and fail-safe.** Every st
 ## Hard Gates
 
 1. **Milestones must exist before execution.** Either from `agentic-milestone-planning` skill or user-provided. Never generate milestones inline during execution.
-2. **Canonical structured state must be updated before and after every milestone.** Use `harness_milestone`, `harness_plan`, and `harness_todo`; rendered markdown is audit output only. If it is not in structured state, it didn't happen.
+2. **Canonical structured state must be updated before and after every milestone.** Use `harness_milestone` for milestone creation, dependency metadata, attempts, plan files, review files, and milestone lifecycle. Use `todoread` and `todowrite` for normal milestone/task progress updates visible to the agent. Rendered markdown is audit output only. If it is not in structured state, it didn't happen.
 3. **Each milestone must complete the full pipeline.** agentic-plan-crafting → agentic-run-plan → agentic-review-work. No shortcuts. No skipping agentic-review-work "because it looked fine."
 4. **Failed milestones block dependents.** If M2 depends on M1 and M1 fails review, M2 does not start. Period.
 5. **User confirmation required at gate points.** Before starting a new milestone phase (planning, execution, review), check if the user wants to continue, pause, or abort.
 6. **Never modify completed milestones.** Once a milestone passes agentic-review-work, its files are locked. If a later milestone needs changes to earlier work, that is a new milestone.
 7. **Checkpoint after every milestone completion.** Write a checkpoint file recording what was done, test results, and review verdict before proceeding.
-8. **Do not execute plan tasks directly as the main agent.** In long-run mode, the main agent is an orchestrator only. Plan task implementation must go through `agentic-run-plan` / worker-validator flow, and structured task progress must be persisted with `harness_plan set_task_status`.
+8. **Do not execute plan tasks directly as the main agent.** In long-run mode, the main agent is an orchestrator only. Plan task implementation must go through `agentic-run-plan` / worker-validator flow, and structured task progress must be persisted with `todoread` and `todowrite`.
 
 ## When To Use
 
@@ -37,7 +37,7 @@ Long-running execution must be **resumable, auditable, and fail-safe.** Every st
 ## Input
 
 1. **Structured harness run identity** — `runId` plus optional `rootDir`/`PI_HARNESS_STATE_ROOT`.
-2. Canonical state is loaded with `harness_milestone load` and `harness_plan load`; `state.md`, milestone markdown, and checkpoint markdown are rendered/audit artifacts only.
+2. Canonical milestone metadata is loaded with `harness_milestone load`; normal milestone/task progress is loaded with `todoread`. `state.md`, milestone markdown, and checkpoint markdown are rendered/audit artifacts only.
 
 If no structured milestone state exists, ask the user if they want to run `agentic-milestone-planning` first.
 
@@ -46,7 +46,7 @@ If no structured milestone state exists, ask the user if they want to run `agent
 ### Phase 1: Load and Validate State
 
 1. Load canonical milestone state with `harness_milestone load` using the run's `runId` and `rootDir`.
-2. For every milestone that has a `planFile`/plan id, load canonical task state with `harness_plan load`; do not infer task status from markdown checkboxes.
+2. For every milestone that has a `planFile`/plan id, call `todoread` to load canonical milestone/task progress; do not infer task status from markdown checkboxes.
 3. Validate:
    - All milestone dependencies in structured state form a valid DAG (no cycles, topological sort possible)
    - No milestone is in an invalid state (e.g., `executing` without an attached structured plan)
@@ -123,15 +123,15 @@ Before starting a milestone:
    - Create a plan document at `docs/engineering-discipline/plans/YYYY-MM-DD-<milestone-name>.md`
    - The plan must satisfy all milestone success criteria
    - The plan must not modify files outside the milestone's scope
-3. Prepare to record the plan file path in canonical structured state after user approval
+3. Prepare to record the plan file path in canonical milestone state after user approval
 4. **User gate:** Present the plan and ask for approval before execution
-5. After approval, attach the plan to the milestone via `harness_plan`:
+5. After approval, attach the plan file path to the milestone via `harness_milestone`:
    ```json
-   { "runId": "<run-id>", "action": "attach", "planId": "<plan-id>", "milestoneId": "M1", "title": "...", "goal": "...", "planFile": "docs/.../plan.md" }
+   { "runId": "<run-id>", "action": "update", "id": "M1", "planFile": "docs/.../plan.md" }
    ```
-6. Define every task from the approved plan via `harness_plan define_tasks` before execution begins:
+6. Initialize normal task progress from the approved plan via `todowrite` before execution begins:
    ```json
-   { "runId": "<run-id>", "action": "define_tasks", "planId": "<plan-id>", "tasks": [{ "id": 1, "name": "...", "status": "pending" }] }
+   { "items": [{ "id": "1", "content": "...", "status": "pending" }] }
    ```
 
 #### Step 2-3: Run Plan Phase
@@ -142,7 +142,7 @@ Before starting a milestone:
    - Parallel execution for independent tasks
    - Information-isolated validators
    - The main agent must not edit/write/bash implementation files directly for plan tasks
-   - After every task PASS/FAIL, persist structured status with `harness_plan set_task_status`
+   - After every task PASS/FAIL, persist structured progress with `todoread` and `todowrite`
 3. If agentic-run-plan reports failure after 3 retries on any task:
    - Update canonical structured state via `harness_milestone set_status`: set milestone status to `failed`
    - Record failure details in execution log
@@ -308,7 +308,7 @@ After all milestones are completed (including the Integration Verification Miles
 
 When resuming a paused or interrupted session:
 
-1. Use `harness_milestone load` and `harness_plan load` to determine last known canonical state
+1. Use `harness_milestone load` for milestone lifecycle metadata and `todoread` for normal milestone/task progress.
 2. For each milestone, determine recovery action:
 
 | Last Status | Recovery Action |
@@ -321,7 +321,7 @@ When resuming a paused or interrupted session:
 | `failed` | Present failure to user; ask whether to retry or skip (see Skip Rules below) |
 | `skipped` | Skip (user previously chose to skip this milestone) |
 
-3. For `executing` milestones: use `harness_plan load` to find the first task whose structured status is not `completed`; do not use markdown checkboxes for recovery.
+3. For executing milestones, call `todoread` and continue from the first item whose status is not `completed` or `cancelled`. Do not infer task status from markdown checkboxes.
 4. Read the structured milestone `attempts` counter to determine retry budget remaining. Do not reset the counter on resume — it persists across crashes to prevent infinite retry loops.
 5. Present recovery plan to user before proceeding.
 
@@ -360,13 +360,13 @@ If a single milestone's total active time (from planning start to review complet
 
 ## Structured State vs Markdown
 
-`state.md`, milestone markdown files, and plan markdown files are rendered views of the canonical structured state stored in `state.json`. Agents must update progress through `harness_milestone`, `harness_plan`, and `harness_todo` tools. Editing markdown files directly bypasses the structured state and will be overwritten on the next render.
+`state.md`, milestone markdown files, and plan markdown files are rendered views of the canonical structured state stored in `state.json`. Use `harness_milestone` for milestone creation, dependency metadata, attempts, plan files, review files, and milestone lifecycle. Use `todoread` and `todowrite` for normal milestone/task progress updates visible to the agent. Editing markdown files directly bypasses the structured state and will be overwritten on the next render.
 
 ## Context Window Management
 
 Long-running sessions will hit context window limits. Pi automatically compresses old messages (context compaction). The harness must be designed to survive this:
 
-1. **Never rely on conversation memory for state.** Canonical state lives in structured harness state (`state.json` plus replay events). If the context is compressed, reload with `harness_milestone load` and `harness_plan load` — no information is lost.
+1. **Never rely on conversation memory for state.** Canonical state lives in structured harness state (`state.json` plus replay events). If the context is compressed, reload milestone metadata with `harness_milestone load` and progress with `todoread` — no information is lost.
 2. **Each milestone is a fresh context boundary.** When starting a new milestone's agentic-plan-crafting, the worker subagent starts with a clean context. It receives only the milestone definition and completed predecessor context (see F8 contract) — not the full conversation history.
 3. **Checkpoint files are audit artifacts, not canonical state.** If context is lost mid-milestone, recovery reads structured state first and checkpoint files only for summarized predecessor context.
 4. **Avoid accumulating large inline state.** Do not build up a running summary of all milestones in the conversation. Instead, reference structured harness state and rendered audit artifacts by path.

--- a/extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-milestone-planning/SKILL.md
@@ -447,6 +447,8 @@ Attempts: number of plan-execute-review cycles attempted (incremented at each St
 { "runId": "<run-id>", "action": "create", "id": "M1", "name": "Milestone Name", "status": "pending", "dependencies": [] }
 ```
 
+This initialization records milestone metadata. Normal milestone/task progress during execution is read with `todoread` and updated with `todowrite`.
+
 **Individual milestone file (M1-<name>.md) format:**
 
 ```markdown

--- a/extensions/agentic-harness/skills/agentic-plan-crafting/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-plan-crafting/SKILL.md
@@ -60,7 +60,7 @@ docs/engineering-discipline/plans/YYYY-MM-DD-<feature-name>.md
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **Worker note:** Execute this plan task-by-task using the agentic-run-plan skill or subagents. Checkbox (`- [ ]`) syntax is rendered task formatting only; canonical progress is stored with `harness_plan define_tasks` and `harness_plan set_task_status`.
+> **Worker note:** Execute this plan task-by-task using the agentic-run-plan skill or subagents. Checkbox syntax is rendered task formatting only; canonical progress is read with `todoread` and updated with `todowrite`.
 
 **Goal:** [One sentence describing what this plan builds]
 
@@ -262,9 +262,14 @@ Expected: No regressions — all pre-existing tests still pass
 
 **If the final verification fails**, the plan is not complete. The worker-validator loop in `agentic-run-plan` will handle failure response (see agentic-run-plan's E2E Failure Response Protocol).
 
-After all tasks complete, update the plan's final status through `harness_plan` rather than editing markdown checkboxes:
+After all tasks complete, update final task progress through `todowrite` rather than editing markdown checkboxes:
 ```json
-{ "runId": "<run-id>", "action": "set_task_status", "planId": "<plan-id>", "taskId": 1, "status": "completed" }
+{
+  "todos": [
+    { "id": "M1", "content": "Plan milestone", "status": "completed" },
+    { "id": "M1.T1", "content": "Task 1", "status": "completed" }
+  ]
+}
 ```
 
 ## No Placeholders

--- a/extensions/agentic-harness/skills/agentic-review-work/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-review-work/SKILL.md
@@ -211,6 +211,8 @@ After review is complete, update the milestone status through `harness_milestone
 { "runId": "<run-id>", "action": "set_status", "id": "M1", "status": "completed" }
 ```
 
+If review completion corresponds to a plan task, update that task through `todowrite` rather than `harness_plan`.
+
 - **PASS** → Report results to the user and suggest next steps (PR creation, deployment, etc.)
 - **FAIL** → Report failure items to the user. If fixes are needed, suggest transitioning to the `agentic-run-plan` or `agentic-systematic-debugging` skill
 - If the plan itself has issues → suggest returning to the `agentic-plan-crafting` skill to revise the plan

--- a/extensions/agentic-harness/skills/agentic-run-plan/SKILL.md
+++ b/extensions/agentic-harness/skills/agentic-run-plan/SKILL.md
@@ -187,18 +187,19 @@ Report your verdict as PASS or FAIL.
 
 **2-4. Task Status Update (MANDATORY)**
 
-After the validator passes, you **MUST** update the structured plan state via `harness_plan`. Do not skip this step — it is what drives the footer progress display and session restore.
+After the validator passes, you **MUST** update structured progress via `todowrite`. First call `todoread`, then write back the complete list with the relevant `M#.T#` item marked `completed`.
 
 ```json
-{ "runId": "<run-id>", "action": "set_task_status", "planId": "<plan-id>", "taskId": 1, "status": "completed" }
+{
+  "todos": [
+    { "id": "M1", "content": "Foundation", "status": "in_progress" },
+    { "id": "M1.T1", "content": "Create shared service", "status": "completed" },
+    { "id": "M1.T2", "content": "Register todowrite", "status": "pending" }
+  ]
+}
 ```
 
-For failed tasks:
-```json
-{ "runId": "<run-id>", "action": "set_task_status", "planId": "<plan-id>", "taskId": 1, "status": "failed" }
-```
-
-If you do not have a `runId`, use `harness_milestone load` or `harness_plan load` to discover the current state.
+For failed tasks, follow the same pattern with the relevant `M#.T#` item marked `failed`. If you do not have a `runId`, call `todoread` first and use the active run inferred from the session.
 
 **Retry limit:** If the same task fails 3 consecutive times, report the situation to the user and request intervention.
 
@@ -222,11 +223,16 @@ Sequential execution required for:
 
 ### Structured Plan State Updates
 
-When executing a plan through the harness, prefer updating plan progress via the `harness_plan` tool rather than editing plan markdown files directly.
+When executing a plan through the harness, update normal task progress via `todoread` and `todowrite` rather than editing plan markdown files directly.
 
 **After completing a task:**
 ```json
-{ "runId": "<run-id>", "action": "set_task_status", "planId": "<plan-id>", "taskId": 1, "status": "completed" }
+{
+  "todos": [
+    { "id": "M1", "content": "Foundation", "status": "in_progress" },
+    { "id": "M1.T1", "content": "Task 1", "status": "completed" }
+  ]
+}
 ```
 
 **When the plan is first loaded:**

--- a/extensions/agentic-harness/tests/dual-lock-race.test.ts
+++ b/extensions/agentic-harness/tests/dual-lock-race.test.ts
@@ -1,0 +1,199 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyAndPersistFromLoadedState, withHarnessStateMutationLock } from "../harness-state-service.js";
+import {
+  createHarnessStateSnapshot,
+  harnessStateSnapshotPath,
+  readHarnessStateSnapshot,
+  writeHarnessStateSnapshot,
+} from "../harness-storage.js";
+import { createHarnessState } from "../harness-state.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "dual-lock-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * H1 Regression Test: Dual lock registry race condition
+ *
+ * Background (BEFORE fix):
+ *   - `harness-state-service.ts` used `harnessStateMutationLocks` (Map A)
+ *   - `index.ts` `persistStructuredSubagentTaskStatuses` used `structuredTaskStatusLocks` (Map B)
+ *   - Both protected the same state.json file, but they were independent locks.
+ *   - A todowrite call (Map A) and a subagent lifecycle update (Map B) could
+ *     read-modify-write the same file concurrently, causing a lost update.
+ *
+ * Fix:
+ *   - `persistStructuredSubagentTaskStatuses` now uses `withHarnessStateMutationLock`
+ *     (the shared lock from harness-state-service.ts), so all state mutations
+ *     on the same run are serialized through one lock Map.
+ *   - Lock keys are canonicalized via `path.resolve()` to prevent path aliasing.
+ *
+ * These tests verify the fix: both the service path (todowrite) and the raw
+ * path (simulating subagent lifecycle) use the SAME shared lock. Both changes
+ * must be preserved because the shared lock serializes them.
+ */
+describe("H1: dual lock registry race condition (regression)", () => {
+  it("preserves both changes when service path and subagent path run concurrently", async () => {
+    const rootDir = await makeTempDir();
+    const runId = "race-test";
+    const ctx = { sessionManager: { appendCustomEntry: () => {} } };
+
+    // Setup: initial state with M1=pending and M2=pending
+    const initialState = createHarnessState({ runId, title: runId });
+    initialState.milestones.push(
+      {
+        id: "M1",
+        name: "Milestone 1",
+        status: "pending",
+        dependencies: [],
+        attempts: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        id: "M2",
+        name: "Milestone 2",
+        status: "pending",
+        dependencies: [],
+        attempts: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    );
+    const snapshotPath = harnessStateSnapshotPath(rootDir, runId);
+    await writeHarnessStateSnapshot(snapshotPath, createHarnessStateSnapshot(initialState));
+
+    // --- Service path (todowrite / applyAndPersistFromLoadedState) ---
+    // Uses withHarnessStateMutationLock in harness-state-service.ts
+    // Changes M1: pending → executing
+    const servicePath = async () => {
+      await applyAndPersistFromLoadedState(runId, rootDir, () => ({
+        type: "set_milestone_status" as const,
+        id: "M1",
+        status: "executing" as const,
+      }), ctx);
+    };
+
+    // --- Subagent lifecycle path (simulates persistStructuredSubagentTaskStatuses) ---
+    // AFTER fix: uses withHarnessStateMutationLock — the SAME shared lock as the service path.
+    // This is the exact same read-modify-write pattern, now wrapped in the shared lock.
+    // Changes M2: pending → completed
+    const subagentPath = async () => {
+      await withHarnessStateMutationLock(runId, rootDir, async () => {
+        const snapshot = await readHarnessStateSnapshot(snapshotPath);
+        if (!snapshot) throw new Error("snapshot should exist");
+
+        const modifiedState = { ...snapshot.state };
+        modifiedState.milestones = modifiedState.milestones.map((m) =>
+          m.id === "M2" ? { ...m, status: "completed" as const, updatedAt: new Date().toISOString() } : m,
+        );
+        await writeHarnessStateSnapshot(
+          snapshotPath,
+          createHarnessStateSnapshot(modifiedState),
+        );
+      });
+    };
+
+    // Run both paths concurrently — same as todowrite + subagent lifecycle
+    // happening at the same time on the same run.
+    await Promise.all([servicePath(), subagentPath()]);
+
+    // Verify: BOTH changes must be preserved
+    const finalSnapshot = await readHarnessStateSnapshot(snapshotPath);
+    expect(finalSnapshot).toBeTruthy();
+
+    const m1 = finalSnapshot!.state.milestones.find((m) => m.id === "M1");
+    const m2 = finalSnapshot!.state.milestones.find((m) => m.id === "M2");
+
+    // With the shared lock, both changes are serialized and preserved.
+    expect(m1?.status, "M1 should be 'executing' (service path change lost!)").toBe("executing");
+    expect(m2?.status, "M2 should be 'completed' (subagent path change lost!)").toBe("completed");
+  });
+
+  it("preserves both changes across 10 concurrent iterations", async () => {
+    const rootDir = await makeTempDir();
+    const runId = "race-multi";
+    const ctx = { sessionManager: { appendCustomEntry: () => {} } };
+
+    const snapshotPath = harnessStateSnapshotPath(rootDir, runId);
+    let lostUpdateCount = 0;
+
+    for (let iteration = 0; iteration < 10; iteration++) {
+      // Reset state before each iteration
+      const resetState = createHarnessState({ runId, title: runId });
+      for (let i = 1; i <= 5; i++) {
+        resetState.milestones.push({
+          id: `M${i}`,
+          name: `Milestone ${i}`,
+          status: "pending",
+          dependencies: [],
+          attempts: 0,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      await writeHarnessStateSnapshot(snapshotPath, createHarnessStateSnapshot(resetState));
+
+      // Service path: M1 → executing, M3 → validating
+      const servicePath = async () => {
+        await applyAndPersistFromLoadedState(runId, rootDir, () => ({
+          type: "set_milestone_status" as const,
+          id: "M1",
+          status: "executing" as const,
+        }), ctx);
+        await applyAndPersistFromLoadedState(runId, rootDir, () => ({
+          type: "set_milestone_status" as const,
+          id: "M3",
+          status: "validating" as const,
+        }), ctx);
+      };
+
+      // Subagent lifecycle path: M2 → completed, M4 → failed
+      // AFTER fix: uses withHarnessStateMutationLock (same shared lock)
+      const subagentPath = async () => {
+        await withHarnessStateMutationLock(runId, rootDir, async () => {
+          const snapshot = await readHarnessStateSnapshot(snapshotPath);
+          if (!snapshot) return;
+          let modifiedState = { ...snapshot.state };
+          modifiedState.milestones = modifiedState.milestones.map((m) => {
+            if (m.id === "M2") return { ...m, status: "completed" as const };
+            if (m.id === "M4") return { ...m, status: "failed" as const };
+            return m;
+          });
+          await writeHarnessStateSnapshot(snapshotPath, createHarnessStateSnapshot(modifiedState));
+        });
+      };
+
+      await Promise.all([servicePath(), subagentPath()]);
+
+      const finalSnapshot = await readHarnessStateSnapshot(snapshotPath);
+      const milestones = finalSnapshot!.state.milestones;
+
+      const m1 = milestones.find((m) => m.id === "M1")!;
+      const m2 = milestones.find((m) => m.id === "M2")!;
+      const m3 = milestones.find((m) => m.id === "M3")!;
+      const m4 = milestones.find((m) => m.id === "M4")!;
+
+      const serviceChangesLost = m1.status !== "executing" || m3.status !== "validating";
+      const subagentChangesLost = m2.status !== "completed" || m4.status !== "failed";
+
+      if (serviceChangesLost || subagentChangesLost) {
+        lostUpdateCount++;
+      }
+    }
+
+    // With a shared lock, lost updates should NEVER happen.
+    expect(lostUpdateCount, `${lostUpdateCount}/10 iterations had lost updates (expected 0 with shared lock)`).toBe(0);
+  });
+});

--- a/extensions/agentic-harness/tests/extension.test.ts
+++ b/extensions/agentic-harness/tests/extension.test.ts
@@ -1061,13 +1061,70 @@ describe("webfetch Tool", () => {
 });;
 
 describe("Harness Tools", () => {
-  it("should register harness_milestone, harness_plan, and harness_todo", () => {
+  it("should register todoread, todowrite, harness_milestone, harness_plan, and harness_todo", () => {
     const { mockPi, tools } = createMockPi();
     extension(mockPi);
 
+    expect(tools.get("todoread")).toBeDefined();
+    expect(tools.get("todowrite")).toBeDefined();
     expect(tools.get("harness_milestone")).toBeDefined();
     expect(tools.get("harness_plan")).toBeDefined();
     expect(tools.get("harness_todo")).toBeDefined();
+    expect(tools.get("harness_plan")!.promptSnippet).toBeUndefined();
+    expect(tools.get("harness_plan")!.promptGuidelines).toBeUndefined();
+    expect(tools.get("harness_todo")!.promptSnippet).toBeUndefined();
+    expect(tools.get("harness_todo")!.promptGuidelines).toBeUndefined();
+    expect(tools.get("todoread")!.promptGuidelines.length).toBeGreaterThan(0);
+    expect(tools.get("todowrite")!.promptGuidelines.length).toBeGreaterThan(0);
+  });
+
+  it("should prefer todoread and todowrite in active tools", () => {
+    const { mockPi } = createMockPi();
+    const activeTools = ["todoread", "todowrite", "harness_plan", "harness_todo", "harness_milestone"];
+    mockPi.getActiveTools = vi.fn(() => activeTools);
+    mockPi.setActiveTools = vi.fn();
+
+    extension(mockPi);
+
+    expect(mockPi.setActiveTools).toHaveBeenCalledWith([
+      "todoread",
+      "todowrite",
+      "harness_milestone",
+    ]);
+  });
+
+  it("should prefer todoread and todowrite again on session_start", async () => {
+    const { mockPi, events } = createMockPi();
+    const activeTools = ["todoread", "todowrite", "harness_plan", "harness_todo", "harness_milestone"];
+    mockPi.getActiveTools = vi.fn(() => activeTools);
+    mockPi.setActiveTools = vi.fn();
+    extension(mockPi);
+    mockPi.setActiveTools.mockClear();
+
+    await events.get("session_start")![0](
+      {},
+      {
+        cwd: ".",
+        sessionManager: { getBranch: vi.fn(() => []) },
+        ui: {
+          setHeader: vi.fn(),
+          setFooter: vi.fn(),
+          setStatus: vi.fn(),
+          setWidget: vi.fn(),
+          setWorkingVisible: vi.fn(),
+          notify: vi.fn(),
+        },
+        model: undefined,
+        modelRegistry: { getAvailable: vi.fn(() => []) },
+        getContextUsage: vi.fn(),
+      } as any,
+    );
+
+    expect(mockPi.setActiveTools).toHaveBeenCalledWith([
+      "todoread",
+      "todowrite",
+      "harness_milestone",
+    ]);
   });
 
   it("should have runId and action as required on harness_milestone", () => {

--- a/extensions/agentic-harness/tests/harness-tools.test.ts
+++ b/extensions/agentic-harness/tests/harness-tools.test.ts
@@ -40,13 +40,42 @@ function createMockCtx(options?: { customEntries?: Array<{ type: string; data: u
 }
 
 describe("harness-tools registration", () => {
-  it("registers harness_milestone, harness_plan, and harness_todo", () => {
+  it("registers todoread, todowrite, harness_milestone, harness_plan, and harness_todo", () => {
     const { mockPi, tools } = createMockPi();
     registerHarnessTools(mockPi as any);
 
+    expect(tools.has("todoread")).toBe(true);
+    expect(tools.has("todowrite")).toBe(true);
     expect(tools.has("harness_milestone")).toBe(true);
     expect(tools.has("harness_plan")).toBe(true);
     expect(tools.has("harness_todo")).toBe(true);
+  });
+
+  it("keeps legacy tools registered without prompt training", () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+
+    const planTool = tools.get("harness_plan")!;
+    expect(planTool.description).toBe(
+      "Compatibility tool for structured harness plan state. Prefer todoread/todowrite for normal agent-facing progress updates.",
+    );
+    expect(planTool.promptSnippet).toBeUndefined();
+    expect(planTool.promptGuidelines).toBeUndefined();
+
+    const todoTool = tools.get("harness_todo")!;
+    expect(todoTool.description).toBe(
+      "Compatibility tool for structured harness todo state. Prefer todoread/todowrite for normal agent-facing progress updates.",
+    );
+    expect(todoTool.promptSnippet).toBeUndefined();
+    expect(todoTool.promptGuidelines).toBeUndefined();
+  });
+
+  it("keeps todoread and todowrite prompt guidance populated", () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+
+    expect(tools.get("todoread")!.promptGuidelines.length).toBeGreaterThan(0);
+    expect(tools.get("todowrite")!.promptGuidelines.length).toBeGreaterThan(0);
   });
 
   it("exposes expected parameters on harness_milestone", () => {
@@ -84,6 +113,154 @@ describe("harness-tools registration", () => {
       "set", "update_status", "clear", "load", "render",
     ]);
     expect(schema.properties.ownerType?.enum).toContain("plan_task");
+  });
+
+  it("exposes expected parameters on todowrite and todoread", () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+
+    const readSchema = tools.get("todoread")!.parameters;
+    expect(readSchema.properties.runId).toBeDefined();
+    expect(readSchema.properties.rootDir).toBeDefined();
+
+    const writeSchema = tools.get("todowrite")!.parameters;
+    expect(writeSchema.properties.runId).toBeDefined();
+    expect(writeSchema.properties.todos).toBeDefined();
+    expect(writeSchema.properties.todos.items.properties.status.enum).toEqual([
+      "pending", "in_progress", "completed", "failed", "cancelled",
+    ]);
+    expect(writeSchema.properties.todos.items.properties.priority.enum).toEqual([
+      "high", "medium", "low",
+    ]);
+  });
+});
+
+describe("todowrite and todoread execute", () => {
+  it("reads milestones and plan tasks from harness state", async () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+    const rootDir = await makeTempDir();
+    const ctx = createMockCtx();
+
+    await tools.get("harness_milestone")!.execute(
+      "tc-1",
+      { runId: "run-1", action: "create", id: "M1", name: "Milestone 1", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await tools.get("harness_plan")!.execute(
+      "tc-2",
+      { runId: "run-1", action: "attach", planId: "m1-plan", milestoneId: "M1", title: "Plan", goal: "Goal", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await tools.get("harness_plan")!.execute(
+      "tc-3",
+      { runId: "run-1", action: "define_tasks", planId: "m1-plan", tasks: [{ id: 1, name: "Task 1" }], rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    const result = await tools.get("todoread")!.execute(
+      "tc-4",
+      { runId: "run-1", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.details.todos.map((todo: any) => todo.id)).toEqual(["M1", "M1.T1"]);
+  });
+
+  it("updates milestone and plan task statuses", async () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+    const rootDir = await makeTempDir();
+    const ctx = createMockCtx();
+
+    await tools.get("harness_milestone")!.execute(
+      "tc-1",
+      { runId: "run-1", action: "create", id: "M1", name: "Milestone 1", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await tools.get("harness_plan")!.execute(
+      "tc-2",
+      { runId: "run-1", action: "attach", planId: "m1-plan", milestoneId: "M1", title: "Plan", goal: "Goal", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await tools.get("harness_plan")!.execute(
+      "tc-3",
+      { runId: "run-1", action: "define_tasks", planId: "m1-plan", tasks: [{ id: 1, name: "Task 1" }], rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    const milestoneResult = await tools.get("todowrite")!.execute(
+      "tc-4",
+      {
+        runId: "run-1",
+        rootDir,
+        todos: [{ id: "M1", content: "Milestone 1", status: "in_progress", priority: "low" }],
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(milestoneResult.isError).toBeFalsy();
+    let snapshot = await readHarnessStateSnapshot(join(rootDir, "run-1", "state.json"));
+    expect(snapshot?.state.milestones[0]?.status).toBe("executing");
+
+    const taskResult = await tools.get("todowrite")!.execute(
+      "tc-5",
+      {
+        runId: "run-1",
+        rootDir,
+        todos: [{ id: "M1.T1", content: "Task 1", status: "completed" }],
+      },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(taskResult.isError).toBeFalsy();
+    snapshot = await readHarnessStateSnapshot(join(rootDir, "run-1", "state.json"));
+    expect(snapshot?.state.plans[0]?.tasks[0]?.status).toBe("completed");
+  });
+
+  it("returns an error for an unknown milestone id", async () => {
+    const { mockPi, tools } = createMockPi();
+    registerHarnessTools(mockPi as any);
+    const rootDir = await makeTempDir();
+    const ctx = createMockCtx();
+
+    await tools.get("harness_milestone")!.execute(
+      "tc-1",
+      { runId: "run-1", action: "create", id: "M1", name: "Milestone 1", rootDir },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    const result = await tools.get("todowrite")!.execute(
+      "tc-2",
+      { runId: "run-1", rootDir, todos: [{ id: "M9", content: "Missing", status: "completed" }] },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Milestone M9 not found");
   });
 });
 

--- a/extensions/agentic-harness/tests/skill-docs.test.ts
+++ b/extensions/agentic-harness/tests/skill-docs.test.ts
@@ -6,18 +6,21 @@ function readSkill(name: string): string {
 }
 
 describe("skill docs reference structured harness tools", () => {
-  it("agentic-run-plan requires mandatory structured task status updates", () => {
+  it("agentic-run-plan requires mandatory todowrite task status updates", () => {
     const src = readSkill("agentic-run-plan");
     expect(src).toContain("Task Status Update (MANDATORY)");
-    expect(src).toContain('"action": "set_task_status"');
+    expect(src).toContain("todowrite");
+    expect(src).toContain("todoread");
+    expect(src).not.toContain("harness_plan set_task_status");
     expect(src).toContain("After the validator passes");
     expect(src).toContain("rendered output only");
   });
 
-  it("agentic-long-run references harness_milestone, harness_plan, and canonical structured state", () => {
+  it("agentic-long-run references harness_milestone, todowrite, todoread, and canonical structured state", () => {
     const src = readSkill("agentic-long-run");
     expect(src).toContain("harness_milestone");
-    expect(src).toContain("harness_plan");
+    expect(src).toContain("todowrite");
+    expect(src).toContain("todoread");
     expect(src).toContain("canonical structured state");
   });
 
@@ -27,17 +30,28 @@ describe("skill docs reference structured harness tools", () => {
     expect(src).not.toContain("checkboxes marked");
     expect(src).not.toContain("Update state.md");
     expect(src).not.toContain("Checkpoint files are the source of truth");
-    expect(src).toContain("do not use markdown checkboxes for recovery");
+    expect(src).toContain("Do not infer task status from markdown checkboxes");
   });
 
   it("agentic-long-run forbids main-agent direct task execution and requires structured task status", () => {
     const src = readSkill("agentic-long-run");
     expect(src).toContain("Do not execute plan tasks directly as the main agent");
-    expect(src).toContain("harness_plan define_tasks");
-    expect(src).toContain("harness_plan set_task_status");
+    expect(src).toContain("Initialize normal task progress from the approved plan via `todowrite`");
+    expect(src).toContain("todoread");
+    expect(src).toContain("todowrite");
+    expect(src).not.toContain("harness_plan set_task_status");
     expect(src).toContain("harness_milestone set_status");
     expect(src).not.toContain("Update state.md: set milestone status");
     expect(src).not.toContain("Set milestone status to `skipped` in state.md");
+  });
+
+  it("agentic-long-run records milestone plan files through harness_milestone", () => {
+    const src = readSkill("agentic-long-run");
+    expect(src).toContain("Use `harness_milestone` for milestone creation, dependency metadata, attempts, plan files");
+    expect(src).toContain("attach the plan file path to the milestone via `harness_milestone`");
+    expect(src).toContain('{ "runId": "<run-id>", "action": "update", "id": "M1", "planFile": "docs/.../plan.md" }');
+    expect(src).not.toContain("attach the plan to the milestone via `harness_plan`");
+    expect(src).not.toContain('{ "runId": "<run-id>", "action": "attach", "planId": "<plan-id>", "milestoneId": "M1", "title": "...", "goal": "...", "planFile": "docs/.../plan.md" }');
   });
 
   it("agentic-plan-crafting references harness_plan and define_tasks", () => {
@@ -45,16 +59,21 @@ describe("skill docs reference structured harness tools", () => {
     expect(src).toContain("harness_plan");
     expect(src).toContain("define_tasks");
     expect(src).not.toContain("syntax for progress tracking");
-    expect(src).toContain("canonical progress is stored with `harness_plan define_tasks`");
+    expect(src).toContain("canonical progress is read with `todoread` and updated with `todowrite`");
   });
 
   it("agentic-review-work references harness_milestone", () => {
     const src = readSkill("agentic-review-work");
     expect(src).toContain("harness_milestone");
+    expect(src).toContain("todowrite");
+    expect(src).toContain("rather than `harness_plan`");
   });
 
   it("agentic-milestone-planning references harness_milestone", () => {
     const src = readSkill("agentic-milestone-planning");
     expect(src).toContain("harness_milestone");
+    expect(src).toContain("todoread");
+    expect(src).toContain("todowrite");
+    expect(src).not.toContain("harness_plan set_task_status");
   });
 });

--- a/extensions/agentic-harness/tests/todo-facade.test.ts
+++ b/extensions/agentic-harness/tests/todo-facade.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { applyHarnessCommand, createHarnessState, type HarnessState } from "../harness-state.js";
+import {
+  milestoneStatusToTodoStatus,
+  parseTodoFacadeId,
+  planTaskStatusToTodoStatus,
+  readTodosFromHarnessState,
+  todoStatusToMilestoneStatus,
+  todoStatusToPlanTaskStatus,
+} from "../todo-facade.js";
+
+function apply(state: HarnessState, command: Parameters<typeof applyHarnessCommand>[1]): HarnessState {
+  return applyHarnessCommand(state, command, { now: "2026-05-18T00:00:00.000Z" }).state;
+}
+
+describe("todo facade id parsing", () => {
+  it("parses milestone and plan task ids", () => {
+    expect(parseTodoFacadeId("M1")).toEqual({ kind: "milestone", milestoneId: "M1" });
+    expect(parseTodoFacadeId("M2.T3")).toEqual({ kind: "plan_task", milestoneId: "M2", taskId: 3 });
+    expect(parseTodoFacadeId("misc")).toEqual({ kind: "unknown", id: "misc" });
+  });
+});
+
+describe("todo facade status mappings", () => {
+  it("maps between harness and facade statuses", () => {
+    expect(todoStatusToMilestoneStatus("in_progress")).toBe("executing");
+    expect(todoStatusToPlanTaskStatus("in_progress")).toBe("running");
+    expect(milestoneStatusToTodoStatus("validating")).toBe("in_progress");
+    expect(planTaskStatusToTodoStatus("skipped")).toBe("cancelled");
+  });
+});
+
+describe("readTodosFromHarnessState", () => {
+  it("returns milestones and selected plan tasks", () => {
+    let state = createHarnessState({
+      runId: "run-1",
+      title: "Run 1",
+      now: "2026-05-18T00:00:00.000Z",
+    });
+    state = apply(state, {
+      type: "upsert_milestone",
+      milestone: { id: "M1", name: "Milestone 1", status: "completed" },
+    });
+    state = apply(state, {
+      type: "upsert_milestone",
+      milestone: { id: "M2", name: "Milestone 2", status: "executing" },
+    });
+    state = apply(state, {
+      type: "attach_plan",
+      plan: { id: "m2-plan", milestoneId: "M2", title: "M2 Plan", goal: "Ship M2" },
+    });
+    state = apply(state, {
+      type: "define_plan_tasks",
+      planId: "m2-plan",
+      tasks: [
+        { id: 1, name: "Task 1", status: "running" },
+        { id: 2, name: "Task 2", status: "pending" },
+      ],
+    });
+
+    const result = readTodosFromHarnessState(state, { rootDir: "root-dir" });
+
+    expect(result.runId).toBe("run-1");
+    expect(result.rootDir).toBe("root-dir");
+    expect(result.todos.map((todo) => todo.id)).toEqual(["M1", "M2", "M2.T1", "M2.T2"]);
+    expect(result.todos).toEqual([
+      { id: "M1", content: "Milestone 1", status: "completed", priority: "medium" },
+      { id: "M2", content: "Milestone 2", status: "in_progress", priority: "high" },
+      { id: "M2.T1", content: "Task 1", status: "in_progress", priority: "high" },
+      { id: "M2.T2", content: "Task 2", status: "pending", priority: "medium" },
+    ]);
+  });
+});

--- a/extensions/agentic-harness/todo-facade.ts
+++ b/extensions/agentic-harness/todo-facade.ts
@@ -1,0 +1,96 @@
+import {
+  selectPlanForMilestone,
+  type HarnessMilestoneStatus,
+  type HarnessPlanTaskStatus,
+  type HarnessState,
+} from "./harness-state.js";
+
+export type TodoFacadeStatus = "pending" | "in_progress" | "completed" | "failed" | "cancelled";
+export type TodoFacadePriority = "high" | "medium" | "low";
+
+export interface TodoFacadeItem {
+  id: string;
+  content: string;
+  status: TodoFacadeStatus;
+  priority?: TodoFacadePriority;
+}
+
+export interface TodoReadResult {
+  runId: string;
+  rootDir?: string;
+  todos: TodoFacadeItem[];
+}
+
+export function parseTodoFacadeId(id: string):
+  | { kind: "milestone"; milestoneId: string }
+  | { kind: "plan_task"; milestoneId: string; taskId: number }
+  | { kind: "unknown"; id: string } {
+  const milestone = /^M\d+$/.exec(id);
+  if (milestone) return { kind: "milestone", milestoneId: id };
+
+  const task = /^(M\d+)\.T(\d+)$/.exec(id);
+  if (task) return { kind: "plan_task", milestoneId: task[1], taskId: Number(task[2]) };
+
+  return { kind: "unknown", id };
+}
+
+export function milestoneStatusToTodoStatus(status: HarnessMilestoneStatus): TodoFacadeStatus {
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "skipped") return "cancelled";
+  if (status === "planning" || status === "executing" || status === "validating") return "in_progress";
+  return "pending";
+}
+
+export function planTaskStatusToTodoStatus(status: HarnessPlanTaskStatus): TodoFacadeStatus {
+  if (status === "running") return "in_progress";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "skipped") return "cancelled";
+  return "pending";
+}
+
+export function todoStatusToMilestoneStatus(status: TodoFacadeStatus): HarnessMilestoneStatus {
+  if (status === "in_progress") return "executing";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "skipped";
+  return "pending";
+}
+
+export function todoStatusToPlanTaskStatus(status: TodoFacadeStatus): HarnessPlanTaskStatus {
+  if (status === "in_progress") return "running";
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "skipped";
+  return "pending";
+}
+
+export function readTodosFromHarnessState(
+  state: HarnessState,
+  options: { rootDir?: string } = {},
+): TodoReadResult {
+  const todos: TodoFacadeItem[] = [];
+
+  for (const milestone of state.milestones) {
+    todos.push({
+      id: milestone.id,
+      content: milestone.name,
+      status: milestoneStatusToTodoStatus(milestone.status),
+      priority: milestone.status === "executing" || milestone.status === "validating" ? "high" : "medium",
+    });
+
+    const plan = selectPlanForMilestone(state, milestone);
+    if (!plan) continue;
+    for (const task of plan.tasks) {
+      todos.push({
+        id: `${milestone.id}.T${task.id}`,
+        content: task.name,
+        status: planTaskStatusToTodoStatus(task.status),
+        priority: task.status === "running" || task.status === "failed" ? "high" : "medium",
+      });
+    }
+  }
+
+  return { runId: state.runId, rootDir: options.rootDir, todos };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-engineering-discipline-extension",
-  "version": "1.26.1",
+  "version": "1.26.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-engineering-discipline-extension",
-      "version": "1.26.1",
+      "version": "1.26.5",
       "bundleDependencies": [
         "@code-yeongyu/pi-nested-agents-md",
         "pi-lsp-client"


### PR DESCRIPTION
…ondition

Add simplified agent-facing tools (todoread/todowrite) over HarnessState with M1/M1.T1 ID format support. Replace dual mutex registries with a single shared lock to prevent lost updates under concurrent mutations.

- Extract harness-state-service.ts (shared load/apply/persist helpers)
- Add todo-facade.ts (ID parsing, status mapping, state reading)
- Register todoread/todowrite tools in harness-tools.ts
- Consolidate mutation locks: persistStructuredSubagentTaskStatuses now uses withHarnessStateMutationLock (single registry)
- Canonicalize lock keys via path.resolve() to prevent aliasing
- Add try-catch to preferTodoSurfaceTools for extension loading safety
- Update skill docs to reference todoread/todowrite for progress tracking
- Add dual-lock-race.test.ts regression test (concurrent mutations)
- Add todowrite/todoread execute tests and todo-facade mapper tests
- Include implementation plan document