### PR TITLE
Scope goal state to pi sessions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,18 +6,51 @@
   <title>ROACH PI — Pi Engineering Discipline Extension</title>
   <meta name="description" content="Strict engineering discipline and agentic orchestration for the pi coding agent. Multi-agent workflows, plan execution, and milestone planning.">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🪳</text></svg>">
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('theme');
+        if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+      } catch (e) {}
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;600;700&family=Noto+Sans+KR:wght@400;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
-  <!-- Language Toggle -->
-  <div class="lang-toggle" id="langToggle">
-    <button class="active" onclick="setLang('en')">EN</button>
-    <button onclick="setLang('ko')">KR</button>
-  </div>
+  <!-- Navigation -->
+  <nav>
+    <div class="nav-inner">
+      <a href="#" class="nav-brand">
+        <span class="logo-mark" aria-hidden="true"></span>
+        ROACH PI
+      </a>
+      <ul class="nav-links">
+        <li><a href="#why"><span data-lang="en">Why ROACH PI?</span><span data-lang="ko">왜 ROACH PI?</span></a></li>
+        <li><a href="#quickstart"><span data-lang="en">Quick Start</span><span data-lang="ko">빠른 시작</span></a></li>
+        <li><a href="#features"><span data-lang="en">Features</span><span data-lang="ko">기능</span></a></li>
+        <li><a href="#faq"><span data-lang="en">FAQ</span><span data-lang="ko">FAQ</span></a></li>
+        <li><a href="features/workspace-memory.html"><span data-lang="en">Docs</span><span data-lang="ko">문서</span></a></li>
+      </ul>
+      <div class="nav-right">
+        <a class="nav-gh" href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">GitHub</a>
+        <!-- Language Toggle -->
+        <div class="lang-toggle" id="langToggle">
+          <button class="active" onclick="setLang('en')">EN</button>
+          <button onclick="setLang('ko')">KR</button>
+        </div>
+        <!-- Theme Toggle -->
+        <div class="theme-toggle" id="themeToggle">
+          <button onclick="setTheme('light')">LT</button>
+          <button onclick="setTheme('dark')">DK</button>
+        </div>
+      </div>
+    </div>
+  </nav>
 
   <script>
     function setLang(lang) {
@@ -30,60 +63,102 @@
       btns.forEach(function(b) { b.classList.remove('active'); });
       document.querySelector('#langToggle button[onclick="setLang(\'' + lang + '\')"]').classList.add('active');
     }
-  </script>
 
-  <!-- Navigation -->
-  <nav>
-    <div class="container">
-      <ul>
-        <li><a href="#why">● <span data-lang="en">Why ROACH PI?</span><span data-lang="ko">왜 ROACH PI?</span></a></li>
-        <li><a href="#quickstart">▶ <span data-lang="en">Quick Start</span><span data-lang="ko">빠른 시작</span></a></li>
-        <li><a href="#features">■ <span data-lang="en">Features</span><span data-lang="ko">기능</span></a></li>
-        <li><a href="#faq">● <span data-lang="en">FAQ</span><span data-lang="ko">FAQ</span></a></li>
-        <li><a href="features/workspace-memory.html">→ <span data-lang="en">Docs</span><span data-lang="ko">문서</span></a></li>
-        <li><a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a></li>
-      </ul>
-    </div>
-  </nav>
+    function setTheme(theme) {
+      if (theme === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      } else {
+        document.documentElement.removeAttribute('data-theme');
+      }
+      try { localStorage.setItem('theme', theme); } catch (e) {}
+      var tbtns = document.querySelectorAll('#themeToggle button');
+      tbtns.forEach(function(b) { b.classList.remove('active'); });
+      document.querySelector('#themeToggle button[onclick="setTheme(\'' + theme + '\')"]').classList.add('active');
+    }
+    // Initialise theme toggle active state (default light)
+    (function () {
+      var current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      var sel = document.querySelector('#themeToggle button[onclick="setTheme(\'' + current + '\')"]');
+      if (sel) sel.classList.add('active');
+    })();
+  </script>
 
   <!-- Hero -->
   <section class="hero">
     <div class="container">
-      <div class="hero-ascii">
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <span class="eyebrow">§ PI · AGENTIC DISCIPLINE</span>
+          <h1>
+            <span data-lang="en">Engineering <span class="em-italic grad">discipline</span>, with the agent wired in.</span>
+            <span data-lang="ko"><span class="em-italic grad">엔지니어링</span> 디사이플린, 에이전트가 내장된.</span>
+          </h1>
+          <p class="hero-subtitle">
+            <span data-lang="en">Strict engineering discipline and agentic orchestration for the <strong>pi coding agent</strong>. Multi-agent workflows, executable plans, and milestone-level decomposition.</span>
+            <span data-lang="ko"><strong>pi 코딩 에이전트</strong>를 위한 엄격한 엔지니어링 디사이플린과 에이전트 오케스트레이션. 다중 에이전트 워크플로, 실행 가능한 계획, 마일스톤 분해.</span>
+          </p>
+          <div class="hero-install">
+            <span class="mit-pill">MIT License</span>
+          </div>
+        </div>
+
+        <div class="hero-visual">
+          <div class="terminal-card">
+            <div class="terminal-bar">
+              <span class="terminal-dot red"></span>
+              <span class="terminal-dot yellow"></span>
+              <span class="terminal-dot green"></span>
+              <span class="terminal-tag">ROACH · PI</span>
+            </div>
+            <div class="terminal-body">
+<pre class="hero-ascii">
  ██████╗ ███████╗████████╗██████╗  ██████╗     ██████╗ ██╗   ██╗███████╗██████╗
  ██╔══██╗██╔════╝╚══██╔══╝██╔══██╗██╔═══██╗    ██╔══██╗╚██╗ ██╔╝██╔════╝██╔══██╗
  ██████╔╝█████╗     ██║   ██████╔╝██║   ██║    ██████╔╝ ╚████╔╝ █████╗  ██████╔╝
  ██╔══██╗██╔══╝     ██║   ██╔══██╗██║   ██║    ██╔══██╗  ╚██╔╝  ██╔══╝  ██╔══██╗
  ██████╔╝███████╗   ██║   ██║  ██║╚██████╔╝    ██████╔╝   ██║   ███████╗██║  ██║
  ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝     ╚═════╝    ╚═╝   ╚══════╝╚═╝  ╚═╝
-  </div>
-      <h1>
-        <span data-lang="en">Engineering Discipline Extension</span>
-        <span data-lang="ko">엔지니어링 디사이플린 익스텐션</span>
-      </h1>
-      <p class="hero-subtitle">
-        <span data-lang="en">Strict engineering discipline and agentic orchestration for the <strong>pi coding agent</strong>. Multi-agent workflows, executable plans, and milestone-level decomposition.</span>
-        <span data-lang="ko"><strong>pi 코딩 에이전트</strong>를 위한 엄격한 엔지니어링 디사이플린과 에이전트 오케스트레이션. 다중 에이전트 워크플로, 실행 가능한 계획, 마일스톤 분해.</span>
-      </p>
-      <div class="hero-install">
-        <span class="badge">MIT License</span>
+</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Stat band -->
+      <div class="stat-band">
+        <div class="stat">
+          <div class="stat-num">18+</div>
+          <div class="stat-cap">Agents</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">MIT</div>
+          <div class="stat-cap">License</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">100</div>
+          <div class="stat-cap">Concurrent Jobs</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">EN / KR</div>
+          <div class="stat-cap">Bilingual</div>
+        </div>
       </div>
     </div>
   </section>
 
   <div class="container">
 
-
-
     <!-- Why ROACH PI -->
     <section class="section" id="why">
-      <h2>
-        <span class="icon">●</span>
-        <span data-lang="en">Why ROACH PI?</span>
-        <span data-lang="ko">왜 ROACH PI인가요?</span>
-      </h2>
+      <div class="section-head">
+        <span class="eyebrow">§ 01 · WHY ROACH PI</span>
+        <h2>
+          <span data-lang="en">Why <span class="em-italic grad">ROACH PI</span>?</span>
+          <span data-lang="ko">왜 <span class="em-italic grad">ROACH PI</span>인가요?</span>
+        </h2>
+      </div>
 
-      <div class="grid-2" style="margin-top: 1.5rem;">
+      <div class="grid-2">
 
         <div class="card">
           <span class="feature-icon">●</span>
@@ -154,11 +229,13 @@
 
     <!-- Quick Start -->
     <section class="section" id="quickstart">
-      <h2>
-        <span class="icon">▶</span>
-        <span data-lang="en">Quick Start</span>
-        <span data-lang="ko">빠른 시작</span>
-      </h2>
+      <div class="section-head">
+        <span class="eyebrow">§ 02 · QUICK START</span>
+        <h2>
+          <span data-lang="en">Quick <span class="em-italic grad">Start</span></span>
+          <span data-lang="ko">빠른 <span class="em-italic grad">시작</span></span>
+        </h2>
+      </div>
 
       <p data-lang="en">
         The extension provides a streamlined workflow: <strong>clarify → goal</strong>. <code>/goal</code> creates, activates, continues, and verifies automatically.
@@ -167,83 +244,86 @@
         익스텐션은 단순한 워크플로를 제공합니다: <strong>명확화 → goal</strong>. <code>/goal</code>이 자동으로 생성, 활성화, 이어가기, 검증을 진행합니다.
       </p>
 
-      <ol class="step-list" style="margin-top: 1.5rem;">
+      <ol class="step-list">
 
-        <li>
+        <li class="step">
+          <div class="step-head"><span class="step-index">01</span></div>
           <h3>
             <code>/setup</code>
             <span data-lang="en"> — Configure Settings</span>
             <span data-lang="ko"> — 설정 구성</span>
           </h3>
-          <p data-lang="en">
+          <p class="step-desc" data-lang="en">
             Run once after installation to apply recommended settings. Sets <code>quietStartup: true</code> so the extension's custom ROACH PI banner replaces the default startup listing.
           </p>
-          <p data-lang="ko">
+          <p class="step-desc" data-lang="ko">
             설치 후 한 번 실행하여 권장 설정을 적용합니다. 익스텐션의 커스텀 ROACH PI 배너가 기본 시작 목록을 대체하도록 <code>quietStartup: true</code>를 설정합니다.
           </p>
         </li>
 
-        <li>
+        <li class="step">
+          <div class="step-head"><span class="step-index">02</span></div>
           <h3>
             <code>/clarify</code>
             <span data-lang="en"> — Resolve Ambiguity</span>
             <span data-lang="ko"> — 모호성 해결</span>
           </h3>
-          <p data-lang="en">
+          <p class="step-desc" data-lang="en">
             The agent asks dynamic, context-aware questions one at a time while exploring the codebase in parallel. Ends with a structured <strong>Goal Contract</strong> that defines scope, constraints, success criteria, and evidence requirements.
           </p>
-          <p data-lang="ko">
+          <p class="step-desc" data-lang="ko">
             에이전트가 코드베이스를 병렬로 탐색하면서 동적이고 문맥에 맞는 질문을 하나씩 묻습니다. 범위, 제약, 성공 기준, 증거 요구사항을 정의하는 구조화된 <strong>Goal Contract</strong>로 끝납니다.
           </p>
         </li>
 
-        <li>
+        <li class="step">
+          <div class="step-head"><span class="step-index">03</span></div>
           <h3>
             <code>/goal</code>
             <span data-lang="en"> — Activate Durable Execution</span>
             <span data-lang="ko"> — durable 실행 활성화</span>
           </h3>
-          <p data-lang="en">
+          <p class="step-desc" data-lang="en">
             Starts or continues a durable runtime that tracks goals, subgoals, todos, evidence, blockers, verifier receipts, and automatic continuation. Completion requires an independent verifier PASS.
           </p>
-          <p data-lang="ko">
+          <p class="step-desc" data-lang="ko">
             목표, 하위 목표, todo, 증거, 차단 요소, 검증 영수증, 자동 이어가기를 추적하는 durable runtime을 시작하거나 이어갑니다. 완료에는 독립 verifier PASS가 필요합니다.
           </p>
         </li>
 
-        <li>
+        <li class="step">
+          <div class="step-head"><span class="step-index">04</span></div>
           <h3>
             <code>/goal subgoal</code>
             <span data-lang="en"> — Subgoal Queueing</span>
             <span data-lang="ko"> — 하위 목표 큐잉</span>
           </h3>
-          <p data-lang="en">
+          <p class="step-desc" data-lang="en">
             For complex multi-step tasks. Queue subgoals with dependencies and required evidence, then let the goal runtime advance after verifier-guarded completion.
           </p>
-          <p data-lang="ko">
+          <p class="step-desc" data-lang="ko">
             복잡한 다단계 작업을 위해. 의존성과 필요한 증거가 있는 하위 목표를 큐에 넣고, verifier-guarded 완료 후 goal runtime이 진행하게 합니다.
           </p>
         </li>
 
-      </ol>
-
-        <li>
+        <li class="step">
+          <div class="step-head"><span class="step-index">05</span></div>
           <h3>
             <code>/loop</code>
             <span data-lang="en"> — Session Loop Scheduler</span>
             <span data-lang="ko"> — 세션 루프 스케줄러</span>
           </h3>
-          <p data-lang="en">
+          <p class="step-desc" data-lang="en">
             Schedule recurring prompts at fixed intervals. Cron-style timing — fires on schedule regardless of execution state. Supports <code>5s</code>, <code>10m</code>, <code>2h</code>, <code>1d</code> formats. Up to 100 concurrent jobs with per-job error isolation and automatic cleanup on session shutdown.
           </p>
-          <p data-lang="ko">
+          <p class="step-desc" data-lang="ko">
             고정 간격으로 반복 프롬프트를 스케줄링합니다. Cron 스타일 타이밍 — 실행 상태와 관계없이 스케줄대로 실행됩니다. <code>5s</code>, <code>10m</code>, <code>2h</code>, <code>1d</code> 형식을 지원합니다. 최대 100개 동시 작업, 작업별 에러 격리, 세션 종료 시 자동 정리.
           </p>
         </li>
 
       </ol>
 
-      <div class="card card-blue" style="margin-top: 2rem;">
+      <div class="card-blue" style="margin-top: 2rem;">
         <p data-lang="en" style="margin-bottom: 0;">
           <strong>💡 Tip:</strong> The <code>ask_user_question</code> tool is always available — the agent will ask clarifying questions autonomously whenever it detects ambiguity, even outside <code>/clarify</code> mode.
         </p>
@@ -255,13 +335,35 @@
 
     <!-- Features -->
     <section class="section" id="features">
-      <h2>
-        <span class="icon">■</span>
-        <span data-lang="en">Key Features</span>
-        <span data-lang="ko">주요 기능</span>
-      </h2>
+      <div class="section-head">
+        <span class="eyebrow">§ 03 · KEY FEATURES</span>
+        <h2>
+          <span data-lang="en">Key <span class="em-italic grad">Features</span></span>
+          <span data-lang="ko">주요 <span class="em-italic grad">기능</span></span>
+        </h2>
+      </div>
 
-      <div class="grid-2" style="margin-top: 1.5rem;">
+      <!-- At-a-glance spec strip -->
+      <div class="spec-strip">
+        <div class="spec-cell">
+          <span class="spec-key">Bundled Agents</span>
+          <span class="spec-val">18+</span>
+        </div>
+        <div class="spec-cell">
+          <span class="spec-key">Parallel Tasks</span>
+          <span class="spec-val">12 / 10</span>
+        </div>
+        <div class="spec-cell">
+          <span class="spec-key">Chain Depth</span>
+          <span class="spec-val">3 max</span>
+        </div>
+        <div class="spec-cell">
+          <span class="spec-key">Loop Jobs</span>
+          <span class="spec-val">100</span>
+        </div>
+      </div>
+
+      <div class="grid-2">
 
         <div class="card">
           <span class="feature-icon">★</span>
@@ -408,13 +510,14 @@
 
       </div>
     </section>
-    <section class="section" id="faq">
-      <h2>
-        <span class="icon">●</span>
-        FAQ
-      </h2>
 
-      <div style="margin-top: 1.5rem;">
+    <section class="section" id="faq">
+      <div class="section-head">
+        <span class="eyebrow">§ 04 · FAQ</span>
+        <h2>FAQ</h2>
+      </div>
+
+      <div class="faq-list">
 
         <details>
           <summary>
@@ -520,17 +623,20 @@
   <!-- Footer -->
   <footer>
     <div class="container">
-      <p>
-        <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
-        <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
-      </p>
-      <p style="margin-top: 0.5rem;">
-        <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
-        <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
-      </p>
-      <p style="margin-top: 0.5rem;">
-        <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
-      </p>
+      <div class="footer-inner">
+        <span class="logo-mark" aria-hidden="true"></span>
+        <p>
+          <span data-lang="en">ROACH PI — Pi Engineering Discipline Extension</span>
+          <span data-lang="ko">ROACH PI — Pi 엔지니어링 디사이플린 익스텐션</span>
+        </p>
+        <p>
+          <span data-lang="en">Built with ■ terminal aesthetics and ● ASCII vibes</span>
+          <span data-lang="ko">■ 터미널 미학과 ● ASCII 무드로 구축</span>
+        </p>
+        <p>
+          <a href="https://github.com/tmdgusya/pi-engineering-discipline-extension" target="_blank">→ GitHub</a>
+        </p>
+      </div>
     </div>
   </footer>
 

--- a/docs/pi-core-worktree-source.md
+++ b/docs/pi-core-worktree-source.md
@@ -1,0 +1,71 @@
+# Pi Core Source and Build/Test Workflow
+
+This document captures the editable pi core checkout prepared for the worktree-session goal.
+
+## Editable core checkout
+
+- Source path: `/Users/lit/.pi/agent/git/github.com/earendil-works/pi`
+- Remote: `https://github.com/earendil-works/pi.git`
+- Current HEAD: `7be8a10d`
+- Core package: `/Users/lit/.pi/agent/git/github.com/earendil-works/pi/packages/coding-agent`
+- Package name/version: `@earendil-works/pi-coding-agent@0.77.0`
+- Installed/global pi package checked for parity: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent`, version `0.77.0`
+- Working tree after preparation: clean
+
+This is the durable editable source for core work. Do not implement core behavior by patching `node_modules` in this roach-pi extension checkout.
+
+## Relevant core files for later subgoals
+
+- CLI entry and argument parsing:
+  - `packages/coding-agent/src/cli.ts`
+  - `packages/coding-agent/src/cli/args.ts`
+  - `packages/coding-agent/src/main.ts`
+- Session/runtime replacement:
+  - `packages/coding-agent/src/core/session-manager.ts`
+  - `packages/coding-agent/src/core/agent-session-runtime.ts`
+- Interactive commands and shutdown paths:
+  - `packages/coding-agent/src/modes/interactive/interactive-mode.ts`
+  - `packages/coding-agent/src/core/slash-commands.ts`
+
+## Preparation commands run
+
+```bash
+mkdir -p /Users/lit/.pi/agent/git/github.com/earendil-works
+git clone https://github.com/earendil-works/pi.git /Users/lit/.pi/agent/git/github.com/earendil-works/pi
+cd /Users/lit/.pi/agent/git/github.com/earendil-works/pi
+npm install
+npm run build
+```
+
+`npm run build` passed after installing workspace dependencies. The build generated model metadata during `packages/ai` build; those generated-file changes were reset afterward so the checkout remained clean.
+
+## Confirmed test workflow
+
+Run the monorepo build before the coding-agent test suite so workspace package `dist/` entries exist:
+
+```bash
+cd /Users/lit/.pi/agent/git/github.com/earendil-works/pi
+npm run build
+npm --prefix packages/coding-agent test
+```
+
+Observed test status after build:
+
+- Full `npm --prefix packages/coding-agent test`: 126 files passed, 6 skipped, 1 test failed.
+- The single observed failure was `test/session-id-readonly.test.ts > rejects an existing fork target session id`, where stderr contained an upstream/provider `401 authentication_error` instead of the expected duplicate session-id message.
+- Focused tests relevant to upcoming worktree implementation passed:
+
+```bash
+npm --prefix packages/coding-agent exec vitest --run \
+  test/args.test.ts \
+  test/session-manager/file-operations.test.ts \
+  test/suite/agent-session-runtime.test.ts
+```
+
+Focused result: 3 files passed, 91 tests passed.
+
+## Notes for implementation
+
+- `packages/coding-agent/package.json` exposes `build` and `test` scripts.
+- The root build order is important: `packages/tui`, `packages/ai`, `packages/agent`, then `packages/coding-agent`.
+- The global installed pi package and editable checkout both report `@earendil-works/pi-coding-agent@0.77.0`, so the checkout matches the active installed package version.

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,5 +1,5 @@
 /* ============================================
-   ROACH PI — Neo-Brutalist Design System
+   ROACH PI — Editorial Design System (omp.sh)
    ============================================ */
 
 /* --- Reset & Base --- */
@@ -10,17 +10,79 @@
 }
 
 :root {
-  --black: #000000;
-  --white: #FFFFFF;
-  --blue: #0000FF;
-  --gray-light: #F5F5F5;
-  --border: 6px solid var(--black);
-  --border-thick: 8px solid var(--black);
-  --shadow: 6px 6px 0 var(--black);
-  --shadow-sm: 4px 4px 0 var(--black);
-  --shadow-lg: 8px 8px 0 var(--black);
-  --font: 'MiSans', sans-serif;
-  --max-width: 960px;
+  /* ---- Color tokens (oklch) — LIGHT (default) ---- */
+  --ink-0: oklch(13.5% 0.018 295);
+  --ink-3: oklch(30% 0.02 293);
+  --ink-5: oklch(50% 0.022 290);
+  --ink-7: oklch(82% 0.014 285);
+  --paper: oklch(96.5% 0.005 80);
+  --paper-raised: oklch(98.5% 0.004 80);
+  --paper-sunken: oklch(94% 0.006 80);
+
+  /* ---- Accents ---- */
+  --magenta: oklch(70% 0.24 340);
+  --iris:    oklch(62% 0.21 295);
+  --cyan:    oklch(81% 0.14 200);
+  --success: oklch(78% 0.16 150);
+  --accent-grad: linear-gradient(100deg, var(--magenta), var(--iris) 55%, var(--cyan));
+
+  /* ---- Lines / surfaces ---- */
+  --hairline: oklch(22% 0.025 285 / 0.12);
+  --hairline-strong: oklch(22% 0.025 285 / 0.20);
+  --grid-line: oklch(22% 0.025 285 / 0.04);
+  --ring: oklch(62% 0.21 295 / 0.35);
+
+  /* ---- Typography ---- */
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+  --font-sans: "Geist", "Plus Jakarta Sans", "Noto Sans KR", system-ui, sans-serif;
+  --font-ui: "Plus Jakarta Sans", "Geist", "Noto Sans KR", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-kr: "Noto Sans KR", "Geist", sans-serif;
+
+  /* ---- Type scale ---- */
+  --fs-hero: clamp(2.6rem, 6vw, 5rem);
+  --fs-h2: clamp(1.9rem, 3.4vw, 2.9rem);
+  --fs-h3: clamp(1.05rem, 1.6vw, 1.25rem);
+  --fs-eyebrow: 0.72rem;
+  --fs-body: 1.0rem;
+  --fs-small: 0.85rem;
+  --lh-display: 1.02;
+  --lh-body: 1.7;
+  --ls-display: -0.02em;
+  --ls-mono: 0.16em;
+
+  /* ---- Spacing / radius / hairline ---- */
+  --maxw: 1080px;
+  --maxw-prose: 680px;
+  --gutter: clamp(1.25rem, 4vw, 2.5rem);
+  --section-pad: clamp(4rem, 9vw, 7rem);
+  --radius-card: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+  --hair: 1px;
+  --shadow-soft: 0 1px 2px oklch(22% 0.025 285 / 0.05), 0 8px 24px oklch(22% 0.025 285 / 0.04);
+}
+
+[data-theme="dark"] {
+  --ink-0: oklch(95% 0.01 285);
+  --ink-3: oklch(86% 0.012 285);
+  --ink-5: oklch(68% 0.02 288);
+  --ink-7: oklch(40% 0.02 290);
+  --paper: oklch(13.5% 0.018 295);
+  --paper-raised: oklch(17% 0.02 293);
+  --paper-sunken: oklch(11% 0.016 296);
+
+  --magenta: oklch(74% 0.22 340);
+  --iris:    oklch(70% 0.18 295);
+  --cyan:    oklch(83% 0.13 200);
+  --success: oklch(80% 0.15 150);
+  --accent-grad: linear-gradient(100deg, var(--magenta), var(--iris) 55%, var(--cyan));
+
+  --hairline: oklch(82% 0.014 285 / 0.14);
+  --hairline-strong: oklch(82% 0.014 285 / 0.24);
+  --grid-line: oklch(82% 0.014 285 / 0.045);
+  --ring: oklch(70% 0.18 295 / 0.45);
+  --shadow-soft: 0 1px 2px oklch(0% 0 0 / 0.4), 0 10px 30px oklch(0% 0 0 / 0.35);
 }
 
 html {
@@ -29,246 +91,254 @@ html {
 }
 
 body {
-  font-family: 'MiSans', 'Noto Sans KR', sans-serif;
-  background-color: var(--white);
-  color: var(--black);
-  line-height: 1.7;
+  background: var(--paper);
+  color: var(--ink-0);
+  font-family: var(--font-sans);
+  line-height: var(--lh-body);
+  font-size: var(--fs-body);
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color .35s ease, color .35s ease;
 }
 
-/* --- MiSans Font Import --- */
+body.lang-ko {
+  font-family: var(--font-kr);
+}
+
+/* Faint background grid texture */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(90deg, transparent 0 calc(25% - 1px), var(--grid-line) calc(25% - 1px) 25%);
+  background-size: var(--maxw) 100%;
+  background-position: center;
+}
+
+/* Focus */
+*:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* --- Layout --- */
 .container {
-  max-width: var(--max-width);
+  max-width: var(--maxw);
   margin: 0 auto;
-  padding: 2rem 1.5rem;
+  padding: 0 var(--gutter);
 }
 
 .section {
-  padding: 3rem 0;
-  border-bottom: 3px solid var(--black);
+  padding: var(--section-pad) 0;
+  border-top: var(--hair) solid var(--hairline);
 }
 
-.section:last-of-type {
-  border-bottom: none;
+/* --- Helpers --- */
+.grad {
+  background: var(--accent-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+[data-lang] { /* base, latin labels use sans */ }
+body.lang-ko [data-lang="ko"] { font-family: var(--font-kr); }
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--fs-eyebrow);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+  margin-bottom: 1.25rem;
+  display: block;
 }
 
 /* --- Typography --- */
-h1, h2, h3, h4 {
-  font-weight: 900;
-  line-height: 1.2;
-  text-transform: uppercase;
-  letter-spacing: -0.02em;
-}
-
-h1 {
-  font-size: 3rem;
-  margin-bottom: 1rem;
+h1, h2 {
+  font-family: var(--font-display);
+  font-weight: 500;
+  letter-spacing: var(--ls-display);
+  line-height: var(--lh-display);
 }
 
 h2 {
-  font-size: 2rem;
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 4px solid var(--black);
-  display: inline-block;
+  font-size: var(--fs-h2);
+  margin-bottom: 1.75rem;
 }
 
-h3 {
-  font-size: 1.4rem;
-  margin-bottom: 1rem;
-}
+h2 .em-italic { font-style: italic; }
 
 p {
   margin-bottom: 1rem;
 }
 
 a {
-  color: var(--black);
+  color: var(--ink-0);
   text-decoration: none;
-  border-bottom: 3px solid var(--blue);
-  transition: border-color 0.1s;
+  border-bottom: 1px solid var(--iris);
+  transition: color .15s, border-color .15s;
 }
 
 a:hover {
-  border-bottom-color: var(--black);
+  color: var(--iris);
+  border-bottom-color: var(--magenta);
 }
 
 strong {
-  font-weight: 900;
-}
-
-/* --- Neo-Brutalist Components --- */
-
-.card {
-  background: var(--white);
-  border: var(--border);
-  box-shadow: var(--shadow);
-  padding: 1.5rem;
-  transition: transform 0.1s, box-shadow 0.1s;
-}
-
-.card:hover {
-  transform: translate(-2px, -2px);
-  box-shadow: var(--shadow-lg);
-}
-
-.card-blue {
-  border-color: var(--blue);
-  box-shadow: 6px 6px 0 var(--blue);
-}
-
-.badge {
-  display: inline-block;
-  background: var(--black);
-  color: var(--white);
-  padding: 0.25rem 0.75rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  border: none;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.btn {
-  display: inline-block;
-  background: var(--black);
-  color: var(--white);
-  border: var(--border);
-  box-shadow: var(--shadow-sm);
-  padding: 0.75rem 1.5rem;
-  font-family: var(--font);
-  font-size: 1rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  cursor: pointer;
-  text-decoration: none;
-  letter-spacing: 0.03em;
-  transition: transform 0.1s, box-shadow 0.1s;
-}
-
-.btn:hover {
-  transform: translate(-2px, -2px);
-  box-shadow: var(--shadow);
-  border-bottom-color: var(--black);
-}
-
-.btn-blue {
-  background: var(--blue);
-  box-shadow: 4px 4px 0 var(--black);
-}
-
-.btn-blue:hover {
-  box-shadow: 6px 6px 0 var(--black);
-}
-
-/* --- Code Blocks --- */
-pre {
-  background: var(--black);
-  color: var(--white);
-  padding: 1.25rem 1.5rem;
-  overflow-x: auto;
-  border: var(--border);
-  box-shadow: var(--shadow-sm);
-  font-size: 0.9rem;
-  line-height: 1.6;
-  margin: 1rem 0;
+  font-weight: 600;
+  color: var(--ink-0);
 }
 
 code {
-  font-family: 'Courier New', Courier, monospace;
+  font-family: var(--font-mono);
 }
 
-p code, li code {
-  background: var(--gray-light);
-  border: 2px solid var(--black);
-  padding: 0.1rem 0.4rem;
+p code, li code, .faq-body code, .step-desc code {
+  background: var(--paper-sunken);
+  border: 1px solid var(--hairline);
+  border-radius: 5px;
+  padding: 0.08rem 0.4rem;
   font-size: 0.85em;
+  color: var(--ink-3);
 }
 
-/* --- ASCII Icons --- */
-.icon {
-  font-family: monospace;
-  font-size: 1.2em;
-  margin-right: 0.5rem;
-  display: inline-block;
+/* --- Logo mark --- */
+.logo-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--accent-grad);
+  flex: 0 0 auto;
+  box-shadow: 0 1px 4px oklch(62% 0.21 295 / 0.3);
 }
 
-/* --- Grid System --- */
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+/* --- Navigation --- */
+nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: color-mix(in oklch, var(--paper) 80%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: var(--hair) solid var(--hairline);
+  transition: background-color .35s ease;
 }
 
-/* --- Hero Section --- */
-.hero {
-  padding: 4rem 0 3rem;
-  text-align: center;
-  border-bottom: 4px solid var(--black);
-}
-
-.hero-ascii {
-  font-family: 'Courier New', monospace;
-  font-size: 0.7rem;
-  line-height: 1.1;
-  white-space: pre;
-  display: inline-block;
-  text-align: left;
-  margin-bottom: 2rem;
-  color: var(--black);
-}
-
-.hero-subtitle {
-  font-size: 1.2rem;
-  font-weight: 400;
-  margin-bottom: 2rem;
-  color: var(--black);
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.hero-install {
-  margin-top: 2rem;
-}
-
-/* --- Language Toggle --- */
-.lang-toggle {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 100;
+.nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  min-height: 60px;
   display: flex;
-  gap: 0;
-  border: var(--border);
-  box-shadow: var(--shadow-sm);
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
-.lang-toggle button {
-  background: var(--white);
-  border: none;
-  border-right: 3px solid var(--black);
-  padding: 0.4rem 0.8rem;
-  font-family: var(--font);
-  font-size: 0.85rem;
-  font-weight: 700;
-  cursor: pointer;
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  border-bottom: none;
+  color: var(--ink-0);
+}
+.nav-brand:hover { color: var(--ink-0); }
+
+.nav-links {
+  display: flex;
+  gap: 1.4rem;
+  list-style: none;
+  margin: 0 auto;
+  flex-wrap: wrap;
+}
+
+.nav-links a {
+  font-family: var(--font-mono);
   text-transform: uppercase;
-  transition: background 0.1s;
+  font-size: 0.78rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+  border-bottom: none;
+  padding-bottom: 2px;
+  position: relative;
+  transition: color .15s;
 }
 
-.lang-toggle button:last-child {
-  border-right: none;
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 1px;
+  background: var(--accent-grad);
+  transition: width .2s ease;
 }
 
-.lang-toggle button.active {
-  background: var(--black);
-  color: var(--white);
+.nav-links a:hover {
+  color: var(--ink-0);
+}
+.nav-links a:hover::after { width: 100%; }
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
 }
 
-.lang-toggle button:hover:not(.active) {
-  background: var(--gray-light);
+.nav-right .nav-gh {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+  border-bottom: none;
+}
+.nav-right .nav-gh:hover { color: var(--ink-0); }
+
+/* --- Pill toggles (lang + theme) --- */
+.lang-toggle,
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  background: transparent;
+}
+
+.lang-toggle button,
+.theme-toggle button {
+  background: transparent;
+  border: none;
+  padding: 0.3rem 0.7rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+  cursor: pointer;
+  transition: background .2s, color .2s;
+  line-height: 1.4;
+}
+
+.lang-toggle button.active,
+.theme-toggle button.active {
+  background: var(--paper-raised);
+  color: var(--ink-0);
+}
+
+.lang-toggle button:hover:not(.active),
+.theme-toggle button:hover:not(.active) {
+  color: var(--ink-3);
 }
 
 /* Language content switching */
@@ -281,50 +351,344 @@ body.lang-ko [data-lang="en"] {
 }
 
 body.lang-ko [data-lang="ko"] {
-  display: block;
+  display: inline;
 }
 
-/* --- Feature Cards --- */
-.feature-icon {
-  font-size: 2rem;
-  margin-bottom: 0.75rem;
-  display: block;
+/* --- Hero --- */
+.hero {
+  padding: clamp(3rem, 8vw, 6rem) 0 clamp(2.5rem, 6vw, 4rem);
 }
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: var(--fs-hero);
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 .em-italic { font-style: italic; font-weight: 500; }
+
+.hero-subtitle {
+  font-family: var(--font-sans);
+  font-size: 1.05rem;
+  color: var(--ink-5);
+  max-width: var(--maxw-prose);
+  line-height: var(--lh-body);
+  margin-bottom: 1.75rem;
+}
+
+/* MIT pill */
+.mit-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  padding: 0.35rem 0.85rem;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+}
+.mit-pill::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-grad);
+}
+
+/* Terminal card (ASCII art) */
+.terminal-card {
+  background: oklch(13.5% 0.018 295);
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid oklch(82% 0.014 285 / 0.12);
+}
+
+.terminal-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.terminal-dot.red { background: oklch(65% 0.2 25); }
+.terminal-dot.yellow { background: oklch(82% 0.16 90); }
+.terminal-dot.green { background: oklch(75% 0.17 145); }
+
+.terminal-tag {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+  color: oklch(68% 0.02 288);
+}
+
+.terminal-body {
+  padding: 1.1rem 1rem;
+  overflow-x: auto;
+}
+
+.hero-ascii {
+  font-family: var(--font-mono);
+  font-size: clamp(0.32rem, 1.1vw, 0.62rem);
+  line-height: 1.1;
+  white-space: pre;
+  margin: 0;
+  background: var(--accent-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Stat band */
+.stat-band {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: clamp(2.5rem, 6vw, 4rem);
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.stat {
+  padding: 1.5rem 0.5rem;
+  border-left: 1px solid var(--hairline);
+}
+.stat:first-child { border-left: none; }
+
+.stat-num {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-weight: 500;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.stat-cap {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+}
+
+/* --- Section header rule --- */
+.section-head {
+  max-width: var(--maxw-prose);
+  margin-bottom: 2.5rem;
+}
+.section-head .eyebrow {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--hairline);
+  margin-bottom: 1.5rem;
+}
+
+/* --- Grid --- */
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+/* --- Editorial Cards --- */
+.card {
+  background: var(--paper-raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-card);
+  padding: 1.5rem;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease, background-color .35s ease;
+}
+
+.card:hover {
+  transform: translateY(-1px);
+  border-color: var(--hairline-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.feature-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--paper-sunken);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  margin-bottom: 0.9rem;
+}
+
+/* cycle accent tints across cards */
+.card:nth-child(4n+1) .feature-icon { color: var(--magenta); }
+.card:nth-child(4n+2) .feature-icon { color: var(--iris); }
+.card:nth-child(4n+3) .feature-icon { color: var(--cyan); }
+.card:nth-child(4n+4) .feature-icon { color: var(--success); }
 
 .feature-title {
-  font-weight: 900;
-  font-size: 1.1rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.2rem;
+  line-height: 1.2;
   margin-bottom: 0.5rem;
-  text-transform: uppercase;
+  letter-spacing: -0.01em;
 }
 
 .feature-desc {
   font-size: 0.95rem;
-  color: var(--black);
-  line-height: 1.6;
+  color: var(--ink-5);
+  line-height: 1.65;
+}
+.feature-desc p { margin-bottom: 0; }
+
+/* --- Quick Start steps --- */
+.step-list {
+  list-style: none;
+  counter-reset: step;
+  margin-top: 2rem;
 }
 
-/* --- FAQ Accordion --- */
+#quickstart .step-list li,
+#quickstart > .container li,
+#quickstart li.step {
+  counter-increment: step;
+  display: block;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--hairline);
+  position: relative;
+}
+#quickstart .step-list li:first-child { border-top: none; }
+
+.step-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.65rem;
+}
+
+.step-index {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--ink-5);
+}
+
+#quickstart h3 {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--fs-h3);
+  margin: 0;
+}
+
+#quickstart h3 code {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  background: var(--paper-sunken);
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  padding: 0.15rem 0.55rem;
+  color: var(--iris);
+}
+
+.step-desc, #quickstart li p {
+  font-size: 0.95rem;
+  color: var(--ink-5);
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* Tip callout */
+.card-blue {
+  background: var(--paper-raised);
+  border: 1px solid var(--hairline);
+  border-left: 2px solid var(--iris);
+  border-radius: var(--radius-card);
+  padding: 1.4rem 1.5rem;
+}
+.card-blue::before {
+  content: "TIP";
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: var(--ls-mono);
+  color: var(--iris);
+  margin-bottom: 0.5rem;
+}
+.card-blue p { color: var(--ink-5); }
+
+/* Feature spec strip */
+.spec-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--hairline);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  margin-bottom: 2.5rem;
+}
+.spec-cell {
+  background: var(--paper-raised);
+  padding: 1.1rem 1rem;
+}
+.spec-key {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: var(--ls-mono);
+  text-transform: uppercase;
+  color: var(--ink-5);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+.spec-val {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 500;
+}
+
+/* --- FAQ --- */
+.faq-list {
+  max-width: var(--maxw-prose);
+}
+
 details {
-  border: var(--border);
-  box-shadow: var(--shadow-sm);
-  margin-bottom: 1rem;
-  background: var(--white);
+  border-top: 1px solid var(--hairline);
 }
-
-details[open] {
-  box-shadow: var(--shadow);
+.faq-list details:last-child {
+  border-bottom: 1px solid var(--hairline);
 }
 
 summary {
-  padding: 1rem 1.5rem;
+  padding: 1.3rem 0;
   cursor: pointer;
-  font-weight: 700;
-  font-size: 1rem;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.1rem;
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 summary::-webkit-details-marker {
@@ -332,178 +696,97 @@ summary::-webkit-details-marker {
 }
 
 summary::before {
-  content: '▶';
-  font-family: monospace;
-  transition: transform 0.2s;
+  content: '+';
+  font-family: var(--font-mono);
+  font-weight: 400;
+  color: var(--ink-5);
+  font-size: 1.2rem;
+  transition: transform .2s;
 }
 
 details[open] summary::before {
-  transform: rotate(90deg);
+  content: '–';
 }
 
-details .faq-body {
-  padding: 0 1.5rem 1.5rem;
-  line-height: 1.7;
+.faq-body {
+  padding: 0 0 1.5rem 1.95rem;
+  color: var(--ink-5);
+  line-height: var(--lh-body);
+  max-width: 60ch;
 }
-
-/* --- Step List (Quick Start) --- */
-.step-list {
-  list-style: none;
-  counter-reset: step;
-}
-
-.step-list li {
-  counter-increment: step;
-  padding: 1.5rem;
-  border: var(--border);
-  box-shadow: var(--shadow-sm);
-  margin-bottom: 1.5rem;
-  position: relative;
-  padding-left: 4rem;
-}
-
-.step-list li::before {
-  content: counter(step);
-  position: absolute;
-  left: -0.5rem;
-  top: -0.5rem;
-  width: 2.5rem;
-  height: 2.5rem;
-  background: var(--black);
-  color: var(--white);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 900;
-  font-size: 1.2rem;
-  border: 3px solid var(--black);
-}
-
-/* --- Navigation --- */
-nav {
-  position: sticky;
-  top: 0;
-  background: var(--white);
-  border-bottom: var(--border-thick);
-  z-index: 50;
-  padding: 0.75rem 0;
-}
-
-nav ul {
-  display: flex;
-  gap: 1.5rem;
-  list-style: none;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  flex-wrap: wrap;
-}
-
-nav a {
-  font-weight: 700;
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  border-bottom: none;
-  padding: 0.25rem 0;
-  position: relative;
-}
-
-nav a::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 0;
-  height: 3px;
-  background: var(--blue);
-  transition: width 0.15s;
-}
-
-nav a:hover::after {
-  width: 100%;
-}
+.faq-body p { margin-bottom: 0; }
 
 /* --- Footer --- */
 footer {
-  border-top: var(--border-thick);
-  padding: 2rem 1.5rem;
-  text-align: center;
-  font-weight: 700;
-  font-size: 0.85rem;
-  text-transform: uppercase;
+  border-top: 1px solid var(--hairline);
+  padding: clamp(3rem, 6vw, 4rem) 0;
   margin-top: 2rem;
+  transition: background-color .35s ease;
 }
 
-footer a {
-  border-bottom: 3px solid var(--blue);
+.footer-inner {
+  font-family: var(--font-mono);
+  font-size: var(--fs-small);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-5);
 }
+
+.footer-inner .logo-mark { margin-bottom: 1rem; }
+.footer-inner p { margin-bottom: 0.5rem; }
+
+footer a {
+  color: var(--ink-0);
+  border-bottom: 1px solid var(--iris);
+}
+footer a:hover { color: var(--iris); }
 
 /* --- Responsive --- */
 @media (max-width: 768px) {
-  :root {
-    --border: 4px solid var(--black);
-    --border-thick: 6px solid var(--black);
-    --shadow: 4px 4px 0 var(--black);
-    --shadow-sm: 3px 3px 0 var(--black);
-    --shadow-lg: 6px 6px 0 var(--black);
+  .hero-grid {
+    grid-template-columns: 1fr;
   }
-
-  h1 {
-    font-size: 2rem;
-  }
-
-  h2 {
-    font-size: 1.5rem;
-  }
-
   .grid-2 {
     grid-template-columns: 1fr;
   }
-
-  .hero {
-    padding: 2.5rem 0 2rem;
+  .stat-band {
+    grid-template-columns: 1fr 1fr;
   }
-
-  .hero-ascii {
-    font-size: 0.45rem;
+  .stat:nth-child(odd) { border-left: none; }
+  .spec-strip {
+    grid-template-columns: 1fr 1fr;
   }
-
-  nav ul {
+  .nav-links {
+    order: 3;
+    width: 100%;
+    margin: 0;
     gap: 1rem;
-  }
-
-  nav a {
-    font-size: 0.8rem;
-  }
-
-  .lang-toggle {
-    position: static;
-    display: flex;
+    padding-bottom: 0.6rem;
     justify-content: center;
-    margin-bottom: 1rem;
   }
+  .nav-brand { margin-right: auto; }
 }
 
 @media (max-width: 480px) {
   html {
     font-size: 14px;
   }
-
-  .hero-ascii {
-    font-size: 0.35rem;
+  .stat-band {
+    grid-template-columns: 1fr;
   }
-
-  .step-list li {
-    padding-left: 3.5rem;
+  .stat { border-left: none; border-top: 1px solid var(--hairline); }
+  .stat:first-child { border-top: none; }
+  .spec-strip {
+    grid-template-columns: 1fr;
   }
 }
 
 /* --- Print --- */
 @media print {
-  .lang-toggle, nav {
+  nav, .lang-toggle, .theme-toggle {
     display: none;
   }
-
+  body::before { display: none; }
   .card, details {
     box-shadow: none;
     break-inside: avoid;

--- a/extensions/agentic-harness/index.ts
+++ b/extensions/agentic-harness/index.ts
@@ -75,6 +75,7 @@ import { defaultClarificationStateRoot } from "./clarification-storage.js";
 import { applyAndPersistClarificationCommand, loadClarificationState, persistClarificationState } from "./clarification-state-service.js";
 import { extractClarificationStateReplayEventsFromSessionEntries, restoreClarificationStateFromSnapshotAndEvents } from "./clarification-events.js";
 import { renderClarificationGateSummary, type ClarificationCommand, type ClarificationGoalContract, type ClarificationState } from "./clarification-state.js";
+import { resolveSessionScopedRunId } from "./runtime-run-id.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -483,7 +484,7 @@ export default function (pi: ExtensionAPI) {
       parameters: ClarificationStateParams,
       execute: async (_toolCallId, params, _signal, _onUpdate, ctx) => {
         const toolCtx = ctx as any;
-        const runId = toolCtx?.runId || toolCtx?.sessionId || "default";
+        const runId = resolveSessionScopedRunId(toolCtx);
         const rootDir = defaultClarificationStateRoot(toolCtx?.cwd || process.cwd());
         const refresh = (state: ClarificationState) => {
           latestClarificationState = state;
@@ -1578,7 +1579,7 @@ Do not start multi-step implementation without a clear understanding of what the
       currentPhase = "clarifying";
       activeArtifactDocument = null;
       const commandCtx = ctx as any;
-      const clarificationRunId = commandCtx?.runId || commandCtx?.sessionId || "default";
+      const clarificationRunId = resolveSessionScopedRunId(commandCtx);
       const clarificationRootDir = defaultClarificationStateRoot(commandCtx?.cwd || process.cwd());
       const started = await applyAndPersistClarificationCommand(clarificationRunId, clarificationRootDir, { type: "start_interview", topic }, ctx);
       latestClarificationState = started.state;
@@ -1598,7 +1599,7 @@ Do not start multi-step implementation without a clear understanding of what the
     },
   });
 
-  const goalRunId = (ctx: any): string => ctx?.runId || ctx?.sessionId || "default";
+  const goalRunId = (ctx: any): string => resolveSessionScopedRunId(ctx);
   const goalRootDir = (ctx: any): string => defaultGoalStateRoot(ctx?.cwd || process.cwd());
   const notifyGoal = (ctx: any, message: string, level?: "info" | "error" | "success") => {
     if (ctx?.ui?.notify) ctx.ui.notify(message, level);
@@ -1697,7 +1698,7 @@ Do not start multi-step implementation without a clear understanding of what the
 
     if (!goal) {
       const clarificationRootDir = defaultClarificationStateRoot(ctx?.cwd || process.cwd());
-      const clarification = await loadClarificationState(ctx?.runId || ctx?.sessionId || "default", clarificationRootDir);
+      const clarification = await loadClarificationState(resolveSessionScopedRunId(ctx), clarificationRootDir);
       if (clarification.goalContract) {
         latestClarificationState = clarification;
         latestClarificationRootDir = clarificationRootDir;
@@ -1782,7 +1783,7 @@ Do not start multi-step implementation without a clear understanding of what the
   };
   const restoreLatestClarificationState = async (ctx: any, events: ReturnType<typeof extractClarificationStateReplayEventsFromSessionEntries>): Promise<ClarificationState> => {
     const rootDir = defaultClarificationStateRoot(ctx?.cwd || process.cwd());
-    const fallbackRunId = ctx?.runId || ctx?.sessionId || "default";
+    const fallbackRunId = resolveSessionScopedRunId(ctx);
     const runIds = [...new Set(events.map((event) => event.runId))];
     if (runIds.length === 0) {
       return (await restoreClarificationStateFromSnapshotAndEvents(rootDir, fallbackRunId, events)).state;

--- a/extensions/agentic-harness/runtime-run-id.ts
+++ b/extensions/agentic-harness/runtime-run-id.ts
@@ -1,0 +1,28 @@
+export function resolveSessionScopedRunId(ctx: unknown, fallback = "default"): string {
+  const context = isRecord(ctx) ? ctx : undefined;
+  const sessionManager = isRecord(context?.sessionManager) ? context.sessionManager : undefined;
+  const getSessionId = sessionManager?.getSessionId;
+
+  if (typeof getSessionId === "function") {
+    const sessionId = getSessionId.call(sessionManager);
+    if (typeof sessionId === "string" && sessionId.trim()) {
+      return `session-${sessionId.trim()}`;
+    }
+  }
+
+  const sessionId = context?.sessionId;
+  if (typeof sessionId === "string" && sessionId.trim()) {
+    return `session-${sessionId.trim()}`;
+  }
+
+  const runId = context?.runId;
+  if (typeof runId === "string" && runId.trim()) {
+    return runId.trim();
+  }
+
+  return fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/extensions/agentic-harness/tests/runtime-run-id.test.ts
+++ b/extensions/agentic-harness/tests/runtime-run-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionScopedRunId } from "../runtime-run-id.js";
+
+describe("runtime run id resolution", () => {
+  it("uses the pi session id before the shared default run id", () => {
+    const ctx = {
+      runId: "default",
+      sessionManager: {
+        getSessionId: () => "abc-123",
+      },
+    };
+
+    expect(resolveSessionScopedRunId(ctx)).toBe("session-abc-123");
+  });
+
+  it("uses an explicit sessionId when no session manager is available", () => {
+    expect(resolveSessionScopedRunId({ sessionId: "session-from-context", runId: "default" })).toBe("session-session-from-context");
+  });
+
+  it("falls back to runId for non-session contexts", () => {
+    expect(resolveSessionScopedRunId({ runId: "worker-run-1" })).toBe("worker-run-1");
+  });
+
+  it("keeps the legacy default only when no session identity exists", () => {
+    expect(resolveSessionScopedRunId({})).toBe("default");
+  });
+});

--- a/extensions/pi-code-previews/src/diff.ts
+++ b/extensions/pi-code-previews/src/diff.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-control-regex */
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
 import {
@@ -468,7 +469,7 @@ function tokenListWeight(tokens: string[]): number {
 function tokenWeight(token: string): number {
   if (/^[A-Za-z_$][\w$]*$/.test(token)) return 2;
   if (/^\d+(?:\.\d+)?$/.test(token)) return 1.5;
-  if (/^(?:===|!==|=>|==|!=|<=|>=|&&|\|\||[+\-*\/%<>=!?:]+)$/.test(token)) return 0.75;
+  if (/^(?:===|!==|=>|==|!=|<=|>=|&&|\|\||[+\-*%<>=!?:]+)$/.test(token)) return 0.75;
   if (/^[{}()[\].,;]$/.test(token)) return 0.15;
   return 1;
 }

--- a/extensions/pi-code-previews/src/secret-warnings.ts
+++ b/extensions/pi-code-previews/src/secret-warnings.ts
@@ -5,11 +5,11 @@ export interface SecretWarning {
 
 const SECRET_WARNINGS: SecretWarning[] = [
   { label: "private key", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
-  { label: "AWS secret key", pattern: /\bAWS_SECRET_ACCESS_KEY\s*=\s*["']?[^\s'\"]{12,}/i },
+  { label: "AWS secret key", pattern: /\bAWS_SECRET_ACCESS_KEY\s*=\s*["']?[^\s'"]{12,}/i },
   {
     label: "API key",
     pattern:
-      /\b(?:OPENAI|ANTHROPIC|GOOGLE|GEMINI|MISTRAL|GROQ|TOGETHER|PERPLEXITY|XAI)_API_KEY\s*=\s*["']?[^\s'\"]{12,}/i,
+      /\b(?:OPENAI|ANTHROPIC|GOOGLE|GEMINI|MISTRAL|GROQ|TOGETHER|PERPLEXITY|XAI)_API_KEY\s*=\s*["']?[^\s'"]{12,}/i,
   },
   { label: "GitHub token", pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/ },
   { label: "JWT", pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },

--- a/extensions/pi-code-previews/src/shiki.ts
+++ b/extensions/pi-code-previews/src/shiki.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-control-regex */
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import { bundledThemesInfo, createHighlighter } from "shiki";
 import { hashString } from "./hash.ts";

--- a/extensions/pi-code-previews/src/terminal-text.ts
+++ b/extensions/pi-code-previews/src/terminal-text.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-control-regex */
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 
 export function escapeControlChars(text: string): string {

--- a/extensions/pi-code-previews/tests/smoke.test.ts
+++ b/extensions/pi-code-previews/tests/smoke.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { escapeControlChars, stripAnsi } from "../src/terminal-text.ts";
+
+describe("terminal text helpers", () => {
+  it("strips ansi and makes control characters visible", () => {
+    expect(stripAnsi("\u001b[31mred\u001b[0m")).toBe("red");
+    expect(escapeControlChars("a\rb\u001b[31m")).toBe("a␍b␛[31m");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-engineering-discipline-extension",
-  "version": "1.28.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-engineering-discipline-extension",
-      "version": "1.28.0",
+      "version": "1.33.0",
       "bundleDependencies": [
         "@code-yeongyu/pi-nested-agents-md",
         "pi-lsp-client",


### PR DESCRIPTION
## Summary
- Scope /goal and /clarify runtime state by pi session id instead of the shared default run id.
- Include the updated docs/index.html + docs/style.css homepage refresh.
- Add pi core checkout/build workflow notes for upcoming worktree-session work.
- Make pi-code-previews check/test pass by fixing existing lint warnings and adding a smoke test.

## Tests
- npm --prefix extensions/agentic-harness run build
- npm --prefix extensions/agentic-harness test (69 files, 682 tests)
- npm --prefix extensions/fff-search run build
- npm --prefix extensions/fff-search test (1 file, 15 tests)
- npm --prefix extensions/session-loop run build
- npm --prefix extensions/session-loop test (1 file, 35 tests)
- npm --prefix extensions/workspace-memory run build
- npm --prefix extensions/workspace-memory test (5 files, 11 tests)
- npm --prefix extensions/pi-code-previews run check
- npm --prefix extensions/pi-code-previews test (1 file, 1 test)
