### PR TITLE
fix: render subagent action-mode calls correctly

### DIFF
--- a/extensions/agentic-harness/render.ts
+++ b/extensions/agentic-harness/render.ts
@@ -157,6 +157,19 @@ export function renderCall(
     return new Text(text, 0, 0);
   }
 
+  const action = previewText(args.action, 30);
+  if (action) {
+    const id = previewText(args.id, 50);
+    let preview = "run management";
+    if (action === "status") preview = id ? `run ${id}` : "all active runs";
+    else if (action === "wait" || action === "interrupt" || action === "mark-background") preview = id ? `run ${id}` : "missing run id";
+    else if (id) preview = `run ${id}`;
+
+    let text = theme.fg("toolTitle", theme.bold("subagent ")) + theme.fg("accent", action);
+    text += `\n  ${theme.fg("dim", preview)}`;
+    return new Text(text, 0, 0);
+  }
+
   // Single mode
   const isReceivingArgs = context.argsComplete === false;
   const agentName = previewText(args.agent, 40) ?? (isReceivingArgs ? "starting..." : "missing agent");

--- a/extensions/agentic-harness/tests/render.test.ts
+++ b/extensions/agentic-harness/tests/render.test.ts
@@ -40,6 +40,16 @@ describe("subagent call rendering", () => {
     expect(text).toContain("missing task");
     expect(text).not.toContain("subagent ...");
   });
+
+  it("renders action status without missing single-mode fields", () => {
+    const rendered = renderCall({ action: "status" }, theme, { argsComplete: true });
+    const text = rendered.render(80).join("\n");
+
+    expect(text).toContain("subagent status");
+    expect(text).toContain("all active runs");
+    expect(text).not.toContain("missing agent");
+    expect(text).not.toContain("missing task");
+  });
 });
 
 describe("formatTokens", () => {


### PR DESCRIPTION
## Problem

Subagent action-mode calls such as `{ action: "status" }` rendered as:

```
subagent missing agent
  missing task
```

even though they are valid management calls that do not require `agent`/`task`.

## Root Cause

`renderCall()` in `extensions/agentic-harness/render.ts` only handled `tasks` (parallel) and `chain` modes before falling through to single-mode rendering. It did not handle `action`, so valid action-mode args were interpreted as missing single-mode fields.

## Fix

Add an action-mode render branch before the single-mode fallback in `renderCall()`. It renders:
- `status` → `all active runs` or `run <id>`
- `wait`/`interrupt`/`mark-background` → `run <id>` or `missing run id`

## Verification

- New regression test in `tests/render.test.ts` failed before the fix (confirmed `missing agent` output)
- After fix: `npm test -- tests/render.test.ts` — 26/26 passed
- `npm run build` (tsc --noEmit) — clean

## Files Changed

- `extensions/agentic-harness/render.ts` — action-mode render branch
- `extensions/agentic-harness/tests/render.test.ts` — regression test